### PR TITLE
fix(backend): validate frontend oauth redirect urls

### DIFF
--- a/backend/app/api/v1/routes/google_photos.py
+++ b/backend/app/api/v1/routes/google_photos.py
@@ -275,7 +275,8 @@ async def authorize(
 def _redirect_to_popup_bridge(
     nonce: str | None, *, error: bool = False
 ) -> RedirectResponse:
-    url = f"{get_settings().VITE_FRONTEND_URL}/oauth-connected.html"
+    frontend_url = str(get_settings().VITE_FRONTEND_URL).rstrip("/")
+    url = f"{frontend_url}/oauth-connected.html"
     params = []
     if error:
         params.append("error")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
+    AnyHttpUrl,
     AnyUrl,
     BeforeValidator,
     Field,
@@ -48,8 +49,8 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     SECRET_KEY: str
     SECRET_KEY_PREVIOUS: str | None = None
-    VITE_FRONTEND_URL: str = "http://localhost:5173"
-    FRONTEND_URL: str = ""
+    VITE_FRONTEND_URL: AnyHttpUrl = AnyHttpUrl("http://localhost:5173")
+    FRONTEND_URL: AnyHttpUrl | None = None
     ENVIRONMENT: Literal["local", "production"] = "local"
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
@@ -69,7 +70,7 @@ class Settings(BaseSettings):
     @property
     def all_cors_origins(self) -> list[str]:
         return [str(origin).rstrip("/") for origin in self.BACKEND_CORS_ORIGINS] + [
-            self.VITE_FRONTEND_URL
+            str(self.VITE_FRONTEND_URL).rstrip("/")
         ]
 
     SQLALCHEMY_DATABASE_URI: Annotated[
@@ -83,7 +84,7 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _default_frontend_url(self) -> Self:
-        if not self.FRONTEND_URL:
+        if self.FRONTEND_URL is None:
             self.FRONTEND_URL = self.VITE_FRONTEND_URL
         return self
 
@@ -102,7 +103,7 @@ class Settings(BaseSettings):
         missing: list[str] = []
         if not self.VITE_MAPBOX_TOKEN:
             missing.append("VITE_MAPBOX_TOKEN")
-        if "localhost" in self.VITE_FRONTEND_URL:
+        if "localhost" in str(self.VITE_FRONTEND_URL):
             missing.append("VITE_FRONTEND_URL")
         if not self.VITE_GOOGLE_CLIENT_ID and not self.VITE_MICROSOFT_CLIENT_ID:
             missing.append("VITE_GOOGLE_CLIENT_ID or VITE_MICROSOFT_CLIENT_ID")

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -170,6 +170,7 @@ async def _render_pdf(  # noqa: C901
     dark: bool,
 ) -> AsyncGenerator[PdfProgress]:
     settings = get_settings()
+    frontend_url = str(settings.FRONTEND_URL or settings.VITE_FRONTEND_URL).rstrip("/")
     yield PdfProgress(phase="loading", done=0)
 
     context = await browser.new_context(
@@ -183,7 +184,7 @@ async def _render_pdf(  # noqa: C901
                 {
                     "name": "session",
                     "value": session_cookie,
-                    "url": settings.FRONTEND_URL,
+                    "url": frontend_url,
                 },
             ]
         )
@@ -208,7 +209,7 @@ async def _render_pdf(  # noqa: C901
         page.on("requestfailed", _on_finished)
         await page.emulate_media(media="print")
         dark_param = "true" if dark else "false"
-        url = f"{settings.FRONTEND_URL}/print/{aid}?dark={dark_param}"
+        url = f"{frontend_url}/print/{aid}?dark={dark_param}"
         await page.goto(url, wait_until="domcontentloaded")
         logger.info("DOM loaded for album %s", aid)
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
- Validate frontend URLs with Pydantic AnyHttpUrl so missing schemes fail at settings load.
- Normalize typed URL values at path-concatenation call sites for OAuth popup bridge and PDF rendering.
- Fix the local OAuth popup hang caused by a scheme-less VITE_FRONTEND_URL.