### PR TITLE
fix(frontend): thumbnail URLs for videos target the poster, not the mp4

### DIFF
--- a/frontend/src/components/album/map/mapSegments.ts
+++ b/frontend/src/components/album/map/mapSegments.ts
@@ -1,6 +1,6 @@
 import type { Segment, Step } from "@/client";
 import { DEFAULT_COUNTRY_COLOR } from "../colors";
-import { mediaThumbUrl, posterPath } from "@/utils/media";
+import { mediaThumbUrl } from "@/utils/media";
 import "./map-segments.css";
 import mapboxgl from "mapbox-gl";
 import bezierSpline from "@turf/bezier-spline";
@@ -345,8 +345,7 @@ export function drawSegmentsAndMarkers(
     el.setAttribute("role", "img");
     el.setAttribute("aria-label", step.name);
     if (step.cover) {
-      const coverPath = posterPath(step.cover);
-      el.style.backgroundImage = `url(${mediaThumbUrl(coverPath, albumId)})`;
+      el.style.backgroundImage = `url(${mediaThumbUrl(step.cover, albumId)})`;
     }
     new mapboxgl.Marker({ element: el }).setLngLat(lngLat).addTo(m);
   }

--- a/frontend/src/utils/media.ts
+++ b/frontend/src/utils/media.ts
@@ -26,7 +26,7 @@ export function mediaThumbUrl(
   albumId: string,
   width: number = THUMB_WIDTHS[0],
 ): string {
-  return `${mediaUrl(name, albumId)}?w=${width}`;
+  return `${mediaUrl(posterPath(name), albumId)}?w=${width}`;
 }
 
 export function mediaSrcset(name: string, albumId: string): string {

--- a/frontend/tests/utils/media.test.ts
+++ b/frontend/tests/utils/media.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/client/client.gen", () => ({
+  client: { getConfig: () => ({ baseUrl: "" }) },
+}));
+
+import { mediaThumbUrl } from "@/utils/media";
+
+describe("mediaThumbUrl", () => {
+  it("returns the poster .jpg for a video, not the .mp4", () => {
+    const url = mediaThumbUrl("clip.mp4", "aid-1", 200);
+    expect(url).toBe("/api/v1/albums/aid-1/media/clip.jpg?w=200");
+  });
+
+  it("passes through .jpg paths unchanged", () => {
+    const url = mediaThumbUrl("photo.jpg", "aid-1", 800);
+    expect(url).toBe("/api/v1/albums/aid-1/media/photo.jpg?w=800");
+  });
+});


### PR DESCRIPTION
## Summary
`mediaThumbUrl()` passed `.mp4` names through unchanged, so step-cover and landscape-photo thumbnails in `AlbumNav` and `InspectorDrawer` produced requests like `/albums/<aid>/media/foo.mp4?w=200`. The backend then tried to PIL-open the mp4 and crashed with `UnidentifiedImageError`.

Fix: route the translation through `posterPath()` inside `mediaThumbUrl` itself. Thumbnail callers always hit the poster `.jpg`, single point of truth. Also drops the now-redundant manual `posterPath()` in `mapSegments.ts`.

Regression test added in `tests/utils/media.test.ts`.