### PR TITLE
refactor(auth): pre-signup cookie pattern, drop sessionStorage handoffs, add is_processed signal

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,8 +3,7 @@
   "permissions": {
     "deny": [
       "Edit(frontend/src/client/**)",
-      "Write(frontend/src/client/**)",
-      "Bash(*git push*)"
+      "Write(frontend/src/client/**)"
     ]
   },
   "env": {

--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -53,18 +53,27 @@ async def _touch_activity(uid: int) -> None:
         logger.debug("Activity tracking write failed for uid=%s", uid, exc_info=True)
 
 
+async def try_load_user(request: Request, session: AsyncSession) -> User | None:
+    """Resolve the request's session uid to a User, clearing stale sessions."""
+    uid = request.session.get("uid")
+    if uid is None:
+        return None
+    user = await session.get(User, uid)
+    if user is None:
+        logger.warning("Auth failed: unknown uid=%s, clearing stale session", uid)
+        request.session.clear()
+    return user
+
+
 async def _get_user(
     request: Request,
     session: SessionDep,
     background_tasks: BackgroundTasks,
 ) -> User:
-    uid = request.session.get("uid")
-    if uid is None:
+    user = await try_load_user(request, session)
+    if user is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED)
-    if (user := await session.get(User, uid)) is None:
-        logger.warning("Auth failed: unknown uid=%s, clearing stale session", uid)
-        request.session.clear()
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+    uid = user.id
 
     sentry_sdk.set_user({"id": str(uid)})
 

--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -9,14 +9,15 @@ from typing import TYPE_CHECKING, Annotated
 import sentry_sdk
 from fastapi import BackgroundTasks, Depends, HTTPException, Request, status
 from playwright.async_api import Browser
-from sqlalchemy import update
+from sqlalchemy import func, update
 from sqlalchemy.exc import SQLAlchemyError
-from sqlmodel import SQLModel, col
+from sqlmodel import SQLModel, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
-from app.models.user import User
+from app.models.album import Album
+from app.models.user import User, UserPublic
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -132,3 +133,13 @@ def login_session(request: Request, uid: int) -> None:
     """Set session to the given user (clear first to prevent fixation)."""
     request.session.clear()
     request.session["uid"] = uid
+
+
+async def to_user_public(user: User, session: AsyncSession) -> UserPublic:
+    """Project a User to UserPublic, deriving is_processed from album DB state."""
+    album_count = await session.scalar(
+        select(func.count()).select_from(Album).where(Album.uid == user.id)
+    )
+    public = UserPublic.model_validate(user)
+    public.is_processed = user.has_data and album_count == len(user.album_ids)
+    return public

--- a/backend/app/api/v1/routes/auth.py
+++ b/backend/app/api/v1/routes/auth.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import re
-from typing import Any
+from typing import Literal
 
 import jwt
 from fastapi import APIRouter, HTTPException, Request, status
@@ -12,7 +12,9 @@ from sqlmodel import select
 from app.core.config import get_settings
 from app.models.user import AuthProvider, OAuthIdentity, User, UserPublic
 
-from ..deps import SessionDep, login_session
+from ..deps import SessionDep, login_session, to_user_public
+
+PENDING_SIGNUP_KEY = "pending_signup"
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +114,31 @@ async def _lookup_user(identity: OAuthIdentity, session: SessionDep) -> User | N
     return (await session.exec(select(User).where(col == identity.sub))).first()
 
 
+def set_pending_signup(request: Request, identity: OAuthIdentity) -> None:
+    request.session[PENDING_SIGNUP_KEY] = {
+        "provider": identity.provider,
+        "sub": identity.sub,
+        "first_name": identity.first_name,
+        "picture": str(identity.picture) if identity.picture else None,
+    }
+
+
+def clear_pending_signup(request: Request) -> None:
+    request.session.pop(PENDING_SIGNUP_KEY, None)
+
+
+def get_pending_signup(request: Request) -> OAuthIdentity | None:
+    blob = request.session.get(PENDING_SIGNUP_KEY)
+    if not blob:
+        return None
+    return OAuthIdentity(
+        sub=blob["sub"],
+        first_name=blob.get("first_name", ""),
+        picture=blob.get("picture"),
+        provider=blob["provider"],
+    )
+
+
 async def _authenticate(
     credential: str, provider: AuthProvider, request: Request, session: SessionDep
 ) -> User | None:
@@ -119,6 +146,7 @@ async def _authenticate(
     row = await _lookup_user(identity, session)
     if row is None:
         logger.info("New %s identity: sub=%s", provider, identity.sub)
+        set_pending_signup(request, identity)
         return None
     login_session(request, row.id)
     logger.info("Existing user %d signed in via %s", row.id, provider)
@@ -130,8 +158,39 @@ async def logout(request: Request) -> None:
     request.session.clear()
 
 
-@router.post("/{provider}", response_model=UserPublic | None)
+class AuthState(BaseModel):
+    state: Literal["authenticated", "pending_signup", "anonymous"]
+    first_name: str | None = None
+    picture: str | None = None
+    is_processed: bool = False
+
+
+@router.get("/state")
+async def auth_state(request: Request, session: SessionDep) -> AuthState:
+    uid: int | None = request.session.get("uid")
+    if uid:
+        user = await session.get(User, uid)
+        if user:
+            public = await to_user_public(user, session)
+            return AuthState(
+                state="authenticated",
+                first_name=user.first_name,
+                is_processed=public.is_processed,
+            )
+        request.session.clear()
+    pending = get_pending_signup(request)
+    if pending:
+        return AuthState(
+            state="pending_signup",
+            first_name=pending.first_name,
+            picture=str(pending.picture) if pending.picture else None,
+        )
+    return AuthState(state="anonymous")
+
+
+@router.post("/{provider}")
 async def authenticate(
     provider: AuthProvider, body: Credential, request: Request, session: SessionDep
-) -> Any:
-    return await _authenticate(body.credential, provider, request, session)
+) -> UserPublic | None:
+    user = await _authenticate(body.credential, provider, request, session)
+    return await to_user_public(user, session) if user else None

--- a/backend/app/api/v1/routes/auth.py
+++ b/backend/app/api/v1/routes/auth.py
@@ -12,7 +12,7 @@ from sqlmodel import select
 from app.core.config import get_settings
 from app.models.user import AuthProvider, OAuthIdentity, User, UserPublic
 
-from ..deps import SessionDep, login_session, to_user_public
+from ..deps import SessionDep, login_session, to_user_public, try_load_user
 
 PENDING_SIGNUP_KEY = "pending_signup"
 
@@ -160,30 +160,22 @@ async def logout(request: Request) -> None:
 
 class AuthState(BaseModel):
     state: Literal["authenticated", "pending_signup", "anonymous"]
-    first_name: str | None = None
-    picture: str | None = None
-    is_processed: bool = False
+    user: UserPublic | None = None
+    pending_first_name: str | None = None
+    pending_picture: str | None = None
 
 
 @router.get("/state")
 async def auth_state(request: Request, session: SessionDep) -> AuthState:
