### PR TITLE
fix(frontend): sync photo focus navigation

### DIFF
--- a/frontend/e2e/photo-focus.test.ts
+++ b/frontend/e2e/photo-focus.test.ts
@@ -84,6 +84,28 @@ test.describe("Photo focus & arrow navigation", () => {
     await expect(selected(page)).toHaveCount(1);
   });
 
+  test("ArrowRight moves DOM focus to the selected photo", async ({
+    focusPage: page,
+  }) => {
+    await scrollToStep(page, "Argentina", "Buenos Aires");
+    const first = photos(page).first();
+    await first.click();
+    await expect(first).toHaveAttribute("aria-pressed", "true");
+
+    await page.keyboard.press("ArrowRight");
+    await expect(selected(page)).toHaveCount(1);
+
+    await expect
+      .poll(async () =>
+        selected(page).evaluate(
+          (el) =>
+            document.activeElement?.getAttribute("data-media") ===
+            el.getAttribute("data-media"),
+        ),
+      )
+      .toBe(true);
+  });
+
   test("ArrowLeft moves selection to previous photo", async ({
     focusPage: page,
   }) => {
@@ -171,9 +193,7 @@ test.describe("Photo focus & arrow navigation", () => {
     expect(unique.size).toBe(indices.length);
   });
 
-  test("forward then backward is a round trip", async ({
-    focusPage: page,
-  }) => {
+  test("forward then backward is a round trip", async ({ focusPage: page }) => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     await photos(page).first().click();
 
@@ -229,7 +249,9 @@ test.describe("Send to unused & set as cover", () => {
     await openEditor(page);
   });
 
-  test("sendToUnused removes photo and advances focus", async ({ focusPage: page }) => {
+  test("sendToUnused removes photo and advances focus", async ({
+    focusPage: page,
+  }) => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     await photos(page).first().click();
     await expect(selected(page)).toHaveCount(1);
@@ -286,7 +308,9 @@ test.describe("Send to unused & set as cover", () => {
     await expect(selected(page)).toHaveCount(0, { timeout: 3_000 });
   });
 
-  test("setAsCover advances focus to next photo", async ({ focusPage: page }) => {
+  test("setAsCover advances focus to next photo", async ({
+    focusPage: page,
+  }) => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     const first = photos(page).first();
     await first.click();
@@ -297,5 +321,19 @@ test.describe("Send to unused & set as cover", () => {
     // Focus should advance - the photo became cover, so it's no longer navigable.
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
     await expect(first).not.toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("empty unused tray keeps a usable drop target", async ({
+    focusPage: page,
+  }) => {
+    await scrollToStep(page, "Argentina", "Buenos Aires");
+    const track = page.locator(".unused-drawer .drawer-track");
+
+    await expect
+      .poll(async () => {
+        const box = await track.boundingBox();
+        return box?.height ?? 0;
+      })
+      .toBeGreaterThan(40);
   });
 });

--- a/frontend/e2e/undo-redo.test.ts
+++ b/frontend/e2e/undo-redo.test.ts
@@ -49,6 +49,24 @@ test.describe("Undo & redo", () => {
     await expect(unusedBadge(page)).toHaveText("0", { timeout: 3_000 });
   });
 
+  test("Ctrl+Z after sendToUnused restores focus to the moved photo", async ({
+    focusPage: page,
+  }) => {
+    const photo = photos(page).first();
+    await photo.click();
+    const originalMedia = await photo.getAttribute("data-media");
+
+    await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
+    await expect(unusedBadge(page)).toHaveText("1", { timeout: 3_000 });
+
+    await page.keyboard.press("Control+z");
+    await expect(unusedBadge(page)).toHaveText("0", { timeout: 3_000 });
+
+    await expect(
+      page.locator(`[data-media="${originalMedia}"]`),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
   test("Ctrl+Shift+Z re-applies the undone action", async ({
     focusPage: page,
   }) => {

--- a/frontend/src/components/AlbumViewer.vue
+++ b/frontend/src/components/AlbumViewer.vue
@@ -276,7 +276,7 @@ if (props.printMode) {
   const photoFocus = usePhotoFocus();
   photoFocus.init({
     steps: () => visibleSteps.value,
-    mutate: (sid, update) => stepMut.mutate({ sid, update }),
+    mutate: (sid, update, focus) => stepMut.mutate({ sid, update, focus }),
     scrollToStep: (id) => scrollToStep(id, "smooth"),
   });
   onUnmounted(() => photoFocus.dispose());

--- a/frontend/src/components/editor/UnusedDrawer.vue
+++ b/frontend/src/components/editor/UnusedDrawer.vue
@@ -43,6 +43,7 @@ const trackRef = ref<HTMLElement | null>(null);
 useDraggable(trackRef, localUnused, {
   group: "photos",
   animation: 200,
+  draggable: ".media-item",
   onUpdate() {
     save();
   },
@@ -64,9 +65,9 @@ useDraggable(trackRef, localUnused, {
     </div>
     <div ref="trackRef" class="drawer-track column no-wrap">
       <MediaItem v-for="photo in localUnused" :key="photo" :media="photo" />
-    </div>
-    <div v-if="localUnused.length === 0" class="drawer-empty">
-      {{ t("album.dropPhotosHere") }}
+      <div v-if="localUnused.length === 0" class="drawer-empty">
+        {{ t("album.dropPhotosHere") }}
+      </div>
     </div>
   </div>
 </template>
@@ -87,6 +88,8 @@ useDraggable(trackRef, localUnused, {
 }
 
 .drawer-empty {
+  grid-column: 1 / -1;
+  min-height: 8rem;
   flex: 1;
   display: flex;
   align-items: center;
@@ -100,11 +103,6 @@ useDraggable(trackRef, localUnused, {
   transition:
     border-color var(--duration-fast),
     color var(--duration-fast);
-}
-
-// When empty, collapse the track so the empty state fills the drawer
-.unused-drawer:has(.drawer-empty) .drawer-track {
-  flex: none;
 }
 
 // Highlight empty state when dragging over

--- a/frontend/src/composables/usePhotoFocus.ts
+++ b/frontend/src/composables/usePhotoFocus.ts
@@ -4,12 +4,22 @@ import { coverUpdatePayload, unusedUpdatePayload } from "./useStepLayout";
 
 export const STEP_ID_KEY: InjectionKey<number> = Symbol("step-id");
 
+export interface PhotoFocusSnapshot {
+  stepId: number | null;
+  photoId: string | null;
+}
+
 const focusedStepId = ref<number | null>(null);
 const focusedPhotoId = ref<string | null>(null);
 
 let getSteps: () => Step[] = () => [];
-let mutateFn: ((sid: number, update: Partial<StepUpdate>) => void) | null =
-  null;
+let mutateFn:
+  | ((
+      sid: number,
+      update: Partial<StepUpdate>,
+      focus?: { before: PhotoFocusSnapshot; after: PhotoFocusSnapshot },
+    ) => void)
+  | null = null;
 let scrollToStepFn: ((stepId: number) => void) | null = null;
 let scrollRafId = 0;
 let awaitingStepTransition = false;
@@ -38,7 +48,11 @@ function advanceFocus(photos: string[], removedIdx: number) {
 
 function init(config: {
   steps: () => Step[];
-  mutate: (sid: number, update: Partial<StepUpdate>) => void;
+  mutate: (
+    sid: number,
+    update: Partial<StepUpdate>,
+    focus?: { before: PhotoFocusSnapshot; after: PhotoFocusSnapshot },
+  ) => void;
   scrollToStep: (stepId: number) => void;
 }) {
   getSteps = config.steps;
@@ -78,6 +92,7 @@ function scrollFocusedIntoView() {
       scrollRafId = 0;
       awaitingStepTransition = false;
       el.scrollIntoView({ block: "center", behavior: "smooth" });
+      el.focus({ preventScroll: true });
       return;
     }
     if (++attempts < 60) {
@@ -93,6 +108,16 @@ function scrollFocusedIntoView() {
 function focus(stepId: number, photoId: string) {
   focusedStepId.value = stepId;
   focusedPhotoId.value = photoId;
+}
+
+function snapshot(): PhotoFocusSnapshot {
+  return { stepId: focusedStepId.value, photoId: focusedPhotoId.value };
+}
+
+function restore(snapshot: PhotoFocusSnapshot) {
+  focusedStepId.value = snapshot.stepId;
+  focusedPhotoId.value = snapshot.photoId;
+  scrollFocusedIntoView();
 }
 
 function blur() {
@@ -172,9 +197,13 @@ function sendToUnused(): boolean {
   const photoId = focusedPhotoId.value;
   if (!step || !photoId) return false;
 
+  const focusBefore = snapshot();
   const photos = pagedPhotos(step);
   advanceFocus(photos, photos.indexOf(photoId));
-  mutateFn?.(step.id, unusedUpdatePayload(step, [...step.unused, photoId]));
+  mutateFn?.(step.id, unusedUpdatePayload(step, [...step.unused, photoId]), {
+    before: focusBefore,
+    after: snapshot(),
+  });
   return true;
 }
 
@@ -184,9 +213,13 @@ function setAsCover(): boolean {
   const photoId = focusedPhotoId.value;
   if (!step || !photoId) return false;
 
+  const focusBefore = snapshot();
   const photos = pagedPhotos(step);
   advanceFocus(photos, photos.indexOf(photoId));
-  mutateFn?.(step.id, coverUpdatePayload(step, photoId));
+  mutateFn?.(step.id, coverUpdatePayload(step, photoId), {
+    before: focusBefore,
+    after: snapshot(),
+  });
   return true;
 }
 
@@ -196,6 +229,7 @@ const api = {
   init,
   dispose,
   focus,
+  restore,
   blur,
   move,
   sendToUnused,

--- a/frontend/src/composables/useUndoStack.ts
+++ b/frontend/src/composables/useUndoStack.ts
@@ -1,8 +1,16 @@
 import type { AlbumUpdate, StepUpdate } from "@/client";
+import type { PhotoFocusSnapshot } from "@/composables/usePhotoFocus";
+import { usePhotoFocus } from "@/composables/usePhotoFocus";
 import { ref } from "vue";
 
 type UndoEntry =
-  | { type: "step"; sid: number; before: StepUpdate; after: StepUpdate }
+  | {
+      type: "step";
+      sid: number;
+      before: StepUpdate;
+      after: StepUpdate;
+      focus?: { before: PhotoFocusSnapshot; after: PhotoFocusSnapshot };
+    }
   | { type: "album"; before: AlbumUpdate; after: AlbumUpdate };
 
 export function pickSnapshot<T extends object>(
@@ -31,11 +39,16 @@ function syncFlags() {
 let stepMutator: ((sid: number, update: StepUpdate) => void) | null = null;
 let albumMutator: ((update: AlbumUpdate) => void) | null = null;
 
-function replay(entry: UndoEntry, snapshot: StepUpdate | AlbumUpdate) {
+function replay(
+  entry: UndoEntry,
+  snapshot: StepUpdate | AlbumUpdate,
+  focus?: PhotoFocusSnapshot,
+) {
   replaying = true;
   try {
     if (entry.type === "step") {
       stepMutator?.(entry.sid, snapshot as StepUpdate);
+      if (focus) usePhotoFocus().restore(focus);
     } else {
       albumMutator?.(snapshot as AlbumUpdate);
     }
@@ -57,7 +70,11 @@ function undo() {
   if (!entry) return;
   redoEntries.push(entry);
   syncFlags();
-  replay(entry, entry.before);
+  replay(
+    entry,
+    entry.before,
+    entry.type === "step" ? entry.focus?.before : undefined,
+  );
 }
 
 function redo() {
@@ -66,7 +83,11 @@ function redo() {
   if (undoEntries.length >= MAX_STACK) undoEntries.shift();
   undoEntries.push(entry);
   syncFlags();
-  replay(entry, entry.after);
+  replay(
+    entry,
+    entry.after,
+    entry.type === "step" ? entry.focus?.after : undefined,
+  );
 }
 
 function clear() {

--- a/frontend/src/queries/useStepMutation.ts
+++ b/frontend/src/queries/useStepMutation.ts
@@ -2,16 +2,23 @@ import { useMutation, useQueryCache } from "@pinia/colada";
 import { updateStep } from "@/client";
 import type { Step, StepUpdate } from "@/client";
 import { useUndoStack, pickSnapshot } from "@/composables/useUndoStack";
+import type { PhotoFocusSnapshot } from "@/composables/usePhotoFocus";
 import { Notify } from "quasar";
 import { t } from "@/i18n";
 import { queryKeys } from "./keys";
+
+interface StepMutationPayload {
+  sid: number;
+  update: StepUpdate;
+  focus?: { before: PhotoFocusSnapshot; after: PhotoFocusSnapshot };
+}
 
 export function useStepMutation(aid: () => string) {
   const cache = useQueryCache();
   const undoStack = useUndoStack();
 
   return useMutation({
-    mutation: async (payload: { sid: number; update: StepUpdate }) => {
+    mutation: async (payload: StepMutationPayload) => {
       const { data } = await updateStep({
         path: { aid: aid(), sid: payload.sid },
         body: payload.update,
@@ -41,6 +48,7 @@ export function useStepMutation(aid: () => string) {
               Object.keys(payload.update) as (keyof StepUpdate)[],
             ),
             after: { ...payload.update },
+            focus: payload.focus,
           });
         }
       }


### PR DESCRIPTION
- Move DOM focus with arrow-key photo selection.
- Preserve and restore photo focus through undo/redo of step mutations.
- Keep the empty unused tray as a usable drop target without making its placeholder draggable.