### PR TITLE
fix(frontend): correct media item video controls

### DIFF
--- a/frontend/e2e/video-keyboard.test.ts
+++ b/frontend/e2e/video-keyboard.test.ts
@@ -66,18 +66,21 @@ test.describe("Video keyboard controls", () => {
     focusPage: page,
   }) => {
     await scrollToVideo(page);
+    const previousPhoto = page.locator('[data-media="focus-photo-10.jpg"]');
+    await previousPhoto.click();
+    await expect(previousPhoto).toHaveAttribute("aria-pressed", "true");
 
-    // Start video via play overlay
     await playOverlay(page).click();
     await expect(playOverlay(page)).toBeHidden({ timeout: 3_000 });
-    await expect(videoItem(page)).toHaveAttribute("aria-pressed", "true");
+    await expect(videoItem(page)).toHaveAttribute("aria-pressed", "false");
+    await expect(previousPhoto).toHaveAttribute("aria-pressed", "true");
 
     await page.waitForTimeout(200);
 
-    // Arrow keys should not change selection while video is playing
     await page.keyboard.press("ArrowRight");
 
-    await expect(videoItem(page)).toHaveAttribute("aria-pressed", "true");
+    await expect(videoItem(page)).toHaveAttribute("aria-pressed", "false");
+    await expect(previousPhoto).toHaveAttribute("aria-pressed", "true");
     await expect(page.locator('[aria-pressed="true"]')).toHaveCount(1);
   });
 });

--- a/frontend/src/components/album/MediaItem.vue
+++ b/frontend/src/components/album/MediaItem.vue
@@ -53,6 +53,11 @@ function handleClick() {
   photoFocus.focus(stepId!, props.media);
 }
 