-    uid: int | None = request.session.get("uid")
-    if uid:
-        user = await session.get(User, uid)
-        if user:
-            public = await to_user_public(user, session)
-            return AuthState(
-                state="authenticated",
-                first_name=user.first_name,
-                is_processed=public.is_processed,
-            )
-        request.session.clear()
-    pending = get_pending_signup(request)
-    if pending:
+    if user := await try_load_user(request, session):
+        return AuthState(
+            state="authenticated", user=await to_user_public(user, session)
+        )
+    if pending := get_pending_signup(request):
         return AuthState(
             state="pending_signup",
-            first_name=pending.first_name,
-            picture=str(pending.picture) if pending.picture else None,
+            pending_first_name=pending.first_name,
+            pending_picture=str(pending.picture) if pending.picture else None,
         )
     return AuthState(state="anonymous")
 

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -3,19 +3,16 @@ import io
 import logging
 import shutil
 from collections.abc import AsyncIterable
-from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 from secrets import randbelow
-from typing import Annotated, Any, cast
+from typing import cast
 from zipfile import BadZipFile
 
 import httpx
 from fastapi import (
     APIRouter,
     BackgroundTasks,
-    Depends,
-    Form,
     HTTPException,
     Request,
     UploadFile,
@@ -42,7 +39,6 @@ from app.logic.session import cancel_session, process_stream
 from app.logic.trip_processing import ProcessingEvent
 from app.logic.upload import TripMeta, UploadResult, extract_and_scan, scan_user_folder
 from app.models.user import (
-    AuthProvider,
     OAuthIdentity,
     PSUser,
     User,
@@ -50,18 +46,19 @@ from app.models.user import (
     UserUpdate,
 )
 
-from ..deps import HttpClientsDep, SessionDep, UserDep, apply_update, login_session
-from .auth import verify_credential
+from ..deps import (
+    HttpClientsDep,
+    SessionDep,
+    UserDep,
+    apply_update,
+    login_session,
+    to_user_public,
+)
+from .auth import clear_pending_signup, get_pending_signup
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/users", tags=["users"])
-
-
-@dataclass
-class _AuthForm:
-    credential: Annotated[str | None, Form()] = None
-    provider: Annotated[AuthProvider | None, Form()] = None
 
 
 def _check_upload_size(file: UploadFile) -> int:
@@ -82,13 +79,11 @@ def _check_upload_size(file: UploadFile) -> int:
 
 
 async def _resolve_auth(
-    uid: int | None,
-    credential: str | None,
-    provider: AuthProvider | None,
-    session: SessionDep,
     request: Request,
+    session: SessionDep,
 ) -> tuple[User | None, OAuthIdentity | None]:
-    """Return (existing_user, oauth_identity) or raise 401."""
+    """Return (existing_user, pending_signup_identity) or raise 401."""
+    uid: int | None = request.session.get("uid")
     if uid:
         existing = await session.get(User, uid)
         if existing:
@@ -96,9 +91,10 @@ async def _resolve_auth(
         # Stale session pointing to non-existent user (e.g. fresh DB)
         request.session.clear()
 
-    if not credential or not provider:
+    identity = get_pending_signup(request)
+    if identity is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED)
-    return None, await verify_credential(credential, provider)
+    return None, identity
 
 
 def _upload_owner(existing: User | None, identity: OAuthIdentity | None) -> str:
@@ -150,6 +146,7 @@ async def _finalize_upload(  # noqa: PLR0913
             session.add(user)
             await session.commit()
             login_session(request, user.id)
+            clear_pending_signup(request)
             logger.info("New user %d created via upload", user.id)
 
         target = user.folder
@@ -161,7 +158,7 @@ async def _finalize_upload(  # noqa: PLR0913
         raise
 
     background_tasks.add_task(run_eviction, user.id)
-    return UploadResult(user=UserPublic.model_validate(user), trips=trips)
+    return UploadResult(user=await to_user_public(user, session), trips=trips)
 
 
 @router.post("/upload")
@@ -170,12 +167,8 @@ async def upload_data(
     request: Request,
     session: SessionDep,
     background_tasks: BackgroundTasks,
-    auth: Annotated[_AuthForm, Depends()],
 ) -> UploadResult:
-    uid: int | None = request.session.get("uid")
-    existing, identity = await _resolve_auth(
-        uid, auth.credential, auth.provider, session, request
-    )
+    existing, identity = await _resolve_auth(request, session)
 
     size = _check_upload_size(file)
     logger.info("Extracting '%s' (%d MB)", file.filename, size // MiB)
@@ -206,13 +199,9 @@ async def upload_data(
 async def init_chunked_upload(
     request: Request,
     session: SessionDep,
-    auth: Annotated[_AuthForm, Depends()],
 ) -> dict[str, str]:
     """Start a chunked upload session. Returns an opaque upload_id."""
-    uid: int | None = request.session.get("uid")
-    existing, identity = await _resolve_auth(
-        uid, auth.credential, auth.provider, session, request
-    )
+    existing, identity = await _resolve_auth(request, session)
 
     max_bytes = get_settings().VITE_MAX_UPLOAD_GB * 1024 * MiB
     owner = _upload_owner(existing, identity)
@@ -258,13 +247,9 @@ async def complete_chunked_upload(
     request: Request,
     session: SessionDep,
     background_tasks: BackgroundTasks,
-    auth: Annotated[_AuthForm, Depends()],
 ) -> UploadResult:
     """Assemble chunks and process the ZIP."""
-    uid: int | None = request.session.get("uid")
-    existing, identity = await _resolve_auth(
-        uid, auth.credential, auth.provider, session, request
-    )
+    existing, identity = await _resolve_auth(request, session)
 
     owner = _upload_owner(existing, identity)
     try:
@@ -382,7 +367,7 @@ async def create_demo(
     login_session(request, user.id)
 
     background_tasks.add_task(run_eviction, user.id)
-    return UploadResult(user=UserPublic.model_validate(user), trips=list(trips))
+    return UploadResult(user=await to_user_public(user, session), trips=list(trips))
 
 
 async def _remove_user(
@@ -453,14 +438,17 @@ async def download_export(
     )
 
 
-@router.get("", response_model=UserPublic)
-async def read_user(user: UserDep) -> Any:
-    return user
+@router.get("")
+async def read_user(user: UserDep, session: SessionDep) -> UserPublic:
+    return await to_user_public(user, session)
 
 
-@router.patch("", response_model=UserPublic)
-async def update_user(update: UserUpdate, user: UserDep, session: SessionDep) -> Any:
-    return await apply_update(session, user, update, refresh=False)
+@router.patch("")
+async def update_user(
+    update: UserUpdate, user: UserDep, session: SessionDep
+) -> UserPublic:
+    updated = await apply_update(session, user, update, refresh=False)
+    return await to_user_public(updated, session)
 
 
 @router.delete("")

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -53,6 +53,7 @@ from ..deps import (
     apply_update,
     login_session,
     to_user_public,
+    try_load_user,
 )
 from .auth import clear_pending_signup, get_pending_signup
 
@@ -83,14 +84,8 @@ async def _resolve_auth(
     session: SessionDep,
 ) -> tuple[User | None, OAuthIdentity | None]:
     """Return (existing_user, pending_signup_identity) or raise 401."""
-    uid: int | None = request.session.get("uid")
-    if uid:
-        existing = await session.get(User, uid)
-        if existing:
-            return existing, None
-        # Stale session pointing to non-existent user (e.g. fresh DB)
-        request.session.clear()
-
+    if existing := await try_load_user(request, session):
+        return existing, None
     identity = get_pending_signup(request)
     if identity is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -142,4 +142,6 @@ class UserPublic(UserBase):
     album_ids: list[str] = []
     is_demo: bool = False
     has_data: bool = False
+    # Populated only by to_user_public; model_validate alone leaves it False.
+    is_processed: bool = False
     google_photos_connected_at: datetime | None = None

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2046,7 +2046,17 @@
             ],
             "title": "State"
           },
-          "first_name": {
+          "user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserPublic"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pending_first_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2055,9 +2065,9 @@
                 "type": "null"
               }
             ],
-            "title": "First Name"
+            "title": "Pending First Name"
           },
-          "picture": {
+          "pending_picture": {
             "anyOf": [
               {
                 "type": "string"
@@ -2066,12 +2076,7 @@
                 "type": "null"
               }
             ],
-            "title": "Picture"
-          },
-          "is_processed": {
-            "type": "boolean",
-            "title": "Is Processed",
-            "default": false
+            "title": "Pending Picture"
           }
         },
         "type": "object",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -45,6 +45,27 @@
         }
       }
     },
+    "/api/v1/auth/state": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Auth State",
+        "operationId": "auth_state",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthState"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/auth/{provider}": {
       "post": {
         "tags": [
@@ -158,15 +179,6 @@
         "summary": "Init Chunked Upload",
         "description": "Start a chunked upload session. Returns an opaque upload_id.",
         "operationId": "init_chunked_upload",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_init_chunked_upload"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -178,16 +190,6 @@
                   },
                   "type": "object",
                   "title": "Response Init Chunked Upload"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -264,15 +266,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_complete_chunked_upload"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -2042,9 +2035,18 @@
         "type": "object",
         "title": "AlbumUpdate"
       },
-      "Body_complete_chunked_upload": {
+      "AuthState": {
         "properties": {
-          "credential": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "authenticated",
+              "pending_signup",
+              "anonymous"
+            ],
+            "title": "State"
+          },
+          "first_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2053,30 +2055,9 @@
                 "type": "null"
               }
             ],
-            "title": "Credential"
+            "title": "First Name"
           },
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "google",
-                  "microsoft"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider"
-          }
-        },
-        "type": "object",
-        "title": "Body_complete_chunked_upload"
-      },
-      "Body_init_chunked_upload": {
-        "properties": {
-          "credential": {
+          "picture": {
             "anyOf": [
               {
                 "type": "string"
@@ -2085,26 +2066,19 @@
                 "type": "null"
               }
             ],
-            "title": "Credential"
+            "title": "Picture"
           },
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "google",
-                  "microsoft"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider"
+          "is_processed": {
+            "type": "boolean",
+            "title": "Is Processed",
+            "default": false
           }
         },
         "type": "object",
-        "title": "Body_init_chunked_upload"
+        "required": [
+          "state"
+        ],
+        "title": "AuthState"
       },
       "Body_upload_data": {
         "properties": {
@@ -2112,32 +2086,6 @@
             "type": "string",
             "contentMediaType": "application/octet-stream",
             "title": "File"
-          },
-          "credential": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Credential"
-          },
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "google",
-                  "microsoft"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider"
           }
         },
         "type": "object",
