### PR TITLE
perf(upload): parallel chunks with streaming to disk

### DIFF
--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -24,6 +24,7 @@ from fastapi.responses import FileResponse, Response
 from fastapi.sse import EventSourceResponse
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
+from starlette.requests import ClientDisconnect
 
 from app.core.config import get_settings
 from app.core.resources import MiB
@@ -224,6 +225,11 @@ async def upload_chunk(
     """
     try:
         await upload_store.write_chunk_stream(upload_id, chunk_index, request.stream())
+    except ClientDisconnect:
+        logger.info(
+            "Client disconnected during chunk %d of %s", chunk_index, upload_id[:8]
+        )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
     except KeyError:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, "Upload session not found"

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -216,15 +216,14 @@ async def upload_chunk(
     chunk_index: int,
     request: Request,
 ) -> Response:
-    """Upload a single chunk of a file. Body is raw binary.
+    """Stream a chunk body to disk without loading it into memory.
 
     No per-request auth: the cryptographic upload_id (256-bit
     ``secrets.token_urlsafe``) acts as a bearer token.  Ownership is
     verified when the session is finalized in ``complete_chunked_upload``.
     """
-    body = await request.body()
     try:
-        await asyncio.to_thread(upload_store.write_chunk, upload_id, chunk_index, body)
+        await upload_store.write_chunk_stream(upload_id, chunk_index, request.stream())
     except KeyError:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, "Upload session not found"

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -4,11 +4,13 @@ import logging
 import secrets
 import shutil
 import threading
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import BinaryIO
+
+import anyio
 
 from app.core.config import get_settings
 
@@ -16,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 _UPLOAD_TTL = 3600  # 1 hour
 _CHUNK_LIMIT = 80 * 1024 * 1024 + 1024  # 80 MiB + 1 KiB margin
+_FLUSH_AT = 1024 * 1024  # flush buffer to disk every 1 MiB
 
 
 @dataclass
@@ -28,6 +31,25 @@ class _Session:
     lock: threading.Lock = field(default_factory=threading.Lock)
     accumulated_bytes: int = 0
     chunks_written: set[int] = field(default_factory=set)
+
+
+async def _stream_to_file(path: Path, stream: AsyncIterator[bytes], index: int) -> int:
+    """Drain *stream* into *path*, flushing every _FLUSH_AT bytes. Returns total."""
+    written = 0
+    async with await anyio.open_file(path, "wb") as f:
+        buf = bytearray()
+        async for piece in stream:
+            written += len(piece)
+            if written > _CHUNK_LIMIT:
+                msg = f"Chunk {index} exceeds {_CHUNK_LIMIT} bytes"
+                raise ValueError(msg)
+            buf.extend(piece)
+            if len(buf) >= _FLUSH_AT:
+                await f.write(bytes(buf))
+                buf.clear()
+        if buf:
+            await f.write(bytes(buf))
+    return written
 
 
 class UploadStore:
@@ -110,6 +132,58 @@ class UploadStore:
             session.accumulated_bytes = effective + len(data)
             session.chunks_written.add(index)
 
+    async def write_chunk_stream(
+        self, upload_id: str, index: int, stream: AsyncIterator[bytes]
+    ) -> None:
+        """Stream a chunk body to disk without buffering it in memory.
+
+        Raises KeyError if session not found, ValueError on bad input,
+        OverflowError if accumulated size exceeds max_bytes.
+        """
+        session = self._sessions.get(upload_id)
+        if session is None:
+            raise KeyError(upload_id)
+        if not 0 <= index < 10_000:
+            msg = f"Chunk index out of range: {index}"
+            raise ValueError(msg)
+
+        # Pre-check the chunk-count limit for *new* indices (under lock).
+        with session.lock:
+            if (
+                index not in session.chunks_written
+                and len(session.chunks_written) >= session.max_chunks
+            ):
+                msg = f"Too many chunks (limit {session.max_chunks})"
+                raise ValueError(msg)
+
+        tmp_path = session.dir / f"{index:04d}.{secrets.token_hex(8)}.part"
+        try:
+            written = await _stream_to_file(tmp_path, stream, index)
+            self._commit_stream_chunk(session, index, tmp_path, written)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
+            raise
+
+    @staticmethod
+    def _commit_stream_chunk(
+        session: _Session, index: int, tmp_path: Path, written: int
+    ) -> None:
+        """Atomically promote tmp_path to the final chunk path under the lock."""
+        final_path = session.dir / f"{index:04d}"
+        with session.lock:
+            effective = session.accumulated_bytes
+            if index in session.chunks_written:
+                with contextlib.suppress(OSError):
+                    effective -= final_path.stat().st_size
+
+            if effective + written > session.max_bytes:
+                raise OverflowError("Upload exceeds maximum size")
+
+            tmp_path.rename(final_path)
+            session.accumulated_bytes = effective + written
+            session.chunks_written.add(index)
+
     def assemble(self, upload_id: str, *, owner: str) -> tuple[BinaryIO, Path]:
         """Concatenate all chunks into a single seekable file.
 
@@ -137,7 +211,7 @@ class UploadStore:
             msg = "Chunks are not contiguous from 0"
             raise ValueError(msg)
 
-        chunks = sorted(session.dir.glob("[0-9]*"))
+        chunks = sorted(session.dir.glob("[0-9][0-9][0-9][0-9]"))
         assembled = session.dir / "assembled.zip"
         with assembled.open("wb") as out:
             for chunk_path in chunks:

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -126,12 +126,13 @@ class UploadStore:
         try:
             written = await _stream_to_file(tmp_path, stream, index)
             self._commit_stream_chunk(session, index, tmp_path, written)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                tmp_path.unlink()
+        except Exception:
             if upload_id not in self._sessions:
                 raise KeyError(upload_id) from None
             raise
+        finally:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
 
     @staticmethod
     def _commit_stream_chunk(

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -98,40 +98,6 @@ class UploadStore:
         logger.info("Upload session %s created", upload_id[:8])
         return upload_id
 
-    def write_chunk(self, upload_id: str, index: int, data: bytes) -> None:
-        """Write a chunk to the session directory.
-
-        Raises KeyError if session not found, ValueError on bad input,
-        OverflowError if accumulated size exceeds max_bytes.
-        """
-        session = self._sessions.get(upload_id)
-        if session is None:
-            raise KeyError(upload_id)
-        if not 0 <= index < 10_000:
-            msg = f"Chunk index out of range: {index}"
-            raise ValueError(msg)
-        if len(data) > _CHUNK_LIMIT:
-            msg = f"Chunk {index} is {len(data)} bytes (limit {_CHUNK_LIMIT})"
-            raise ValueError(msg)
-
-        with session.lock:
-            # Deduct old size before overflow check so retries aren't falsely rejected
-            effective = session.accumulated_bytes
-            if index in session.chunks_written:
-                with contextlib.suppress(OSError):
-                    effective -= (session.dir / f"{index:04d}").stat().st_size
-            elif len(session.chunks_written) >= session.max_chunks:
-                msg = f"Too many chunks (limit {session.max_chunks})"
-                raise ValueError(msg)
-
-            if effective + len(data) > session.max_bytes:
-                raise OverflowError("Upload exceeds maximum size")
-
-            chunk_path = session.dir / f"{index:04d}"
-            chunk_path.write_bytes(data)
-            session.accumulated_bytes = effective + len(data)
-            session.chunks_written.add(index)
-
     async def write_chunk_stream(
         self, upload_id: str, index: int, stream: AsyncIterator[bytes]
     ) -> None:

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -129,6 +129,8 @@ class UploadStore:
         except BaseException:
             with contextlib.suppress(OSError):
                 tmp_path.unlink()
+            if upload_id not in self._sessions:
+                raise KeyError(upload_id) from None
             raise
 
     @staticmethod

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -201,7 +201,7 @@
           "users"
         ],
         "summary": "Upload Chunk",
-        "description": "Upload a single chunk of a file. Body is raw binary.\n\nNo per-request auth: the cryptographic upload_id (256-bit\n``secrets.token_urlsafe``) acts as a bearer token.  Ownership is\nverified when the session is finalized in ``complete_chunked_upload``.",
+        "description": "Stream a chunk body to disk without loading it into memory.\n\nNo per-request auth: the cryptographic upload_id (256-bit\n``secrets.token_urlsafe``) acts as a bearer token.  Ownership is\nverified when the session is finalized in ``complete_chunked_upload``.",
         "operationId": "upload_chunk",
         "parameters": [
           {

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -158,6 +158,51 @@ class TestWriteChunkStream:
         finally:
             assembled.close()
 
+    async def test_rejects_chunk_exceeding_limit_mid_stream(
+        self, store: UploadStore
+    ) -> None:
+        """A chunk that grows past _CHUNK_LIMIT mid-stream is aborted."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+
+        # _CHUNK_LIMIT is 80 MiB + 1 KiB. Stream 81 MiB in 1 MiB pieces.
+        async def gen() -> AsyncIterator[bytes]:
+            for _ in range(81):
+                yield b"\x00" * (1024 * 1024)
+
+        with pytest.raises(ValueError, match="exceeds"):
+            await store.write_chunk_stream(upload_id, 0, gen())
+
+    async def test_tempfile_cleaned_up_on_error(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+
+        async def gen() -> AsyncIterator[bytes]:
+            for _ in range(81):
+                yield b"\x00" * (1024 * 1024)
+
+        with pytest.raises(ValueError, match="exceeds"):
+            await store.write_chunk_stream(upload_id, 0, gen())
+
+        # No .part files should remain in the session directory
+        session_dir = store._sessions[upload_id].dir
+        leftover = list(session_dir.glob("*.part"))
+        assert leftover == []
+
+    async def test_stream_rejects_accumulated_overflow(
+        self, store: UploadStore
+    ) -> None:
+        upload_id = store.create(100, owner="test")
+
+        async def gen_big() -> AsyncIterator[bytes]:
+            yield b"\x00" * 90
+
+        await store.write_chunk_stream(upload_id, 0, gen_big())
+
+        async def gen_overflow() -> AsyncIterator[bytes]:
+            yield b"\x00" * 20
+
+        with pytest.raises(OverflowError):
+            await store.write_chunk_stream(upload_id, 1, gen_overflow())
+
 
 class TestEviction:
     async def test_expired_session_is_cleaned_up(self, tmp_path: Path) -> None:

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -1,5 +1,6 @@
 """Unit tests for the UploadStore chunked-upload manager."""
 
+import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -202,6 +203,51 @@ class TestWriteChunkStream:
 
         with pytest.raises(OverflowError):
             await store.write_chunk_stream(upload_id, 1, gen_overflow())
+
+    async def test_concurrent_same_index_writes_do_not_corrupt(
+        self, store: UploadStore
+    ) -> None:
+        """Two concurrent writes for the same chunk index must not corrupt."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+
+        async def gen_a() -> AsyncIterator[bytes]:
+            yield b"AAAA"
+
+        async def gen_b() -> AsyncIterator[bytes]:
+            yield b"BBBB"
+
+        # Both writes target index 0 - whichever renames last wins, but
+        # neither should produce garbage bytes in the final chunk.
+        await asyncio.gather(
+            store.write_chunk_stream(upload_id, 0, gen_a()),
+            store.write_chunk_stream(upload_id, 0, gen_b()),
+        )
+
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            final = assembled.read()
+            assert final in (b"AAAA", b"BBBB")
+        finally:
+            assembled.close()
+
+    async def test_concurrent_different_index_writes(self, store: UploadStore) -> None:
+        """Concurrent writes to different indices produce the union."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+
+        async def gen(payload: bytes) -> AsyncIterator[bytes]:
+            yield payload
+
+        await asyncio.gather(
+            store.write_chunk_stream(upload_id, 0, gen(b"AAA")),
+            store.write_chunk_stream(upload_id, 1, gen(b"BBB")),
+            store.write_chunk_stream(upload_id, 2, gen(b"CCC")),
+        )
+
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            assert assembled.read() == b"AAABBBCCC"
+        finally:
+            assembled.close()
 
 
 class TestEviction:

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
+from starlette.requests import ClientDisconnect
 
 from app.logic.chunked_upload import UploadStore
 
@@ -125,6 +126,21 @@ class TestWriteChunkStream:
     async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
         with pytest.raises(KeyError):
             await store.write_chunk_stream("nonexistent", 0, _one(b"x"))
+
+    async def test_client_disconnect_propagates(self, store: UploadStore) -> None:
+        """ClientDisconnect from the stream must not be translated to KeyError."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+
+        async def gen() -> AsyncIterator[bytes]:
+            yield b"partial"
+            raise ClientDisconnect
+
+        with pytest.raises(ClientDisconnect):
+            await store.write_chunk_stream(upload_id, 0, gen())
+
+        # Tempfile cleaned up, session still alive for retry
+        session_dir = store._sessions[upload_id].dir
+        assert list(session_dir.glob("*.part")) == []
 
     async def test_concurrent_same_index_writes_do_not_corrupt(
         self, store: UploadStore

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -11,137 +11,15 @@ from app.logic.chunked_upload import UploadStore
 MAX_BYTES = 1024 * 1024  # 1 MiB - small limit for tests
 
 
+async def _one(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
 @pytest.fixture
 async def store(tmp_path: Path) -> AsyncIterator[UploadStore]:
     store = UploadStore(base=tmp_path / "chunked-uploads")
     async with store.lifespan():
         yield store
-
-
-class TestWriteChunk:
-    async def test_rejects_negative_index(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        with pytest.raises(ValueError, match="out of range"):
-            store.write_chunk(upload_id, -1, b"x")
-
-    async def test_rejects_index_above_9999(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        with pytest.raises(ValueError, match="out of range"):
-            store.write_chunk(upload_id, 10_000, b"x")
-
-    async def test_rejects_oversized_chunk(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        huge = b"\x00" * (80 * 1024 * 1024 + 2048)  # exceeds _CHUNK_LIMIT
-        with pytest.raises(ValueError, match="limit"):
-            store.write_chunk(upload_id, 0, huge)
-
-    async def test_rejects_accumulated_overflow(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"\x00" * (MAX_BYTES - 10))
-        with pytest.raises(OverflowError):
-            store.write_chunk(upload_id, 1, b"\x00" * 20)
-
-    async def test_rejects_too_many_chunks(self, store: UploadStore) -> None:
-        # max_chunks = MAX_BYTES // _CHUNK_LIMIT + 2 = 0 + 2 = 2 for 1 MiB
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"a")
-        store.write_chunk(upload_id, 1, b"b")
-        with pytest.raises(ValueError, match="Too many chunks"):
-            store.write_chunk(upload_id, 2, b"c")
-
-    async def test_retry_not_falsely_rejected_by_overflow(
-        self, store: UploadStore
-    ) -> None:
-        """Retrying a chunk should deduct old size before the overflow check."""
-        upload_id = store.create(100, owner="test")
-        store.write_chunk(upload_id, 0, b"\x00" * 90)
-        # Retry with a smaller chunk - effective total = 11, well under 100
-        store.write_chunk(upload_id, 0, b"\x00" * 11)
-
-    async def test_idempotent_retry_adjusts_size(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"hello")
-        # Re-upload same index with different data - should succeed and
-        # correct the accumulated size (not double-count).
-        store.write_chunk(upload_id, 0, b"world!")
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"world!"
-        finally:
-            assembled.close()
-
-    async def test_idempotent_retry_does_not_count_toward_chunk_limit(
-        self, store: UploadStore
-    ) -> None:
-        # max_chunks = 2 for 1 MiB limit
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"a")
-        store.write_chunk(upload_id, 0, b"a")  # retry - should not increment count
-        store.write_chunk(upload_id, 1, b"b")  # second distinct chunk - should work
-
-    async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
-        with pytest.raises(KeyError):
-            store.write_chunk("nonexistent", 0, b"x")
-
-
-class TestAssemble:
-    async def test_chunks_concatenated_in_order(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 1, b"BBB")
-        store.write_chunk(upload_id, 0, b"AAA")
-
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"AAABBB"
-        finally:
-            assembled.close()
-
-    async def test_no_chunks_raises(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        with pytest.raises(ValueError, match="No chunks"):
-            store.assemble(upload_id, owner="test")
-
-    async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
-        with pytest.raises(KeyError):
-            store.assemble("nonexistent", owner="test")
-
-    async def test_session_removed_after_assemble(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"x")
-        assembled, _ = store.assemble(upload_id, owner="test")
-        assembled.close()
-        # Second assemble should fail - session was consumed
-        with pytest.raises(KeyError):
-            store.assemble(upload_id, owner="test")
-
-    async def test_wrong_owner_raises_permission_error(
-        self, store: UploadStore
-    ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="alice")
-        store.write_chunk(upload_id, 0, b"x")
-        with pytest.raises(PermissionError, match="different user"):
-            store.assemble(upload_id, owner="bob")
-
-    async def test_non_contiguous_chunks_raises(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"AAA")
-        store.write_chunk(upload_id, 2, b"CCC")  # skipped index 1
-        with pytest.raises(ValueError, match="not contiguous"):
-            store.assemble(upload_id, owner="test")
-
-    async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
-        """Orphan .part tempfiles from crashed streaming writes are ignored."""
-        upload_id = store.create(MAX_BYTES, owner="test")
-        store.write_chunk(upload_id, 0, b"real")
-        # Simulate a stale tempfile from a crashed mid-commit streaming write
-        session = store._sessions[upload_id]
-        (session.dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
-
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"real"
-        finally:
-            assembled.close()
 
 
 class TestWriteChunkStream:
@@ -158,6 +36,16 @@ class TestWriteChunkStream:
             assert assembled.read() == b"hello world"
         finally:
             assembled.close()
+
+    async def test_rejects_negative_index(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        with pytest.raises(ValueError, match="out of range"):
+            await store.write_chunk_stream(upload_id, -1, _one(b"x"))
+
+    async def test_rejects_index_above_9999(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        with pytest.raises(ValueError, match="out of range"):
+            await store.write_chunk_stream(upload_id, 10_000, _one(b"x"))
 
     async def test_rejects_chunk_exceeding_limit_mid_stream(
         self, store: UploadStore
@@ -188,21 +76,54 @@ class TestWriteChunkStream:
         leftover = list(session_dir.glob("*.part"))
         assert leftover == []
 
-    async def test_stream_rejects_accumulated_overflow(
-        self, store: UploadStore
-    ) -> None:
+    async def test_rejects_accumulated_overflow(self, store: UploadStore) -> None:
         upload_id = store.create(100, owner="test")
-
-        async def gen_big() -> AsyncIterator[bytes]:
-            yield b"\x00" * 90
-
-        await store.write_chunk_stream(upload_id, 0, gen_big())
-
-        async def gen_overflow() -> AsyncIterator[bytes]:
-            yield b"\x00" * 20
+        await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
 
         with pytest.raises(OverflowError):
-            await store.write_chunk_stream(upload_id, 1, gen_overflow())
+            await store.write_chunk_stream(upload_id, 1, _one(b"\x00" * 20))
+
+    async def test_rejects_too_many_chunks(self, store: UploadStore) -> None:
+        # max_chunks = MAX_BYTES // _CHUNK_LIMIT + 2 = 0 + 2 = 2 for 1 MiB
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"a"))
+        await store.write_chunk_stream(upload_id, 1, _one(b"b"))
+        with pytest.raises(ValueError, match="Too many chunks"):
+            await store.write_chunk_stream(upload_id, 2, _one(b"c"))
+
+    async def test_retry_not_falsely_rejected_by_overflow(
+        self, store: UploadStore
+    ) -> None:
+        """Retrying a chunk should deduct old size before the overflow check."""
+        upload_id = store.create(100, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
+        # Retry with a smaller chunk - effective total = 11, well under 100
+        await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 11))
+
+    async def test_idempotent_retry_adjusts_size(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"hello"))
+        # Re-upload same index with different data - should succeed and
+        # correct the accumulated size (not double-count).
+        await store.write_chunk_stream(upload_id, 0, _one(b"world!"))
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            assert assembled.read() == b"world!"
+        finally:
+            assembled.close()
+
+    async def test_idempotent_retry_does_not_count_toward_chunk_limit(
+        self, store: UploadStore
+    ) -> None:
+        # max_chunks = 2 for 1 MiB limit
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"a"))
+        await store.write_chunk_stream(upload_id, 0, _one(b"a"))  # retry
+        await store.write_chunk_stream(upload_id, 1, _one(b"b"))  # distinct chunk
+
+    async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
+        with pytest.raises(KeyError):
+            await store.write_chunk_stream("nonexistent", 0, _one(b"x"))
 
     async def test_concurrent_same_index_writes_do_not_corrupt(
         self, store: UploadStore
@@ -250,12 +171,72 @@ class TestWriteChunkStream:
             assembled.close()
 
 
+class TestAssemble:
+    async def test_chunks_concatenated_in_order(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 1, _one(b"BBB"))
+        await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
+
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            assert assembled.read() == b"AAABBB"
+        finally:
+            assembled.close()
+
+    async def test_no_chunks_raises(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        with pytest.raises(ValueError, match="No chunks"):
+            store.assemble(upload_id, owner="test")
+
+    async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
+        with pytest.raises(KeyError):
+            store.assemble("nonexistent", owner="test")
+
+    async def test_session_removed_after_assemble(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"x"))
+        assembled, _ = store.assemble(upload_id, owner="test")
+        assembled.close()
+        # Second assemble should fail - session was consumed
+        with pytest.raises(KeyError):
+            store.assemble(upload_id, owner="test")
+
+    async def test_wrong_owner_raises_permission_error(
+        self, store: UploadStore
+    ) -> None:
+        upload_id = store.create(MAX_BYTES, owner="alice")
+        await store.write_chunk_stream(upload_id, 0, _one(b"x"))
+        with pytest.raises(PermissionError, match="different user"):
+            store.assemble(upload_id, owner="bob")
+
+    async def test_non_contiguous_chunks_raises(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
+        await store.write_chunk_stream(upload_id, 2, _one(b"CCC"))  # skipped index 1
+        with pytest.raises(ValueError, match="not contiguous"):
+            store.assemble(upload_id, owner="test")
+
+    async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
+        """Orphan .part tempfiles from crashed streaming writes are ignored."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+        await store.write_chunk_stream(upload_id, 0, _one(b"real"))
+        # Simulate a stale tempfile from a crashed mid-commit streaming write
+        session = store._sessions[upload_id]
+        (session.dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
+
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            assert assembled.read() == b"real"
+        finally:
+            assembled.close()
+
+
 class TestEviction:
     async def test_expired_session_is_cleaned_up(self, tmp_path: Path) -> None:
         store = UploadStore(base=tmp_path / "chunked-uploads")
         async with store.lifespan():
             upload_id = store.create(MAX_BYTES, owner="test")
-            store.write_chunk(upload_id, 0, b"data")
+            await store.write_chunk_stream(upload_id, 0, _one(b"data"))
 
             store._evict(upload_id)
 

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -128,6 +128,36 @@ class TestAssemble:
         with pytest.raises(ValueError, match="not contiguous"):
             store.assemble(upload_id, owner="test")
 
+    async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
+        """Orphan .part tempfiles from crashed streaming writes are ignored."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+        store.write_chunk(upload_id, 0, b"real")
+        # Simulate a stale tempfile from a crashed mid-commit streaming write
+        session = store._sessions[upload_id]
+        (session.dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
+
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            assert assembled.read() == b"real"
+        finally:
+            assembled.close()
+
+
+class TestWriteChunkStream:
+    async def test_writes_stream_to_disk(self, store: UploadStore) -> None:
+        upload_id = store.create(MAX_BYTES, owner="test")
+
+        async def gen() -> AsyncIterator[bytes]:
+            yield b"hello "
+            yield b"world"
+
+        await store.write_chunk_stream(upload_id, 0, gen())
+        assembled, _ = store.assemble(upload_id, owner="test")
+        try:
+            assert assembled.read() == b"hello world"
+        finally:
+            assembled.close()
+
 
 class TestEviction:
     async def test_expired_session_is_cleaned_up(self, tmp_path: Path) -> None:

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -1,6 +1,7 @@
 """Unit tests for the UploadStore chunked-upload manager."""
 
 import asyncio
+import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -242,3 +243,21 @@ class TestEviction:
 
             with pytest.raises(KeyError):
                 store.assemble(upload_id, owner="test")
+
+    async def test_eviction_during_write_surfaces_as_key_error(
+        self, store: UploadStore
+    ) -> None:
+        """A write already in flight when eviction runs raises KeyError, not OSError."""
+        upload_id = store.create(MAX_BYTES, owner="test")
+        session = store._sessions[upload_id]
+
+        async def gen() -> AsyncIterator[bytes]:
+            # Simulate TTL eviction firing after the session lookup but before
+            # the write completes: dir gone, session popped from registry.
+            shutil.rmtree(session.dir)
+            store._sessions.pop(upload_id)
+            session.timer.cancel()
+            yield b"doomed"
+
+        with pytest.raises(KeyError):
+            await store.write_chunk_stream(upload_id, 0, gen())

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from starlette.requests import ClientDisconnect
 
 from app.core.config import get_settings
+from app.logic.chunked_upload import upload_store
 
 from .factories import mock_extract, mock_jwt, sign_in_and_upload
 
@@ -84,6 +86,23 @@ class TestUploadChunk:
                 data={"credential": "fake", "provider": "google"},
             )
         assert complete.status_code == 200
+
+    async def test_client_disconnect_returns_quietly(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Browser abort mid-upload should not produce a 500 traceback."""
+        upload_id = await _init(client)
+
+        async def raise_disconnect(*_args: object, **_kwargs: object) -> None:
+            raise ClientDisconnect
+
+        monkeypatch.setattr(upload_store, "write_chunk_stream", raise_disconnect)
+
+        resp = await client.put(
+            f"/api/v1/users/upload/{upload_id}/0",
+            content=b"anything",
+        )
+        assert resp.status_code == 204
 
     async def test_rejects_overflow(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -234,3 +235,34 @@ class TestCompleteChunkedUpload:
                 data={"credential": "fake", "provider": "microsoft"},
             )
         assert resp.status_code == 403
+
+
+class TestParallelChunkedUpload:
+    async def test_parallel_chunks_complete_cleanly(
+        self, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """4 concurrent PUTs to one session finish and complete succeeds."""
+        upload_id = await _init(client)
+
+        async def put_chunk(index: int, data: bytes) -> None:
+            resp = await client.put(
+                f"/api/v1/users/upload/{upload_id}/{index}",
+                content=data,
+            )
+            assert resp.status_code == 204
+
+        await asyncio.gather(
+            *(
+                put_chunk(i, p)
+                for i, p in enumerate([b"AAAA", b"BBBB", b"CCCC", b"DDDD"])
+            )
+        )
+
+        users_dir = tmp_path / "users"
+        users_dir.mkdir(exist_ok=True)
+        with mock_jwt("google"), mock_extract(users_dir):
+            resp = await client.post(
+                f"/api/v1/users/upload/{upload_id}/complete",
+                data={"credential": "fake", "provider": "google"},
+            )
+        assert resp.status_code == 200

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -47,10 +47,13 @@ server {
     include /etc/nginx/proxy-params.conf;
   }
 
-  # Upload chunks - gated by init, moderate rate limit
+  # Upload chunks - gated by init, moderate rate limit.
+  # proxy_request_buffering off: stream chunks straight to backend instead of
+  # buffering to nginx's temp dir (would balloon with parallel uploads).
   location /api/v1/users/upload/ {
     client_max_body_size 100m;
     limit_req zone=general burst=30 nodelay;
+    proxy_request_buffering off;
     include /etc/nginx/proxy-params.conf;
   }
 

--- a/frontend/src/components/register/ZipUploader.vue
+++ b/frontend/src/components/register/ZipUploader.vue
@@ -18,6 +18,7 @@ const emit = defineEmits<{
 
 const baseUrl = client.getConfig().baseUrl;
 const CHUNK_SIZE = 80 * 1024 * 1024; // 80 MiB
+const PARALLEL_CHUNKS = 4;
 const MAX_RETRIES = 3;
 const RETRY_DELAYS = [1000, 2000, 4000];
 
@@ -34,6 +35,7 @@ const dragging = ref(false);
 const dragDepth = ref(0);
 const fileInputRef = ref<HTMLInputElement>();
 const abortController = ref<AbortController | null>(null);
+const chunkProgress = new Map<number, number>();
 
 onUnmounted(() => abortController.value?.abort());
 
@@ -92,10 +94,16 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function updateProgress(totalSize: number) {
+  let sum = 0;
+  for (const v of chunkProgress.values()) sum += v;
+  progress.value = sum / totalSize;
+}
+
 async function uploadChunkWithRetry(
   url: string,
   blob: Blob,
-  chunkStart: number,
+  chunkIndex: number,
   totalSize: number,
   signal: AbortSignal,
 ): Promise<void> {
@@ -116,13 +124,19 @@ async function uploadChunkWithRetry(
 
         xhr.upload.onprogress = (e) => {
           if (e.lengthComputable) {
-            progress.value = (chunkStart + e.loaded) / totalSize;
+            chunkProgress.set(chunkIndex, e.loaded);
+            updateProgress(totalSize);
           }
         };
         xhr.onload = () => {
           signal.removeEventListener("abort", onAbort);
-          if (xhr.status === 204) resolve();
-          else reject(new Error(`${xhr.status}`));
+          if (xhr.status === 204) {
+            chunkProgress.set(chunkIndex, blob.size);
+            updateProgress(totalSize);
+            resolve();
+          } else {
+            reject(new Error(`${xhr.status}`));
+          }
         };
         xhr.onerror = () => {
           signal.removeEventListener("abort", onAbort);
@@ -167,21 +181,33 @@ async function startUpload(selected: File) {
     if (!initRes.ok) throw new Error(`${initRes.status}`);
     const { upload_id } = (await initRes.json()) as { upload_id: string };
 
-    // 2. Upload chunks
+    // 2. Upload chunks in parallel via a fixed worker pool
     const chunkCount = Math.ceil(selected.size / CHUNK_SIZE);
-    for (let i = 0; i < chunkCount; i++) {
-      const start = i * CHUNK_SIZE;
-      const end = Math.min(start + CHUNK_SIZE, selected.size);
-      const blob = selected.slice(start, end);
-      const url = `${baseUrl}/api/v1/users/upload/${upload_id}/${i}`;
-      await uploadChunkWithRetry(
-        url,
-        blob,
-        start,
-        selected.size,
-        controller.signal,
-      );
-    }
+    chunkProgress.clear();
+    const queue: number[] = Array.from({ length: chunkCount }, (_, i) => i);
+
+    const worker = async (): Promise<void> => {
+      while (queue.length > 0) {
+        const i = queue.shift();
+        if (i === undefined) return;
+        if (controller.signal.aborted) return;
+        const start = i * CHUNK_SIZE;
+        const end = Math.min(start + CHUNK_SIZE, selected.size);
+        const blob = selected.slice(start, end);
+        const url = `${baseUrl}/api/v1/users/upload/${upload_id}/${i}`;
+        await uploadChunkWithRetry(
+          url,
+          blob,
+          i,
+          selected.size,
+          controller.signal,
+        );
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: PARALLEL_CHUNKS }, () => worker()),
+    );
 
     // 3. Complete
     const completeRes = await fetch(
@@ -217,6 +243,7 @@ function reset() {
   file.value = null;
   uploading.value = false;
   progress.value = 0;
+  chunkProgress.clear();
 }
 </script>
 

--- a/frontend/src/components/register/ZipUploader.vue
+++ b/frontend/src/components/register/ZipUploader.vue
@@ -239,6 +239,7 @@ function cancel() {
 }
 
 function reset() {
+  abortController.value?.abort();
   abortController.value = null;
   file.value = null;
   uploading.value = false;


### PR DESCRIPTION
Serial chunk uploads compounded RTT over the Cloudflare Tunnel; each chunk also buffered its full 80 MiB in backend memory (640 MiB worst-case with 4 in flight).

**Frontend:** 4 coroutines share a chunk queue (shift-on-demand), not `Promise.all` over the full list. Per-chunk progress lives in a `Map` keyed by index so the aggregate bar stays accurate regardless of completion order. `AbortController` cascades cancel to in-flight XHRs.

**Backend:** `UploadStore.write_chunk_stream(AsyncIterator[bytes])` drains the request body into a tempfile via `anyio` with a 1 MiB flush buffer. The route forwards `request.stream()` so ASGI never materializes the chunk. Same-index retries are race-safe via tempfile + POSIX rename. Mid-write eviction surfaces as `KeyError` (not `OSError`); browser cancel returns 204 instead of a 500 traceback.

**Nginx:** `proxy_request_buffering off` on the chunk location so nginx doesn't stage the full 80 MiB before forwarding.

Backend RSS drops ~150x (~4.3 MiB steady state).