+function handleEnter() {
+  if (isVideo.value) togglePlay();
+  else handleClick();
+}
+
 function handleSpace() {
   if (isVideo.value && (playing.value || isFocused.value)) togglePlay();
   else handleClick();
@@ -98,15 +103,22 @@ const imgSizes = computed(() => {
 });
 
 const playing = ref(false);
+const rootRef = ref<HTMLElement | null>(null);
 const videoRef = ref<HTMLVideoElement | null>(null);
 
 const frameMutation = useVideoFrameMutation();
+
+async function returnToFramePicker() {
+  playing.value = false;
+  await nextTick();
+  rootRef.value?.focus();
+}
 
 function togglePlay() {
   if (!videoRef.value) return;
   if (playing.value) {
     videoRef.value.pause();
-    playing.value = false;
+    void returnToFramePicker();
   } else {
     void videoRef.value.play();
     playing.value = true;
@@ -122,7 +134,7 @@ async function setFrame() {
   });
   posterCacheBust.value = Date.now();
   videoRef.value.pause();
-  playing.value = false;
+  await returnToFramePicker();
 }
 
 const FRAME_STEP = 1 / 30; // ~1 frame at 30fps
@@ -149,6 +161,7 @@ function onVideoKey(e: KeyboardEvent) {
 
 <template>
   <div
+    ref="rootRef"
     :class="['media-item', { focused: isFocused }]"
     class="relative-position overflow-hidden non-selectable"
     :data-media="media"
@@ -157,7 +170,7 @@ function onVideoKey(e: KeyboardEvent) {
     :aria-label="canFocus ? alt || t('album.selectPhoto') : undefined"
     :aria-pressed="canFocus ? isFocused : undefined"
     @click="handleClick"
-    @keydown.enter="handleClick"
+    @keydown.enter.prevent="handleEnter"
     @keydown.space.prevent="handleSpace"
   >
     <template v-if="isVideo && !printMode">
@@ -177,15 +190,16 @@ function onVideoKey(e: KeyboardEvent) {
         :src="src"
         class="fit video-playing"
         controls
+        playsinline
         preload="none"
-        @ended="playing = false"
+        @ended="returnToFramePicker"
         @keydown="onVideoKey"
       />
       <button
         v-if="!playing"
         class="play-overlay absolute-full cursor-pointer flex flex-center"
         :aria-label="t('album.playVideo')"
-        @click="togglePlay"
+        @click.stop="togglePlay"
       >
         <div class="play-icon flex flex-center">
           <q-icon :name="matPlayArrow" />

--- a/frontend/tests/components/MediaItem.test.ts
+++ b/frontend/tests/components/MediaItem.test.ts
@@ -1,0 +1,118 @@
+import { defineComponent, h, ref } from "vue";
+import { mountWithPlugins } from "../helpers";
+import MediaItem from "@/components/album/MediaItem.vue";
+import { provideAlbum } from "@/composables/useAlbum";
+import { STEP_ID_KEY, usePhotoFocus } from "@/composables/usePhotoFocus";
+
+const mutateAsync = vi.fn();
+let playSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock("@/queries/useVideoFrameMutation", () => ({
+  useVideoFrameMutation: () => ({ mutateAsync }),
+}));
+
+function mountVideoItem() {
+  const Wrapper = defineComponent({
+    setup() {
+      provideAlbum({
+        albumId: ref("album-1"),
+        colors: ref({}),
+        media: ref([
+          {
+            name: "clip.mp4",
+            width: 1920,
+            height: 1080,
+            type: "video/mp4",
+          },
+        ]),
+        tripStart: ref("2024-01-01"),
+        totalDays: ref(1),
+        upgradedMedia: ref(new Set<string>()),
+      });
+      return () => h(MediaItem, { media: "clip.mp4", alt: "Clip" });
+    },
+  });
+
+  return mountWithPlugins(Wrapper, {
+    global: {
+      provide: {
+        [STEP_ID_KEY as symbol]: 7,
+      },
+    },
+    attachTo: document.body,
+  });
+}
+
+describe("MediaItem video controls", () => {
+  beforeEach(() => {
+    mutateAsync.mockResolvedValue(undefined);
+    playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    usePhotoFocus().blur();
+    vi.restoreAllMocks();
+  });
+
+  test("renders inline mobile video playback", () => {
+    const wrapper = mountVideoItem();
+
+    expect(wrapper.get("video").attributes("playsinline")).toBeDefined();
+  });
+
+  test("clicking play overlay starts playback without selecting the media item", async () => {
+    const focus = vi.spyOn(usePhotoFocus(), "focus");
+    const wrapper = mountVideoItem();
+
+    await wrapper.get(".play-overlay").trigger("click");
+
+    expect(playSpy).toHaveBeenCalled();
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  test("Enter opens the inline player and focuses the video", async () => {
+    const wrapper = mountVideoItem();
+    const video = wrapper.get("video").element as HTMLVideoElement;
+
+    await wrapper.get(".media-item").trigger("keydown", { key: "Enter" });
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(playSpy).toHaveBeenCalled();
+    expect(document.activeElement).toBe(video);
+  });
+
+  test("moves focus back to the media item when playback ends", async () => {
+    const wrapper = mountVideoItem();
+    const root = wrapper.get(".media-item").element as HTMLElement;
+    const video = wrapper.get("video").element as HTMLVideoElement;
+
+    await wrapper.get(".play-overlay").trigger("click");
+    video.focus();
+    expect(document.activeElement).toBe(video);
+
+    await wrapper.get("video").trigger("ended");
+
+    expect(document.activeElement).toBe(root);
+  });
+
+  test("moves focus back to the media item after choosing a poster frame", async () => {
+    const wrapper = mountVideoItem();
+    const root = wrapper.get(".media-item").element as HTMLElement;
+    const video = wrapper.get("video").element as HTMLVideoElement;
+
+    await wrapper.get(".play-overlay").trigger("click");
+    video.focus();
+    expect(document.activeElement).toBe(video);
+
+    await wrapper.get(".set-frame-btn").trigger("click");
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      name: "clip.mp4",
+      timestamp: 0,
+    });
+    expect(document.activeElement).toBe(root);
+  });
+});


### PR DESCRIPTION
- Keep video playback inline on mobile and prevent play-overlay clicks from selecting the media cell.
- Restore focus to the media item when playback exits.
- Add component and E2E coverage for video keyboard/playback behavior.