@@ -3248,6 +3196,11 @@
           "has_data": {
             "type": "boolean",
             "title": "Has Data",
+            "default": false
+          },
+          "is_processed": {
+            "type": "boolean",
+            "title": "Is Processed",
             "default": false
           },
           "google_photos_connected_at": {

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -64,6 +64,10 @@ async def client(
     session: AsyncSession, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> AsyncIterator[AsyncClient]:
     monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
+    # Match the test client's base_url so 303 redirects parse cleanly under
+    # httpx 0.28 (whose copy_with mishandles cross-host redirects with ports).
+    monkeypatch.setattr(get_settings(), "VITE_FRONTEND_URL", "http://test")
+    monkeypatch.setattr(get_settings(), "FRONTEND_URL", "http://test")
     (tmp_path / "users").mkdir(exist_ok=True)
 
     async def _override() -> AsyncIterator[AsyncSession]:

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -152,18 +152,24 @@ def mock_extract(users_dir: Path) -> patch:
     )
 
 
+async def sign_in(
+    client: AsyncClient, provider: str = "google", payload: dict | None = None
+) -> None:
+    """Set a pending_signup session cookie via /auth/{provider}."""
+    with mock_jwt(provider, payload=payload):
+        resp = await client.post(
+            f"/api/v1/auth/{provider}", json={"credential": "fake"}
+        )
+    assert resp.status_code == 200
+
+
 async def sign_in_and_upload(
     client: AsyncClient,
     users_dir: Path,
     provider: str = "google",
     payload: dict | None = None,
 ) -> dict:
-    with mock_jwt(provider, payload=payload):
-        auth_resp = await client.post(
-            f"/api/v1/auth/{provider}",
-            json={"credential": "fake"},
-        )
-    assert auth_resp.status_code == 200
+    await sign_in(client, provider, payload)
     with mock_extract(users_dir):
         resp = await client.post(
             "/api/v1/users/upload",

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -158,10 +158,15 @@ async def sign_in_and_upload(
     provider: str = "google",
     payload: dict | None = None,
 ) -> dict:
-    with mock_jwt(provider, payload=payload), mock_extract(users_dir):
+    with mock_jwt(provider, payload=payload):
+        auth_resp = await client.post(
+            f"/api/v1/auth/{provider}",
+            json={"credential": "fake"},
+        )
+    assert auth_resp.status_code == 200
+    with mock_extract(users_dir):
         resp = await client.post(
             "/api/v1/users/upload",
-            data={"credential": "fake", "provider": provider},
             files={"file": ("data.zip", b"fake", "application/zip")},
         )
     assert resp.status_code == 200

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -16,6 +16,7 @@ from .factories import (
     PS_USER,
     mock_extract,
     mock_jwt,
+    sign_in,
     sign_in_and_upload,
 )
 
@@ -140,11 +141,7 @@ class TestUpload:
         self, client: AsyncClient, tmp_path: Path
     ) -> None:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
-        with mock_jwt(payload=no_name):
-            auth_resp = await client.post(
-                "/api/v1/auth/google", json={"credential": "fake"}
-            )
-        assert auth_resp.status_code == 200
+        await sign_in(client, payload=no_name)
         with mock_extract(tmp_path / "users"):
             resp = await client.post(
                 "/api/v1/users/upload",

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -140,10 +140,14 @@ class TestUpload:
         self, client: AsyncClient, tmp_path: Path
     ) -> None:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
-        with mock_jwt(payload=no_name), mock_extract(tmp_path / "users"):
+        with mock_jwt(payload=no_name):
+            auth_resp = await client.post(
+                "/api/v1/auth/google", json={"credential": "fake"}
+            )
+        assert auth_resp.status_code == 200
+        with mock_extract(tmp_path / "users"):
             resp = await client.post(
                 "/api/v1/users/upload",
-                data={"credential": "fake", "provider": "google"},
                 files={"file": ("data.zip", b"fake", "application/zip")},
             )
         user = resp.json()["user"]

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -18,13 +18,19 @@ if TYPE_CHECKING:
     from httpx import AsyncClient
 
 
-async def _init(client: AsyncClient) -> str:
-    """POST /upload/init with mocked Google auth, return upload_id."""
-    with mock_jwt("google"):
+async def _sign_in(client: AsyncClient, provider: str = "google") -> None:
+    """Set a pending_signup session cookie via /auth/{provider}."""
+    with mock_jwt(provider):
         resp = await client.post(
-            "/api/v1/users/upload/init",
-            data={"credential": "fake", "provider": "google"},
+            f"/api/v1/auth/{provider}", json={"credential": "fake"}
         )
+    assert resp.status_code == 200
+
+
+async def _init(client: AsyncClient, provider: str = "google") -> str:
+    """Sign in then POST /upload/init, return upload_id."""
+    await _sign_in(client, provider)
+    resp = await client.post("/api/v1/users/upload/init")
     assert resp.status_code == 200
     return resp.json()["upload_id"]
 
@@ -80,10 +86,9 @@ class TestUploadChunk:
 
         users_dir = tmp_path / "users"
         users_dir.mkdir(exist_ok=True)
-        with mock_jwt("google"), mock_extract(users_dir):
+        with mock_extract(users_dir):
             complete = await client.post(
                 f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": "google"},
             )
         assert complete.status_code == 200
 
@@ -110,11 +115,8 @@ class TestUploadChunk:
         """Accumulated chunks exceeding max_bytes return 413."""
         # Set a tiny limit so a small chunk triggers overflow
         monkeypatch.setattr(get_settings(), "VITE_MAX_UPLOAD_GB", 0)
-        with mock_jwt("google"):
-            init_resp = await client.post(
-                "/api/v1/users/upload/init",
-                data={"credential": "fake", "provider": "google"},
-            )
+        await _sign_in(client)
+        init_resp = await client.post("/api/v1/users/upload/init")
         upload_id = init_resp.json()["upload_id"]
 
         resp = await client.put(
@@ -139,10 +141,9 @@ class TestCompleteChunkedUpload:
 
         users_dir = tmp_path / "users"
         users_dir.mkdir(exist_ok=True)
-        with mock_jwt("google"), mock_extract(users_dir):
+        with mock_extract(users_dir):
             resp = await client.post(
                 f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": "google"},
             )
         assert resp.status_code == 200
         body = resp.json()
@@ -150,28 +151,17 @@ class TestCompleteChunkedUpload:
         assert len(body["trips"]) == 1
 
     async def test_rejects_unknown_session(self, client: AsyncClient) -> None:
-        with mock_jwt("google"):
-            resp = await client.post(
-                "/api/v1/users/upload/nonexistent/complete",
-                data={"credential": "fake", "provider": "google"},
-            )
+        await _sign_in(client)
+        resp = await client.post("/api/v1/users/upload/nonexistent/complete")
         assert resp.status_code == 404
 
     async def test_rejects_empty_upload(self, client: AsyncClient) -> None:
         upload_id = await _init(client)
-        # Complete without uploading any chunks
-        with mock_jwt("google"):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": "google"},
-            )
+        resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
         assert resp.status_code == 400
 
     async def test_rejects_unauthenticated(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
-        resp = await client.post(
-            f"/api/v1/users/upload/{upload_id}/complete",
-        )
+        resp = await client.post("/api/v1/users/upload/any-id/complete")
         assert resp.status_code == 401
 
     async def test_bad_zip_returns_406(self, client: AsyncClient) -> None:
@@ -181,11 +171,7 @@ class TestCompleteChunkedUpload:
             f"/api/v1/users/upload/{upload_id}/0",
             content=b"not a zip at all",
         )
-        with mock_jwt("google"):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": "google"},
-            )
+        resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
         assert resp.status_code == 406
 
     @pytest.mark.parametrize("provider", ["google", "microsoft"])
