### PR TITLE
refactor: collapse POSTGRES_* into single SQLALCHEMY_DATABASE_URI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,10 +42,9 @@ VITE_MAX_UPLOAD_GB=4
 MAX_STORAGE_BYTES=10737418240       # 10 GB. 0 = auto-detect (90% of filesystem capacity).
 
 # --- Defaults - Postgres -----------------------------
-# Only change if you have a custom Postgres setup.
+# The backend reads SQLALCHEMY_DATABASE_URI directly; POSTGRES_USER/DB are for
+# the Docker Postgres image init and the db-backup container.
 
-POSTGRES_SERVER=localhost
-POSTGRES_PORT=5432
 POSTGRES_DB=app
 POSTGRES_USER=postgres
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SECRET_KEY: ci
-      POSTGRES_SERVER: localhost
-      POSTGRES_USER: ci
-      POSTGRES_PASSWORD: ci
-      POSTGRES_DB: ci
+      SQLALCHEMY_DATABASE_URI: postgresql+psycopg://ci:ci@localhost:5432/ci
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -115,11 +112,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      POSTGRES_SERVER: localhost
-      POSTGRES_PORT: "5432"
-      POSTGRES_USER: ci
-      POSTGRES_PASSWORD: ci
-      POSTGRES_DB: ci
+      SQLALCHEMY_DATABASE_URI: postgresql+psycopg://ci:ci@localhost:5432/ci
       SECRET_KEY: ci
     steps:
       - uses: actions/checkout@v6

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,14 @@ def parse_cors(v: Any) -> list[str] | str:
     raise ValueError(v)
 
 
+def ensure_psycopg_scheme(v: Any) -> Any:
+    # SQLAlchemy's +psycopg suffix selects psycopg3; CNPG/Heroku/Render emit
+    # plain postgresql://, so rewrite at ingest rather than at each consumer.
+    if isinstance(v, str) and v.startswith("postgresql://"):
+        return "postgresql+psycopg://" + v.removeprefix("postgresql://")
+    return v
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         # Use top level .env file (one level above ./backend/)
@@ -61,23 +69,9 @@ class Settings(BaseSettings):
             self.VITE_FRONTEND_URL
         ]
 
-    POSTGRES_SERVER: str
-    POSTGRES_PORT: int = 5432
-    POSTGRES_USER: str
-    POSTGRES_PASSWORD: str
-    POSTGRES_DB: str
-
-    @computed_field
-    @property
-    def SQLALCHEMY_DATABASE_URI(self) -> PostgresDsn:
-        return PostgresDsn.build(
-            scheme="postgresql+psycopg",
-            username=self.POSTGRES_USER,
-            password=self.POSTGRES_PASSWORD,
-            host=self.POSTGRES_SERVER,
-            port=self.POSTGRES_PORT,
-            path=self.POSTGRES_DB,
-        )
+    SQLALCHEMY_DATABASE_URI: Annotated[
+        PostgresDsn, BeforeValidator(ensure_psycopg_scheme)
+    ]
 
     VITE_MAPBOX_TOKEN: str | None = None
 

--- a/compose.yml
+++ b/compose.yml
@@ -57,10 +57,7 @@ services:
         condition: service_healthy
         restart: true
     environment:
-      POSTGRES_SERVER: db
-      POSTGRES_USER: ${POSTGRES_USER:?Variable not set}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Variable not set}
-      POSTGRES_DB: ${POSTGRES_DB:?Variable not set}
+      SQLALCHEMY_DATABASE_URI: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SECRET_KEY: ${SECRET_KEY:?Variable not set}
       VITE_FRONTEND_URL: ${VITE_FRONTEND_URL:-}
       VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -4,14 +4,10 @@ import sys
 from pathlib import Path
 
 # Settings are env-driven; the OpenAPI spec isn't affected by these values.
-for key in (
-    "SECRET_KEY",
-    "POSTGRES_SERVER",
-    "POSTGRES_USER",
-    "POSTGRES_PASSWORD",
-    "POSTGRES_DB",
-):
-    os.environ.setdefault(key, "codegen")
+os.environ.setdefault("SECRET_KEY", "codegen")
+os.environ.setdefault(
+    "SQLALCHEMY_DATABASE_URI", "postgresql+psycopg://codegen:codegen@localhost/codegen"
+)
 
 from app.main import app  # noqa: E402
 

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "~=2.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "~=2.0" },
     { name = "python-multipart", specifier = "<1" },
-    { name = "rich", specifier = "~=14.0" },
+    { name = "rich", specifier = "~=15.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "~=2.35" },
     { name = "simplification", specifier = "~=0.7" },
     { name = "sqlalchemy", specifier = "~=2.0" },
@@ -1109,15 +1109,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The backend previously declared five settings fields and built the DSN in a computed property. Collapse into one field with a BeforeValidator that rewrites plain `postgresql://` to `postgresql+psycopg://` so CNPG/Heroku/Render-style URIs work as-is. Consumers (db.py, alembic env) already call `str(...)` on the URI, so they are unchanged.

Compose still composes the DSN from POSTGRES_USER/PASSWORD/DB because the `db` (postgres:18) and `db-backup` (prodrigestivill) images require those parts as separate env vars for their own init contracts. having backend read a derived DSN from compose keeps `.env` a single source of truth for credentials.