### PR TITLE
fix(processing): archive rate weight and retry without re-upload

### DIFF
--- a/backend/app/logic/session.py
+++ b/backend/app/logic/session.py
@@ -10,7 +10,7 @@ import logging
 from collections.abc import AsyncIterator
 
 from app.logic.pipeline import run_processing
-from app.logic.processing import ProcessingEvent
+from app.logic.processing import ErrorData, ProcessingEvent
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,9 @@ class ProcessingSession:
                 self._notify.set()
         except Exception:
             logger.exception("Processing task crashed for user %d", self._uid)
+            # Surface the crash to subscribers; without this the stream ends
+            # silently and the UI can't distinguish success from failure.
+            self._events.append(ErrorData())
         finally:
             self._done = True
             self._notify.set()
@@ -50,6 +53,10 @@ class ProcessingSession:
     @property
     def is_done(self) -> bool:
         return self._done
+
+    @property
+    def had_error(self) -> bool:
+        return any(isinstance(e, ErrorData) for e in self._events)
 
     def cancel(self) -> None:
         self._task.cancel()
@@ -94,15 +101,23 @@ def cancel_session(uid: int) -> None:
 
 
 async def process_stream(user: User) -> AsyncIterator[ProcessingEvent]:
-    """Start or reconnect to a user's processing session."""
+    """Start or reconnect to a user's processing session.
+
+    A finished session that ended in error is replaced with a fresh run so the
+    user can retry without re-uploading. A finished session that succeeded is
+    replayed so a browser refresh still works.
+    """
     session = _sessions.get(user.id)
 
-    if session is not None:
+    if session is not None and not (session.is_done and session.had_error):
         if not session.is_done:
             logger.info("User %d reconnecting to active processing session", user.id)
         async for event in session.subscribe():
             yield event
         return
+
+    if session is not None:
+        logger.info("User %d retrying after failed processing session", user.id)
 
     session = ProcessingSession(user)
     _sessions[user.id] = session

--- a/backend/app/services/open_meteo.py
+++ b/backend/app/services/open_meteo.py
@@ -36,8 +36,16 @@ class _StepLike(Protocol):
     def datetime(self) -> datetime: ...
 
 
-def _elevation_weight(request: Request) -> int:
-    """Each coordinate in a batched elevation request counts as one API call."""
+def _request_weight(request: Request) -> int:
+    """Estimate how many API calls Open-Meteo will charge for this request.
+
+    Elevation is charged per coordinate in the batched lat/lon params.
+    Archive is charged per requested daily variable: the server multiplies each
+    variable into a separate billed call, which is invisible in our HTTP count.
+    """
+    if request.url.path.endswith("/v1/archive"):
+        daily = request.url.params.get("daily", "")
+        return daily.count(",") + 1 if daily else 1
     lat = request.url.params.get("latitude", "")
     return lat.count(",") + 1 if "," in lat else 1
 
@@ -50,7 +58,7 @@ _limiter = AsyncLimiter(480, 60)
 def _client() -> httpx.AsyncClient:
     return cached_client(
         transport=RateLimitedTransport(
-            _limiter, max_concurrent=20, weight_fn=_elevation_weight
+            _limiter, max_concurrent=20, weight_fn=_request_weight
         )
     )
 