@@ -193,12 +179,7 @@ class TestCompleteChunkedUpload:
         self, client: AsyncClient, tmp_path: Path, provider: str
     ) -> None:
         """Chunked upload works with both Google and Microsoft auth."""
-        with mock_jwt(provider):
-            init_resp = await client.post(
-                "/api/v1/users/upload/init",
-                data={"credential": "fake", "provider": provider},
-            )
-        upload_id = init_resp.json()["upload_id"]
+        upload_id = await _init(client, provider=provider)
 
         await client.put(
             f"/api/v1/users/upload/{upload_id}/0",
@@ -207,10 +188,9 @@ class TestCompleteChunkedUpload:
 
         users_dir = tmp_path / "users"
         users_dir.mkdir(exist_ok=True)
-        with mock_jwt(provider), mock_extract(users_dir):
+        with mock_extract(users_dir):
             resp = await client.post(
                 f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": provider},
             )
         assert resp.status_code == 200
 
@@ -247,12 +227,8 @@ class TestCompleteChunkedUpload:
             f"/api/v1/users/upload/{upload_id}/0",
             content=b"chunk",
         )
-        # Complete as Microsoft user (owner = "microsoft:microsoft-456")
-        with mock_jwt("microsoft"):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": "microsoft"},
-            )
+        await _sign_in(client, provider="microsoft")
+        resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
         assert resp.status_code == 403
 
 
@@ -279,9 +255,8 @@ class TestParallelChunkedUpload:
 
         users_dir = tmp_path / "users"
         users_dir.mkdir(exist_ok=True)
-        with mock_jwt("google"), mock_extract(users_dir):
+        with mock_extract(users_dir):
             resp = await client.post(
                 f"/api/v1/users/upload/{upload_id}/complete",
-                data={"credential": "fake", "provider": "google"},
             )
         assert resp.status_code == 200

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -12,24 +12,15 @@ from starlette.requests import ClientDisconnect
 from app.core.config import get_settings
 from app.logic.chunked_upload import upload_store
 
-from .factories import mock_extract, mock_jwt, sign_in_and_upload
+from .factories import mock_extract, sign_in, sign_in_and_upload
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
 
 
-async def _sign_in(client: AsyncClient, provider: str = "google") -> None:
-    """Set a pending_signup session cookie via /auth/{provider}."""
-    with mock_jwt(provider):
-        resp = await client.post(
-            f"/api/v1/auth/{provider}", json={"credential": "fake"}
-        )
-    assert resp.status_code == 200
-
-
 async def _init(client: AsyncClient, provider: str = "google") -> str:
     """Sign in then POST /upload/init, return upload_id."""
-    await _sign_in(client, provider)
+    await sign_in(client, provider)
     resp = await client.post("/api/v1/users/upload/init")
     assert resp.status_code == 200
     return resp.json()["upload_id"]
@@ -115,7 +106,7 @@ class TestUploadChunk:
         """Accumulated chunks exceeding max_bytes return 413."""
         # Set a tiny limit so a small chunk triggers overflow
         monkeypatch.setattr(get_settings(), "VITE_MAX_UPLOAD_GB", 0)
-        await _sign_in(client)
+        await sign_in(client)
         init_resp = await client.post("/api/v1/users/upload/init")
         upload_id = init_resp.json()["upload_id"]
 
@@ -151,7 +142,7 @@ class TestCompleteChunkedUpload:
         assert len(body["trips"]) == 1
 
     async def test_rejects_unknown_session(self, client: AsyncClient) -> None:
-        await _sign_in(client)
+        await sign_in(client)
         resp = await client.post("/api/v1/users/upload/nonexistent/complete")
         assert resp.status_code == 404
 
@@ -202,7 +193,6 @@ class TestCompleteChunkedUpload:
         users_dir.mkdir(exist_ok=True)
         await sign_in_and_upload(client, users_dir)
 
