### PR TITLE
fix(frontend): recover from stale chunk imports after deploys

### DIFF
--- a/frontend/src/composables/useChunkErrorRecovery.ts
+++ b/frontend/src/composables/useChunkErrorRecovery.ts
@@ -1,0 +1,30 @@
+import type { RouteLocationNormalized, Router } from "vue-router";
+
+const RETRY_KEY = "chunk-reload-attempted";
+
+export function useChunkErrorRecovery(router: Router): void {
+  let pendingTarget: RouteLocationNormalized | null = null;
+
+  router.beforeEach((to) => {
+    pendingTarget = to;
+  });
+  router.afterEach(() => {
+    pendingTarget = null;
+    sessionStorage.removeItem(RETRY_KEY);
+  });
+
+  window.addEventListener("vite:preloadError", (event) => {
+    if (!pendingTarget) {
+      event.preventDefault();
+      return;
+    }
+    if (sessionStorage.getItem(RETRY_KEY)) return;
+    sessionStorage.setItem(RETRY_KEY, String(Date.now()));
+    const target = pendingTarget.fullPath;
+    if (location.pathname + location.search !== target) {
+      location.href = target;
+    } else {
+      location.reload();
+    }
+  });
+}

--- a/frontend/src/composables/usePolledExportDownload.ts
+++ b/frontend/src/composables/usePolledExportDownload.ts
@@ -2,7 +2,7 @@ import { useTimeoutFn } from "@vueuse/core";
 import { onScopeDispose, ref, type Ref } from "vue";
 import { Loading, Notify } from "quasar";
 
-export type ExportState = "idle" | "running" | "done" | "error";
+type ExportState = "idle" | "running" | "done" | "error";
 
 export interface PolledExportHandle {
   start(): void;

--- a/frontend/src/composables/useTripProcessingStream.ts
+++ b/frontend/src/composables/useTripProcessingStream.ts
@@ -8,10 +8,9 @@ import {
 } from "@/client";
 import { t } from "@/i18n";
 
-export type { ProcessingPhase };
 export type ProcessingState = "idle" | "running" | "done" | "error";
 
-export interface PhaseProgress {
+interface PhaseProgress {
   done: number;
   total: number;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,7 +24,14 @@ import "@/styles/animations.css";
 import App from "./App.vue";
 import router from "./router";
 
+import { useChunkErrorRecovery } from "@/composables/useChunkErrorRecovery";
 import { client } from "@/client/client.gen";
+
+const PRELOAD_ERROR_PATTERNS = [
+  "Failed to fetch dynamically imported module",
+  "error loading dynamically imported module",
+  "Importing a module script failed",
+];
 
 client.setConfig({
   baseUrl: "",
@@ -43,6 +50,11 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     integrations: [Sentry.replayIntegration()],
     tracesSampleRate: 0,
     replaysOnErrorSampleRate: 1.0,
+    beforeSend(event) {
+      const message = event.exception?.values?.[0]?.value ?? "";
+      if (PRELOAD_ERROR_PATTERNS.some((p) => message.includes(p))) return null;
+      return event;
+    },
   });
   pinia.use(Sentry.createSentryPiniaPlugin());
 }
@@ -50,6 +62,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
 app.use(pinia);
 app.use(PiniaColada);
 app.use(router);
+useChunkErrorRecovery(router);
 app.use(i18n);
 app.use(vue3GoogleLogin, {
   clientId: import.meta.env.VITE_GOOGLE_CLIENT_ID,

--- a/frontend/src/utils/photoQuality.ts
+++ b/frontend/src/utils/photoQuality.ts
@@ -14,7 +14,7 @@ import {
 } from "@/utils/photoLayout";
 import { isPortraitByName } from "@/utils/media";
 
-export type QualityTier = "ok" | "caution" | "warning";
+type QualityTier = "ok" | "caution" | "warning";
 
 export interface QualitySummary {
   caution: number;


### PR DESCRIPTION
## Summary

A tab still holding a previously-deployed `index.html` will 404 on the next dynamic import once the deploy invalidates chunk hashes. Vue Router's lazy-imported routes silently fail, navigation appears stuck, and Sentry fires "Failed to fetch dynamically imported module".

## Fix

`useChunkErrorRecovery` listens for Vite's `vite:preloadError` event (which normalizes Chrome/FF/Safari error string variants), tracks the pending navigation target via `router.beforeEach`, and on preload failure hard-navigates to that target so the freshly-fetched `index.html` references the current chunk hashes.

A `sessionStorage` flag prevents an infinite reload loop if the new deploy also 404s; it clears on the next successful navigation. Preload failures with no pending navigation (modulepreload prefetches) are suppressed via `event.preventDefault()` to avoid noise.

Sentry `beforeSend` drops the three browser-specific preload error message strings since the recovery handler resolves them.

## Why not the more-cited Paulau pattern?

Paulau's blog suggests `WeakSet<Error>` matching between `vite:preloadError.payload` and `router.onError`'s error. That doesn't work in our Vue Router 4 — the lazy-import failure is wrapped as `Error: Couldn't resolve component "default" at "/legal"`, a different object. Driving recovery from `vite:preloadError` directly + tracking the target via `beforeEach` is more robust.