--- a/backend/tests/test_open_meteo.py
+++ b/backend/tests/test_open_meteo.py
@@ -12,6 +12,7 @@ import pytest
 
 from app.services.open_meteo import (
     _LocationResult,
+    _request_weight,
     _weather_from_result,
     _wmo_icon,
     build_weathers,
@@ -184,3 +185,48 @@ class TestBuildWeathers:
             with pytest.raises(RuntimeError, match="Weather API"):
                 async for _ in build_weathers([step]):
                     pass
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit weight
+# ---------------------------------------------------------------------------
+
+
+class TestRequestWeight:
+    def test_elevation_single_coord(self) -> None:
+        req = httpx.Request(
+            "GET", "https://api.open-meteo.com/v1/elevation?latitude=1.0&longitude=2.0"
+        )
+        assert _request_weight(req) == 1
+
+    def test_elevation_batched_coords(self) -> None:
+        req = httpx.Request(
+            "GET",
+            "https://api.open-meteo.com/v1/elevation?latitude=1,2,3,4&longitude=5,6,7,8",
+        )
+        assert _request_weight(req) == 4
+
+    def test_archive_counts_daily_variables(self) -> None:
+        req = httpx.Request(
+            "GET",
+            "https://archive-api.open-meteo.com/v1/archive"
+            "?latitude=1&longitude=2&start_date=2024-01-01&end_date=2024-01-01"
+            "&daily=temperature_2m_max,temperature_2m_min,"
+            "apparent_temperature_max,apparent_temperature_min,weather_code",
+        )
+        assert _request_weight(req) == 5
+
+    def test_archive_single_variable(self) -> None:
+        req = httpx.Request(
+            "GET",
+            "https://archive-api.open-meteo.com/v1/archive"
+            "?latitude=1&longitude=2&daily=temperature_2m_max",
+        )
+        assert _request_weight(req) == 1
+
+    def test_archive_without_daily_param(self) -> None:
+        req = httpx.Request(
+            "GET",
+            "https://archive-api.open-meteo.com/v1/archive?latitude=1&longitude=2",
+        )
+        assert _request_weight(req) == 1

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.logic.processing import (
+    ErrorData,
     PhaseUpdate,
     ProcessingEvent,
     TripStart,
@@ -100,6 +101,26 @@ class TestProcessStream:
 
         assert call_count == 1  # Only one processing run
         assert first == second  # Replayed same events
+
+    async def test_failed_session_retries_with_fresh_run(self) -> None:
+        call_count = 0
+
+        async def fake_processing(_user: User) -> AsyncIterator[ProcessingEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield ErrorData()
+            else:
+                yield TripStart(trip_index=0)
+
+        user = _mock_user(uid=11)
+        with patch("app.logic.session.run_processing", fake_processing):
+            first = await collect_async(process_stream(user))
+            second = await collect_async(process_stream(user))
+
+        assert call_count == 2  # Fresh run after error, not replay
+        assert first == [ErrorData()]
+        assert second == [TripStart(trip_index=0)]
 
     async def test_concurrent_same_user_shares_session(self) -> None:
         gate = asyncio.Event()

--- a/frontend/src/components/register/ProcessingProgress.vue
+++ b/frontend/src/components/register/ProcessingProgress.vue
@@ -15,6 +15,7 @@ import {
   matErrorOutline,
   matRefresh,
   matArrowForward,
+  matUploadFile,
 } from "@quasar/extras/material-icons";
 
 const props = defineProps<{
@@ -27,6 +28,7 @@ const props = defineProps<{
 
 defineEmits<{
   retry: [];
+  reupload: [];
   done: [];
 }>();
 
@@ -144,15 +146,26 @@ watch(
         />
         <div class="error-body column no-wrap q-gutter-y-sm">
           <span class="text-body2 error-msg text-muted">{{ errorDetail }}</span>
-          <q-btn
-            outline
-            no-caps
-            dense
-            :icon="matRefresh"
-            :label="t('register.tryAgain')"
-            class="retry-btn bg-surface"
-            @click="$emit('retry')"
-          />
+          <div class="row q-gutter-sm">
+            <q-btn
+              outline
+              no-caps
+              dense
+              :icon="matRefresh"
+              :label="t('register.tryAgain')"
+              class="retry-btn bg-surface"
+              @click="$emit('retry')"
+            />
+            <q-btn
+              outline
+              no-caps
+              dense
+              :icon="matUploadFile"
+              :label="t('register.uploadAgain')"
+              class="retry-btn bg-surface"
+              @click="$emit('reupload')"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/register/ProcessingProgress.vue
+++ b/frontend/src/components/register/ProcessingProgress.vue
@@ -213,9 +213,14 @@ watch(
   border-color: var(--border-color);
   color: var(--text);
   align-self: flex-start;
+  padding: 0.375rem 1rem;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease;
+}
+
+.retry-btn :deep(.q-btn__content) {
+  gap: 0.5rem;
 }
 
 .retry-btn:hover {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -81,6 +81,7 @@
     "steps": "no steps | {n} step | {n} steps",
     "countries": "no countries | {n} country | {n} countries",
     "tryAgain": "Try again",
+    "uploadAgain": "Upload a different file",
     "openAlbum": "Open your album",
     "unsupportedTitle": "Browser not supported",
     "unsupportedBody": "Switch to a recent browser: {chrome}, {firefox}, {safari}, or {edge}.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -176,7 +176,7 @@
     "videoFrame": "Couldn't set the video poster. @:common.retry",
     "pdfExport": "PDF export failed. @:common.retry",
     "dataExport": "Data export failed. @:common.retry",
-    "processingFailed": "Processing failed. Please try again later.",
+    "processingFailed": "Processing failed.",
     "connectionFailed": "Connection lost. @:common.retry",
     "adjustBoundary": "Couldn't adjust the boundary. @:common.retry"
   },

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -176,7 +176,7 @@
     "videoFrame": "לא הצלחנו לעדכן את הפוסטר. @:common.retry",
     "pdfExport": "ייצוא PDF נכשל. @:common.retry",
     "dataExport": "ייצוא הנתונים נכשל. @:common.retry",
-    "processingFailed": "העיבוד נכשל. נסו שוב מאוחר יותר.",
+    "processingFailed": "העיבוד נכשל.",
     "connectionFailed": "החיבור נותק. @:common.retry",
     "adjustBoundary": "לא הצלחנו לשנות את הגבול. @:common.retry"
   },

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -81,6 +81,7 @@
     "steps": "אין צעדים | צעד אחד | {n} צעדים",
     "countries": "אין מדינות | מדינה אחת | {n} מדינות",
     "tryAgain": "נסו שוב",
+    "uploadAgain": "העלו קובץ אחר",
     "openAlbum": "לאלבום",
     "unsupportedTitle": "הדפדפן שלכם לא נתמך",
     "unsupportedBody": "עברו לדפדפן עדכני: {chrome}, {firefox}, {safari}, או {edge}.",

--- a/frontend/src/pages/UploadView.vue
+++ b/frontend/src/pages/UploadView.vue
@@ -67,6 +67,10 @@ function onUploaded(data: UploadResult) {
 }
 
 function onRetry() {
+  stream.start();
+}
+
+function onReupload() {
   stream.abort();
   uploadResult.value = null;
   sessionStorage.removeItem(UPLOAD_RESULT_KEY);
@@ -135,6 +139,7 @@ function onDone() {
         :phase-done="stream.phaseDone.value"
         :error-detail="stream.errorDetail.value"
         @retry="onRetry"
+        @reupload="onReupload"
         @done="onDone"
       />
     </div>


### PR DESCRIPTION
Two fixes in post-upload processing:

### Open-Meteo archive weight
Archive endpoint bills each daily variable as a separate call, not once per request. We sent 5 daily variables at weight=1, hitting the 480/min limit within ~100 steps and getting 429s. `_request_weight` now counts daily vars for archive paths.

### Retry without re-upload

A failed run can retry in place against the existing upload. "Try again" re-runs processing; "Upload a different file" is a secondary button for swapping the ZIP. Backend drops the redundant `_had_error` flag (derived from events instead) and appends a synthetic `ErrorData` on unhandled exceptions so subscribers see the failure instead of a silent stream end.