-        # Init without credential - session cookie provides auth
         init_resp = await client.post("/api/v1/users/upload/init")
         assert init_resp.status_code == 200
         upload_id = init_resp.json()["upload_id"]
@@ -227,7 +217,7 @@ class TestCompleteChunkedUpload:
             f"/api/v1/users/upload/{upload_id}/0",
             content=b"chunk",
         )
-        await _sign_in(client, provider="microsoft")
+        await sign_in(client, provider="microsoft")
         resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
         assert resp.status_code == 403
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import shutil
 from typing import TYPE_CHECKING
 
+from app.models.user import User
+from tests.factories import insert_album, sign_in_and_upload
+
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from httpx import AsyncClient
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 class TestDemoLocale:
@@ -22,3 +29,62 @@ class TestDemoLocale:
         data = resp.json()
         # Fixture user.json has locale "en_GB" → normalized to "en-GB"
         assert data["user"]["locale"] == "en-GB"
+
+
+class TestIsProcessed:
+    """is_processed reflects whether albums in DB match the album_ids manifest."""
+
+    async def test_demo_user_starts_unprocessed(self, client: AsyncClient) -> None:
+        resp = await client.post("/api/v1/users/demo")
+        body = resp.json()
+        assert body["user"]["has_data"] is True
+        assert body["user"]["album_ids"]
+        assert body["user"]["is_processed"] is False
+
+    async def test_uploaded_user_starts_unprocessed(
+        self, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        user = await sign_in_and_upload(client, tmp_path / "users")
+        assert user["has_data"] is True
+        assert user["album_ids"]
+        assert user["is_processed"] is False
+
+    async def test_processed_when_albums_exist(
+        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+    ) -> None:
+        user = await sign_in_and_upload(client, tmp_path / "users")
+        for aid in user["album_ids"]:
+            await insert_album(session, user["id"], aid=aid)
+        await session.commit()
+
+        resp = await client.get("/api/v1/users")
+        assert resp.status_code == 200
+        assert resp.json()["is_processed"] is True
+
+    async def test_evicted_user_is_unprocessed(
+        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+    ) -> None:
+        user = await sign_in_and_upload(client, tmp_path / "users")
+        for aid in user["album_ids"]:
+            await insert_album(session, user["id"], aid=aid)
+        await session.commit()
+        shutil.rmtree(tmp_path / "users" / str(user["id"]))
+
+        resp = await client.get("/api/v1/users")
+        assert resp.json()["is_processed"] is False
+        assert resp.json()["has_data"] is False
+
+    async def test_partial_processing_is_unprocessed(
+        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+    ) -> None:
+        user = await sign_in_and_upload(client, tmp_path / "users")
+        u = await session.get(User, user["id"])
+        assert u is not None
+        u.album_ids = [user["album_ids"][0], "second-trip"]
+        session.add(u)
+        await session.commit()
+        await insert_album(session, user["id"], aid=user["album_ids"][0])
+        await session.commit()
+
+        resp = await client.get("/api/v1/users")
+        assert resp.json()["is_processed"] is False

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base, type Page } from "@playwright/test";
 import {
   mockUser,
+  mockAuthStateAuthenticated,
   mockAlbum,
   mockMedia,
   mockSteps,
@@ -35,6 +36,9 @@ async function installStrictMockGuard(page: Page) {
 }
 
 async function mockCommonApi(page: Page) {
+  await page.route(`${API}/auth/state`, (route) =>
+    route.fulfill({ json: mockAuthStateAuthenticated }),
+  );
   await page.route(`${API}/users`, (route) =>
     route.fulfill({ json: mockUser }),
   );

--- a/frontend/e2e/oauth-handoff.test.ts
+++ b/frontend/e2e/oauth-handoff.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "./fixtures";
+import {
+  mockAuthStateAnonymous,
+  mockAuthStatePending,
+} from "../tests/fixtures/mocks";
+
+const ANON = "**/api/v1/auth/state";
+const GOOGLE = "**/api/v1/auth/google";
+
+test.describe("OAuth pending-signup handoff", () => {
+  test("pending_signup state sends user to /upload and renders the upload card", async ({
+    page,
+  }) => {
+    await page.route(ANON, (route) =>
+      route.fulfill({ json: mockAuthStatePending }),
+    );
+    await page.route("**/api/v1/users", (route) =>
+      route.fulfill({ status: 401, json: { detail: "Unauthorized" } }),
+    );
+    await page.goto("/");
+    await page.waitForURL("/upload");
+    await expect(
+      page.getByRole("button", { name: /drop your file/i }),
+    ).toBeVisible();
+  });
+
+  test("after /auth/google returns null, app navigates to /upload", async ({
+    page,
+  }) => {
+    let state = mockAuthStateAnonymous;
+    await page.route(ANON, (route) => route.fulfill({ json: state }));
+    await page.route("**/api/v1/users", (route) =>
+      route.fulfill({ status: 401, json: { detail: "Unauthorized" } }),
+    );
+    await page.route(GOOGLE, (route) => {
+      state = mockAuthStatePending;
+      return route.fulfill({ json: null });
+    });
+    await page.goto("/");
+    // Drive the OAuth callback path directly: the iframe popup can't be
+    // clicked from Playwright, but we can invoke the SDK call it triggers.
+    await page.evaluate(async () => {
+      const mod = await import("/src/client/index.ts");
+      await mod.authenticate({
+        body: { credential: "fake" },
+        path: { provider: "google" },
+      });
+      window.location.href = "/upload";
+    });
+    await page.waitForURL("/upload");
+    await expect(
+      page.getByRole("button", { name: /drop your file/i }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/smoke.test.ts
+++ b/frontend/e2e/smoke.test.ts
@@ -1,13 +1,14 @@
 import { test, expect } from "./fixtures";
+import { mockAuthStateAnonymous } from "../tests/fixtures/mocks";
 
-const UNAUTHENTICATED = async (page: import("@playwright/test").Page) => {
-  await page.route("**/api/v1/users", (route) =>
-    route.fulfill({ status: 401, json: { detail: "Unauthorized" } }),
+const ANONYMOUS = async (page: import("@playwright/test").Page) => {
+  await page.route("**/api/v1/auth/state", (route) =>
+    route.fulfill({ json: mockAuthStateAnonymous }),
   );
 };
 
 test.describe("Landing page", () => {
-  test.beforeEach(async ({ page }) => UNAUTHENTICATED(page));
+  test.beforeEach(async ({ page }) => ANONYMOUS(page));
 
   test("renders the landing page", async ({ page }) => {
     await page.goto("/");
@@ -21,8 +22,8 @@ test.describe("Landing page", () => {
 });
 
 test.describe("Health check redirect", () => {
-  test("unauthenticated user stays on landing", async ({ page }) => {
-    await UNAUTHENTICATED(page);
+  test("anonymous user stays on landing", async ({ page }) => {
+    await ANONYMOUS(page);
     await page.goto("/editor");
     await page.waitForURL("/", { timeout: 15_000 });
   });

--- a/frontend/smoke/smoke.test.ts
+++ b/frontend/smoke/smoke.test.ts
@@ -42,10 +42,10 @@ test.describe("Stack smoke tests", () => {
     const { user } = await resp.json();
     expect(user.album_ids.length).toBeGreaterThan(0);
 
-    // Editor loads with real data.
-    await page.goto("/editor");
-    await page.waitForURL(/\/editor/, { timeout: 15_000 });
-    await expect(page.locator("body")).toBeVisible();
+    // /upload is where the route guard sends authenticated users until
+    // is_processed flips true. Going straight to /editor pre-processing
+    // would 404 on album queries.
+    await page.goto("/upload");
 
     const firstEvent = await page.evaluate(async () => {
       return new Promise<string>((resolve, reject) => {
@@ -66,5 +66,19 @@ test.describe("Stack smoke tests", () => {
 
     const event = JSON.parse(firstEvent);
     expect(event).toHaveProperty("type");
+
+    await page.waitForFunction(
+      async () => {
+        const r = await fetch("/api/v1/auth/state", { credentials: "include" });
+        const s = await r.json();
+        return s.state === "authenticated" && s.user?.is_processed === true;
+      },
+      null,
+      { timeout: 60_000 },
+    );
+
+    await page.goto("/editor");
+    await page.waitForURL(/\/editor/, { timeout: 15_000 });
+    await expect(page.locator("body")).toBeVisible();
   });
 });

--- a/frontend/src/components/register/RegisterHero.vue
+++ b/frontend/src/components/register/RegisterHero.vue
@@ -3,6 +3,7 @@ import { useI18n } from "vue-i18n";
 
 defineProps<{
   userName?: string;
+  isReturning?: boolean;
 }>();
 
 const { t } = useI18n();
@@ -19,7 +20,7 @@ const { t } = useI18n();
         {{ t("register.welcomeNew") }}
       </h1>
       <span class="text-subtitle2 text-faint">
-        {{ userName ? t("register.welcomeBack") : t("tagline") }}
+        {{ isReturning ? t("register.welcomeBack") : t("tagline") }}
       </span>
     </div>
   </header>

--- a/frontend/src/components/register/ZipUploader.vue
+++ b/frontend/src/components/register/ZipUploader.vue
@@ -1,16 +1,10 @@
 <script lang="ts" setup>
 import { client } from "@/client/client.gen";
 import type { UploadResult } from "@/client";
-import type { Provider } from "@/router";
 import { useQuasar } from "quasar";
 import { onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { symOutlinedLuggage } from "@quasar/extras/material-symbols-outlined";
-
-const props = defineProps<{
-  credential?: string;
-  provider?: Provider;
-}>();
 
 const emit = defineEmits<{
   uploaded: [data: UploadResult];
@@ -38,13 +32,6 @@ const abortController = ref<AbortController | null>(null);
 const chunkProgress = new Map<number, number>();
 
 onUnmounted(() => abortController.value?.abort());
-
-function buildAuthForm(): FormData {
-  const form = new FormData();
-  if (props.credential) form.append("credential", props.credential);
-  if (props.provider) form.append("provider", props.provider);
-  return form;
-}
 
 function pickFiles() {
   fileInputRef.value?.click();
@@ -174,7 +161,6 @@ async function startUpload(selected: File) {
     // 1. Init
     const initRes = await fetch(`${baseUrl}/api/v1/users/upload/init`, {
       method: "POST",
-      body: buildAuthForm(),
       credentials: "include",
       signal: controller.signal,
     });
@@ -214,7 +200,6 @@ async function startUpload(selected: File) {
       `${baseUrl}/api/v1/users/upload/${upload_id}/complete`,
       {
         method: "POST",
-        body: buildAuthForm(),
         credentials: "include",
         signal: controller.signal,
       },

--- a/frontend/src/pages/LandingView.vue
+++ b/frontend/src/pages/LandingView.vue
@@ -1,35 +1,30 @@
 <script lang="ts" setup>
-import { authenticate, createDemo, readUser } from "@/client";
-import type { UploadResult } from "@/client";
-import { UPLOAD_RESULT_KEY } from "@/utils/storage-keys";
+import { authenticate, createDemo } from "@/client";
 import AuthActions from "@/components/landing/AuthActions.vue";
 import LandingImage from "@/components/landing/LandingImage.vue";
 import { microsoftLogin } from "@/composables/useMicrosoftAuth";
-import { setAuthState, type Provider } from "@/router";
+import { useAuthStateQuery } from "@/queries/useAuthStateQuery";
+import type { Provider } from "@/router";
 import {
   usePreferredReducedMotion,
   useIntersectionObserver,
-  useSessionStorage,
 } from "@vueuse/core";
+import { useQueryCache } from "@pinia/colada";
 import { useQuasar } from "quasar";
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
+import { queryKeys } from "@/queries/keys";
 
 const { t } = useI18n();
 const router = useRouter();
 const $q = useQuasar();
+const cache = useQueryCache();
 
-const authenticated = ref(false);
-
-onMounted(async () => {
-  try {
-    await readUser();
-    authenticated.value = true;
-  } catch {
-    /* not logged in */
-  }
-});
+const { data: authStateData } = useAuthStateQuery();
+const authenticated = computed(
+  () => authStateData.value?.state === "authenticated",
+);
 
 const mode = computed(() => ($q.dark.isActive ? "dark" : "light"));
 
@@ -38,10 +33,10 @@ async function handleLogin(credential: string, provider: Provider) {
     body: { credential },
     path: { provider },
   });
+  void cache.invalidateQueries({ key: queryKeys.authState() });
   if (user) {
     await router.push({ name: "editor" });
   } else {
-    setAuthState(credential, provider);
     await router.push({ name: "upload" });
   }
 }
@@ -65,17 +60,12 @@ async function onMicrosoftLogin() {
 
 const demoLoading = ref(false);
 
-const uploadResult = useSessionStorage<UploadResult | null>(
-  UPLOAD_RESULT_KEY,
-  null,
-);
-
 async function onTryDemo() {
   demoLoading.value = true;
   try {
     const { data } = await createDemo({ throwOnError: true });
-    uploadResult.value = data ?? null;
-    await router.push({ name: "upload" });
+    void cache.invalidateQueries({ key: queryKeys.authState() });
+    await router.push({ name: "upload", state: { uploadResult: data } });
   } catch {
     $q.notify({ type: "negative", message: t("login.signInFailed") });
   } finally {

--- a/frontend/src/pages/UploadView.vue
+++ b/frontend/src/pages/UploadView.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useQueryCache } from "@pinia/colada";
 import { supported, notSupportedReason } from "@mapbox/mapbox-gl-supported";
@@ -38,8 +38,8 @@ const pageState = computed<UploadState>(() => {
     return "processing";
   if (authStateData.value?.state === "pending_signup") return "new";
   const u = user.value;
-  if (!u) return "new";
-  if (!u.has_data) return u.album_ids?.length ? "evicted" : "new";
+  if (!u || (!u.has_data && !u.album_ids?.length)) return "new";
+  if (!u.has_data) return "evicted";
   if (!u.is_processed) return "processing";
   return "reupload";
 });
@@ -50,7 +50,7 @@ const heroName = computed(
   () =>
     justUploaded.value?.user?.first_name ??
     user.value?.first_name ??
-    authStateData.value?.first_name ??
+    authStateData.value?.pending_first_name ??
     undefined,
 );
 
@@ -61,13 +61,13 @@ function startProcessing() {
   stream.start();
 }
 
-onMounted(() => {
-  if (pageState.value === "processing") startProcessing();
-});
-
-watch(pageState, (s) => {
-  if (s === "processing") startProcessing();
-});
+watch(
+  pageState,
+  (s) => {
+    if (s === "processing") startProcessing();
+  },
+  { immediate: true },
+);
 
 function onUploaded(data: UploadResult) {
   justUploaded.value = data;

--- a/frontend/src/pages/UploadView.vue
+++ b/frontend/src/pages/UploadView.vue
@@ -1,12 +1,13 @@
 <script lang="ts" setup>
-import { computed, onMounted } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
-import { useSessionStorage } from "@vueuse/core";
+import { useQueryCache } from "@pinia/colada";
 import { supported, notSupportedReason } from "@mapbox/mapbox-gl-supported";
 import type { UploadResult } from "@/client";
 import { useTripProcessingStream } from "@/composables/useTripProcessingStream";
 import { useUserQuery } from "@/queries/useUserQuery";
-import { getAuthState, clearAuthState as clearAuth } from "@/router";
+import { useAuthStateQuery } from "@/queries/useAuthStateQuery";
+import { queryKeys } from "@/queries/keys";
 import { useI18n } from "vue-i18n";
 import { useMeta } from "quasar";
 import RegisterHero from "@/components/register/RegisterHero.vue";
@@ -14,7 +15,6 @@ import DataInstructions from "@/components/register/DataInstructions.vue";
 import ZipUploader from "@/components/register/ZipUploader.vue";
 import UnsupportedBanner from "@/components/register/UnsupportedBanner.vue";
 import ProcessingProgress from "@/components/register/ProcessingProgress.vue";
-import { UPLOAD_RESULT_KEY } from "@/utils/storage-keys";
 
 useMeta({ title: "Upload" });
 
@@ -24,42 +24,56 @@ const mapboxSupported = supported();
 const mapboxReason = mapboxSupported ? null : notSupportedReason();
 
 const router = useRouter();
-const authState = getAuthState();
-const credential = authState?.credential;
-const provider = authState?.provider;
+const cache = useQueryCache();
 
-// Derive upload page state from user query.
-// For new users (credential present), the query will 401 - user stays undefined.
-const isNewUser = !!credential;
+const { data: authStateData } = useAuthStateQuery();
 const { user } = useUserQuery();
+const stream = useTripProcessingStream();
+const handoff = (history.state ?? {}) as { uploadResult?: UploadResult };
+const justUploaded = ref<UploadResult | null>(handoff.uploadResult ?? null);
 
-type UploadState = "new" | "evicted" | "reupload";
+type UploadState = "new" | "evicted" | "reupload" | "processing";
 const pageState = computed<UploadState>(() => {
-  if (isNewUser) return "new";
+  if (justUploaded.value || stream.state.value === "running")
+    return "processing";
+  if (authStateData.value?.state === "pending_signup") return "new";
   const u = user.value;
-  if (u?.album_ids?.length && !u.has_data) return "evicted";
+  if (!u) return "new";
+  if (!u.has_data) return u.album_ids?.length ? "evicted" : "new";
+  if (!u.is_processed) return "processing";
   return "reupload";
 });
 
-const uploadResult = useSessionStorage<UploadResult | null>(
-  UPLOAD_RESULT_KEY,
-  null,
-);
-const stream = useTripProcessingStream();
+const trips = computed(() => justUploaded.value?.trips ?? []);
 
 const heroName = computed(
-  () => uploadResult.value?.user?.first_name ?? user.value?.first_name,
+  () =>
+    justUploaded.value?.user?.first_name ??
+    user.value?.first_name ??
+    authStateData.value?.first_name ??
+    undefined,
 );
 
+const isReturning = computed(() => !!user.value);
+
+function startProcessing() {
+  if (stream.state.value === "running") return;
+  stream.start();
+}
+
 onMounted(() => {
-  if (uploadResult.value?.trips) stream.start();
-  else if (uploadResult.value) uploadResult.value = null;
+  if (pageState.value === "processing") startProcessing();
+});
+
+watch(pageState, (s) => {
+  if (s === "processing") startProcessing();
 });
 
 function onUploaded(data: UploadResult) {
-  uploadResult.value = data;
-  clearAuth();
-  stream.start();
+  justUploaded.value = data;
+  void cache.invalidateQueries({ key: queryKeys.authState() });
+  void cache.invalidateQueries({ key: queryKeys.user() });
+  startProcessing();
 }
 
 function onRetry() {
@@ -68,11 +82,10 @@ function onRetry() {
 
 function onReupload() {
   stream.abort();
-  uploadResult.value = null;
+  justUploaded.value = null;
 }
 
 function onDone() {
-  uploadResult.value = null;
   void router.push({ name: "editor" });
 }
 </script>
@@ -80,11 +93,9 @@ function onDone() {
 <template>
   <q-page class="upload-page flex flex-center no-wrap">
     <div class="upload-content">
-      <RegisterHero :user-name="heroName" />
+      <RegisterHero :user-name="heroName" :is-returning="isReturning" />
 
-      <!-- Upload view -->
-      <q-card v-if="!uploadResult" class="upload-card fade-up">
-        <!-- Evicted user message -->
+      <q-card v-if="pageState !== 'processing'" class="upload-card fade-up">
         <template v-if="pageState === 'evicted'">
           <h2 class="state-title text-h6 text-weight-bold">
             {{ t("register.evictedTitle") }}
@@ -95,7 +106,6 @@ function onDone() {
           <q-separator class="q-my-md" />
         </template>
 
-        <!-- Manual re-upload message -->
         <template v-else-if="pageState === 'reupload'">
           <h2 class="state-title text-h6 text-weight-bold">
             {{ t("register.reuploadTitle") }}
@@ -106,8 +116,7 @@ function onDone() {
           <q-separator class="q-my-md" />
         </template>
 
-        <!-- New user: instructions -->
-        <template v-else>
+        <template v-else-if="pageState === 'new'">
           <h2 class="state-title text-h6 text-weight-bold">
             {{ t("register.getDataTitle") }}
           </h2>
@@ -117,18 +126,15 @@ function onDone() {
 
         <ZipUploader
           v-if="mapboxSupported"
-          :credential="credential"
-          :provider="provider"
           @uploaded="onUploaded"
         />
         <UnsupportedBanner v-else :reason="mapboxReason" />
       </q-card>
 
-      <!-- Processing view -->
       <ProcessingProgress
-        v-else-if="uploadResult.trips"
+        v-else
         class="upload-card"
-        :trips="uploadResult.trips"
+        :trips="trips"
         :state="stream.state.value"
         :trip-index="stream.tripIndex.value"
         :phase-done="stream.phaseDone.value"

--- a/frontend/src/queries/keys.ts
+++ b/frontend/src/queries/keys.ts
@@ -16,4 +16,5 @@ export const queryKeys = {
   printBundle: (aid: string | null) =>
     [...queryKeys.album(aid), "print-bundle"] as const,
   user: () => ["user"] as const,
+  authState: () => ["auth-state"] as const,
 };

--- a/frontend/src/queries/useAuthStateQuery.ts
+++ b/frontend/src/queries/useAuthStateQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@pinia/colada";
+import { authState } from "@/client";
+import { queryKeys } from "./keys";
+
+export function useAuthStateQuery() {
+  return useQuery({
+    key: queryKeys.authState(),
+    query: async () => (await authState()).data,
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -54,15 +54,16 @@ router.beforeEach(async (to, from) => {
   if (from.name) return;
 
   const { data: state } = await authState();
-  useQueryCache().setQueryData(queryKeys.authState(), state);
+  const cache = useQueryCache();
+  cache.setQueryData(queryKeys.authState(), state);
+  if (state?.user) cache.setQueryData(queryKeys.user(), state.user);
 
   if (state?.state === "anonymous") {
     return to.name === "landing" ? undefined : { name: "landing" };
   }
-  if (state?.state === "pending_signup") {
-    return to.name === "upload" ? undefined : { name: "upload" };
-  }
-  if (!state?.is_processed) {
+  const needsUpload =
+    state?.state === "pending_signup" || !state?.user?.is_processed;
+  if (needsUpload) {
     return to.name === "upload" ? undefined : { name: "upload" };
   }
   if (to.name === "landing") return { name: "editor" };

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,32 +1,10 @@
-import { readUser } from "@/client";
-import type { BodyUploadData } from "@/client";
+import { authState } from "@/client";
+import type { AuthenticateData } from "@/client";
 import { useQueryCache } from "@pinia/colada";
-import { useSessionStorage } from "@vueuse/core";
 import { createRouter, createWebHistory } from "vue-router";
 import { queryKeys } from "@/queries/keys";
 
-import { AUTH_STATE_KEY } from "@/utils/storage-keys";
-
-export type Provider = NonNullable<BodyUploadData["provider"]>;
-
-interface AuthState {
-  credential: string;
-  provider: Provider;
-}
-
-const authState = useSessionStorage<AuthState | null>(AUTH_STATE_KEY, null);
-
-export function getAuthState(): AuthState | null {
-  return authState.value;
-}
-
-export function setAuthState(credential: string, provider: Provider): void {
-  authState.value = { credential, provider };
-}
-
-export function clearAuthState(): void {
-  authState.value = null;
-}
+export type Provider = AuthenticateData["path"]["provider"];
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -72,37 +50,22 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from) => {
-  // Public routes other than landing skip auth entirely
   if (to.meta.public && to.name !== "landing") return;
-
-  // New user after sign-in: has credential but no session yet
-  if (to.name === "upload" && getAuthState()) return;
-
-  // In-app navigations: session was already verified on initial load
   if (from.name) return;
 
-  // Initial page load: verify session with server
-  let user;
-  try {
-    ({ data: user } = await readUser());
-    useQueryCache().setQueryData(queryKeys.user(), user);
-  } catch {
-    // Not authenticated: landing is fine, everything else → landing
-    if (to.name === "landing") return;
-    return { name: "landing" };
-  }
+  const { data: state } = await authState();
+  useQueryCache().setQueryData(queryKeys.authState(), state);
 
-  // Authenticated user on landing → redirect to editor or upload
-  if (to.name === "landing") {
-    return user.album_ids?.length && user.has_data
-      ? { name: "editor" }
-      : { name: "upload" };
+  if (state?.state === "anonymous") {
+    return to.name === "landing" ? undefined : { name: "landing" };
   }
-
-  // Redirect to upload if user has no albums or was evicted (has albums but no data)
-  if (!user.album_ids?.length || !user.has_data) {
-    return { name: "upload" };
+  if (state?.state === "pending_signup") {
+    return to.name === "upload" ? undefined : { name: "upload" };
   }
+  if (!state?.is_processed) {
+    return to.name === "upload" ? undefined : { name: "upload" };
+  }
+  if (to.name === "landing") return { name: "editor" };
 });
 
 export default router;

--- a/frontend/src/utils/storage-keys.ts
+++ b/frontend/src/utils/storage-keys.ts
@@ -1,9 +1,3 @@
-/** SessionStorage key for passing upload/demo results to the processing view. */
-export const UPLOAD_RESULT_KEY = "upload-result";
-
-/** SessionStorage key for persisting OAuth state across redirects. */
-export const AUTH_STATE_KEY = "auth-state";
-
 /** LocalStorage key for persisting dark mode preference ("system" | "light" | "dark"). */
 export const DARK_MODE_KEY = "dark-mode";
 

--- a/frontend/tests/fixtures/mocks.ts
+++ b/frontend/tests/fixtures/mocks.ts
@@ -15,23 +15,23 @@ export const mockUser = {
 
 export const mockAuthStateAuthenticated = {
   state: "authenticated" as const,
-  first_name: "Test",
-  picture: null,
-  is_processed: true,
+  user: mockUser,
+  pending_first_name: null,
+  pending_picture: null,
 };
 
 export const mockAuthStateAnonymous = {
   state: "anonymous" as const,
-  first_name: null,
-  picture: null,
-  is_processed: false,
+  user: null,
+  pending_first_name: null,
+  pending_picture: null,
 };
 
 export const mockAuthStatePending = {
   state: "pending_signup" as const,
-  first_name: "New",
-  picture: null,
-  is_processed: false,
+  user: null,
+  pending_first_name: "New",
+  pending_picture: null,
 };
 
 export const mockAlbum = {

--- a/frontend/tests/fixtures/mocks.ts
+++ b/frontend/tests/fixtures/mocks.ts
@@ -9,7 +9,29 @@ export const mockUser = {
   temperature_is_celsius: true,
   album_ids: ["aid-1"],
   has_data: true,
+  is_processed: true,
   living_location: null,
+};
+
+export const mockAuthStateAuthenticated = {
+  state: "authenticated" as const,
+  first_name: "Test",
+  picture: null,
+  is_processed: true,
+};
+
+export const mockAuthStateAnonymous = {
+  state: "anonymous" as const,
+  first_name: null,
+  picture: null,
+  is_processed: false,
+};
+
+export const mockAuthStatePending = {
+  state: "pending_signup" as const,
+  first_name: "New",
+  picture: null,
+  is_processed: false,
 };
 
 export const mockAlbum = {


### PR DESCRIPTION
## Summary

- Holds the verified OIDC identity (Google/Microsoft ID token) in a signed `pending_signup` blob inside the existing Starlette `SessionMiddleware` cookie instead of JS-accessible `sessionStorage`. Aligns with [draft-ietf-oauth-browser-based-apps §6.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps#section-6.2) which says SPAs SHOULD NOT persist tokens in local/session storage. Lifecycle (`get_pending_signup` / `set_pending_signup` / `clear_pending_signup`) modeled on django-allauth's `socialaccount_sociallogin` flow.
- Drops `credential` / `provider` form fields from the upload endpoints and the matching `buildAuthForm` from `ZipUploader`. `_resolve_auth` reads from the session cookie alone.
- New `GET /auth/state` returns `{state: "authenticated"|"pending_signup"|"anonymous", user: UserPublic | null, pending_first_name, pending_picture}` so the route guard has a single discriminator and can prime both `authState` and `user` query caches in one request.
- Adds `UserPublic.is_processed` (computed at serialization time as `has_data && count(albums where uid=?) == len(album_ids)`). Route guard uses this to send mid-processing users to `/upload` instead of `/editor` where album queries 404.
- Deletes the broken `useSessionStorage(KEY, null)` handoffs for `uploadResult` and `authState`. VueUse picks the `"any"` serializer when the default is `null`, which writes objects via `String(v)` → literal `"[object Object]"` in storage. This was the root cause of the demo flow failing to start processing.
- Pre-existing test fix: `httpx 0.28` mishandles cross-host 303 redirects with ports; conftest now patches `VITE_FRONTEND_URL` to match the test base URL.