### PR TITLE
fix: mitigate media fetch bursts

### DIFF
--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -1,5 +1,11 @@
 # http-level directives (this file is included inside http {} by the nginx image)
 limit_req_zone $binary_remote_addr zone=general:1m rate=10r/s;
+map $request_method $media_read_limit_key {
+  default "";
+  GET $binary_remote_addr;
+  HEAD $binary_remote_addr;
+}
+limit_req_zone $media_read_limit_key zone=media_reads:1m rate=60r/s;
 limit_req_zone $binary_remote_addr zone=uploads:1m rate=1r/m;
 limit_req_zone $binary_remote_addr zone=demo:1m rate=2r/m;
 server_tokens off;
@@ -66,6 +72,12 @@ server {
   # Demo endpoint - prevent mass account creation
   location = /api/v1/users/demo {
     limit_req zone=demo burst=2 nodelay;
+    include /etc/nginx/proxy-params.conf;
+  }
+
+  # Album media files - per-photo fan-out can spike on editor cold load
+  location ~ ^/api/v1/albums/[^/]+/media/[^/]+$ {
+    limit_req zone=media_reads burst=120 nodelay;
     include /etc/nginx/proxy-params.conf;
   }
 

--- a/frontend/src/components/AlbumViewer.vue
+++ b/frontend/src/components/AlbumViewer.vue
@@ -26,6 +26,7 @@ import {
 } from "./album/albumSections";
 import { useActiveSection, pickBestItem } from "@/composables/useActiveSection";
 import { useWindowVirtualizer } from "@/composables/useWindowVirtualizer";
+import { PROGRAMMATIC_SCROLL_KEY } from "@/composables/useProgrammaticScroll";
 import {
   computed,
   defineAsyncComponent,
@@ -34,6 +35,8 @@ import {
   nextTick,
   onMounted,
   onUnmounted,
+  provide,
+  readonly,
   ref,
   watch,
   watchEffect,
@@ -232,7 +235,39 @@ if (props.printMode) {
     setScrollOverride,
     setActive,
     scrollBehavior: getScrollBehavior,
+    programmaticScrolling,
   } = useActiveSection();
+
+  // Suppress photo fetches in steps the smooth scroll passes through.
+  // MediaItem injects this and skips src/srcset while it's true.
+  provide(PROGRAMMATIC_SCROLL_KEY, readonly(programmaticScrolling));
+
+  let scrollClearTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearProgrammaticScroll() {
+    programmaticScrolling.value = false;
+    if (scrollClearTimer) {
+      clearTimeout(scrollClearTimer);
+      scrollClearTimer = null;
+    }
+    window.removeEventListener("wheel", clearProgrammaticScroll, true);
+    window.removeEventListener("touchstart", clearProgrammaticScroll, true);
+    window.removeEventListener("keydown", onCancelKey, true);
+  }
+
+  function onCancelKey(e: KeyboardEvent) {
+    if (
+      e.key === "PageUp" ||
+      e.key === "PageDown" ||
+      e.key === "Home" ||
+      e.key === "End" ||
+      e.key === "ArrowUp" ||
+      e.key === "ArrowDown" ||
+      e.key === " "
+    ) {
+      clearProgrammaticScroll();
+    }
+  }
 
   const stepIdToVIdx = computed(() => {
     const hc = headerCount.value;
@@ -251,11 +286,23 @@ if (props.printMode) {
   });
 
   function scrollToVIdx(idx: number, behavior?: ScrollBehavior) {
-    virtualizer.scrollToIndex(idx, {
-      align: "start",
-      behavior:
-        behavior ?? (getScrollBehavior() === "smooth" ? "smooth" : "auto"),
-    });
+    const b =
+      behavior ?? (getScrollBehavior() === "smooth" ? "smooth" : "auto");
+    if (b === "smooth") {
+      programmaticScrolling.value = true;
+      window.addEventListener("wheel", clearProgrammaticScroll, {
+        capture: true,
+        once: true,
+      });
+      window.addEventListener("touchstart", clearProgrammaticScroll, {
+        capture: true,
+        once: true,
+      });
+      window.addEventListener("keydown", onCancelKey, { capture: true });
+      if (scrollClearTimer) clearTimeout(scrollClearTimer);
+      scrollClearTimer = setTimeout(clearProgrammaticScroll, 1500);
+    }
+    virtualizer.scrollToIndex(idx, { align: "start", behavior: b });
   }
 
   function scrollToStep(id: number, behavior?: ScrollBehavior) {
@@ -313,6 +360,7 @@ if (props.printMode) {
   });
   onUnmounted(() => {
     setScrollOverride(null);
+    clearProgrammaticScroll();
   });
 }
 </script>

--- a/frontend/src/components/album/MediaItem.vue
+++ b/frontend/src/components/album/MediaItem.vue
@@ -3,7 +3,9 @@ import type { PhotoQuality } from "@/utils/photoQuality";
 import { useAlbum } from "@/composables/useAlbum";
 import { usePhotoFocus, STEP_ID_KEY } from "@/composables/usePhotoFocus";
 import { usePrintMode } from "@/composables/usePrintReady";
+import { PROGRAMMATIC_SCROLL_KEY } from "@/composables/useProgrammaticScroll";
 import { useVideoFrameMutation } from "@/queries/useVideoFrameMutation";
+import { useElementVisibility } from "@vueuse/core";
 import {
   isVideo as checkVideo,
   mediaUrl,
@@ -12,7 +14,7 @@ import {
   SIZES_HALF,
   THUMB_WIDTHS,
 } from "@/utils/media";
-import { computed, inject, nextTick, ref } from "vue";
+import { computed, inject, nextTick, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   matPlayArrow,
@@ -32,12 +34,29 @@ const props = withDefaults(
     focusable?: boolean;
     alt?: string;
     quality?: PhotoQuality | null;
+    lazyRoot?: HTMLElement | null;
   }>(),
   { focusable: true, alt: "" },
 );
 
 const { albumId, mediaByName } = useAlbum();
 const printMode = usePrintMode();
+
+const programmaticScroll = inject(PROGRAMMATIC_SCROLL_KEY, ref(false));
+const rootRef = ref<HTMLElement | null>(null);
+const visible = useElementVisibility(rootRef, {
+  scrollTarget: computed(() => props.lazyRoot ?? null),
+  rootMargin: "300px",
+  once: true,
+  initialValue:
+    typeof window !== "undefined" && !("IntersectionObserver" in window),
+});
+const loadImg = ref(printMode || !("IntersectionObserver" in window));
+watchEffect(() => {
+  if (printMode || (visible.value && !programmaticScroll.value)) {
+    loadImg.value = true;
+  }
+});
 
 const stepId = inject(STEP_ID_KEY, null);
 const photoFocus = usePhotoFocus();
@@ -103,7 +122,6 @@ const imgSizes = computed(() => {
 });
 
 const playing = ref(false);
-const rootRef = ref<HTMLElement | null>(null);
 const videoRef = ref<HTMLVideoElement | null>(null);
 
 const frameMutation = useVideoFrameMutation();
@@ -176,12 +194,12 @@ function onVideoKey(e: KeyboardEvent) {
     <template v-if="isVideo && !printMode">
       <img
         v-show="!playing"
-        :src="posterSrc"
-        :srcset="imgSrcset"
+        :src="loadImg ? posterSrc : undefined"
+        :srcset="loadImg ? imgSrcset : undefined"
         :sizes="imgSizes"
         :alt="alt"
         :class="['fit', fitCover ? 'fit-cover' : 'fit-contain']"
-        loading="eager"
+        :loading="printMode ? 'eager' : 'lazy'"
         decoding="async"
       />
       <video
@@ -231,11 +249,11 @@ function onVideoKey(e: KeyboardEvent) {
     </template>
     <template v-else>
       <img
-        :src="isVideo ? posterSrc : src"
-        :srcset="imgSrcset"
+        :src="loadImg ? (isVideo ? posterSrc : src) : undefined"
+        :srcset="loadImg ? imgSrcset : undefined"
         :sizes="imgSizes"
         :alt="alt"
-        loading="eager"
+        :loading="printMode ? 'eager' : 'lazy'"
         :class="['fit', fitCover ? 'fit-cover' : 'fit-contain']"
         decoding="async"
       />

--- a/frontend/src/components/album/map/mapSegments.ts
+++ b/frontend/src/components/album/map/mapSegments.ts
@@ -12,6 +12,22 @@ const FLIGHT_ICON_CLASS = "map-flight-icon";
 const FAINT_OPACITY = 0.9;
 const FAINT_COLOR = "rgba(255, 255, 255, 0.8)";
 
+function setLazyBackground(el: HTMLElement, url: string) {
+  if (!("IntersectionObserver" in window)) {
+    el.style.backgroundImage = `url(${url})`;
+    return;
+  }
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (!entry?.isIntersecting) return;
+      el.style.backgroundImage = `url(${url})`;
+      observer.disconnect();
+    },
+    { rootMargin: "300px" },
+  );
+  observer.observe(el);
+}
+
 function cleanup(m: mapboxgl.Map) {
   for (const layer of m.getStyle()?.layers ?? []) {
     if (layer.id.startsWith(LAYER_PREFIX)) removeMapLayer(m, layer.id);
@@ -345,7 +361,7 @@ export function drawSegmentsAndMarkers(
     el.setAttribute("role", "img");
     el.setAttribute("aria-label", step.name);
     if (step.cover) {
-      el.style.backgroundImage = `url(${mediaThumbUrl(step.cover, albumId)})`;
+      setLazyBackground(el, mediaThumbUrl(step.cover, albumId));
     }
     new mapboxgl.Marker({ element: el }).setLngLat(lngLat).addTo(m);
   }

--- a/frontend/src/components/editor/AlbumNav.vue
+++ b/frontend/src/components/editor/AlbumNav.vue
@@ -388,6 +388,7 @@ watch(activeSectionKey, (key) => {
         :steps="steps"
         :colors="albumColors"
         :format-map-range="formatMapRange"
+        :lazy-root="listRef ?? null"
         @toggle-open="
           openGroupKey = openGroupKey === group.key ? null : group.key
         "

--- a/frontend/src/components/editor/CoverCell.vue
+++ b/frontend/src/components/editor/CoverCell.vue
@@ -1,0 +1,38 @@
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import { useElementVisibility } from "@vueuse/core";
+
+const props = defineProps<{
+  src: string;
+  selected: boolean;
+  label: string;
+  lazyRoot?: HTMLElement | null;
+}>();
+
+defineEmits<{ select: [] }>();
+
+const root = ref<HTMLElement | null>(null);
+const visible = useElementVisibility(root, {
+  scrollTarget: computed(() => props.lazyRoot ?? null),
+  rootMargin: "300px",
+  once: true,
+  initialValue:
+    typeof window !== "undefined" && !("IntersectionObserver" in window),
+});
+</script>
+
+<template>
+  <img
+    ref="root"
+    :src="visible ? src : undefined"
+    class="cover-cell"
+    :class="{ selected }"
+    :aria-label="label"
+    role="button"
+    tabindex="0"
+    alt=""
+    @click="$emit('select')"
+    @keydown.enter="$emit('select')"
+    @keydown.space.prevent="$emit('select')"
+  />
+</template>

--- a/frontend/src/components/editor/InspectorDrawer.vue
+++ b/frontend/src/components/editor/InspectorDrawer.vue
@@ -1,12 +1,13 @@
 <script lang="ts" setup>
 import type { Album, Step, Media } from "@/client";
 import AlbumProperties from "./AlbumProperties.vue";
+import CoverCell from "./CoverCell.vue";
 import UnusedDrawer from "./UnusedDrawer.vue";
 import { useAlbumMutation } from "@/queries/useAlbumMutation";
 import { provideAlbum } from "@/composables/useAlbum";
 import { mediaThumbUrl, isVideo, isPortrait } from "@/utils/media";
 import { useI18n } from "vue-i18n";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { matImage } from "@quasar/extras/material-icons";
 
 const { t } = useI18n();
@@ -58,6 +59,8 @@ const landscapePhotos = computed(() =>
     .map((m) => m.name),
 );
 
+const coverGridRef = ref<HTMLElement | null>(null);
+
 function selectCoverPhoto(name: string) {
   albumMutation.mutate({ [coverField.value]: name });
 }
@@ -90,26 +93,20 @@ const panelLabel = computed(() =>
         <q-icon :name="panelIcon" size="var(--type-md)" />
         <span>{{ panelLabel }}</span>
       </div>
-      <div v-if="landscapePhotos.length" class="cover-grid">
-        <img
+      <div v-if="landscapePhotos.length" ref="coverGridRef" class="cover-grid">
+        <CoverCell
           v-for="(photo, index) in landscapePhotos"
           :key="photo"
           :src="mediaThumbUrl(photo, album.id)"
-          class="cover-cell"
-          :class="{ selected: photo === activeCoverPhoto }"
-          :aria-label="
+          :selected="photo === activeCoverPhoto"
+          :lazy-root="coverGridRef"
+          :label="
             t('album.selectCoverPhoto', {
               index: index + 1,
               total: landscapePhotos.length,
             })
           "
-          role="button"
-          tabindex="0"
-          loading="lazy"
-          alt=""
-          @click="selectCoverPhoto(photo)"
-          @keydown.enter="selectCoverPhoto(photo)"
-          @keydown.space.prevent="selectCoverPhoto(photo)"
+          @select="selectCoverPhoto(photo)"
         />
       </div>
       <div v-else class="panel-hint">{{ t("album.noLandscapePhotos") }}</div>

--- a/frontend/src/components/editor/UnusedDrawer.vue
+++ b/frontend/src/components/editor/UnusedDrawer.vue
@@ -64,7 +64,12 @@ useDraggable(trackRef, localUnused, {
       <q-tooltip>{{ t("album.unusedHint") }}</q-tooltip>
     </div>
     <div ref="trackRef" class="drawer-track column no-wrap">
-      <MediaItem v-for="photo in localUnused" :key="photo" :media="photo" />
+      <MediaItem
+        v-for="photo in localUnused"
+        :key="photo"
+        :media="photo"
+        :lazy-root="trackRef"
+      />
       <div v-if="localUnused.length === 0" class="drawer-empty">
         {{ t("album.dropPhotosHere") }}
       </div>

--- a/frontend/src/components/editor/nav/NavCountryGroup.vue
+++ b/frontend/src/components/editor/nav/NavCountryGroup.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
   steps: Step[];
   colors: Record<string, string>;
   formatMapRange: (dr: DateRange) => string;
+  lazyRoot?: HTMLElement | null;
 }>();
 
 const emit = defineEmits<{
@@ -114,6 +115,7 @@ const allHidden = computed(() =>
         :color="entry.item.color"
         :active="activeStepId === entry.item.id"
         :hidden="hiddenSet.has(entry.item.id)"
+        :lazy-root="lazyRoot"
         @click="emit('scrollToStep', entry.item.id)"
         @toggle="emit('toggleStep', entry.item.id)"
       />

--- a/frontend/src/components/editor/nav/NavStepItem.vue
+++ b/frontend/src/components/editor/nav/NavStepItem.vue
@@ -1,25 +1,45 @@
 <script lang="ts" setup>
+import { computed, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   symOutlinedVisibility,
   symOutlinedVisibilityOff,
 } from "@quasar/extras/material-symbols-outlined";
+import { useActiveSection } from "@/composables/useActiveSection";
+import { useElementVisibility } from "@vueuse/core";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   name: string;
   date: string;
   thumb: string | null;
   color: string;
   active: boolean;
   hidden: boolean;
+  lazyRoot?: HTMLElement | null;
 }>();
 
 defineEmits<{
   click: [];
   toggle: [];
 }>();
+
+const thumbRef = ref<HTMLElement | null>(null);
+const thumbVisible = useElementVisibility(thumbRef, {
+  scrollTarget: computed(() => props.lazyRoot ?? null),
+  rootMargin: "0px",
+  once: true,
+  initialValue:
+    typeof window !== "undefined" && !("IntersectionObserver" in window),
+});
+const { programmaticScrolling } = useActiveSection();
+const loadThumb = ref(false);
+watchEffect(() => {
+  if (thumbVisible.value && !programmaticScrolling.value) {
+    loadThumb.value = true;
+  }
+});
 </script>
 
 <template>
@@ -31,10 +51,10 @@ defineEmits<{
     @click="$emit('click')"
     @keydown.enter="$emit('click')"
   >
-    <div class="item-thumb">
+    <div ref="thumbRef" class="item-thumb">
       <img
         v-if="thumb"
-        :src="thumb"
+        :src="loadThumb ? thumb : undefined"
         alt=""
         width="36"
         height="28"

--- a/frontend/src/composables/useActiveSection.ts
+++ b/frontend/src/composables/useActiveSection.ts
@@ -28,6 +28,7 @@ export function pickBestItem<T extends VirtualItem>(
 
 const activeStepId = ref<number | null>(null);
 const activeSectionKey = ref<string | null>(null);
+const programmaticScrolling = ref(false);
 
 const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
@@ -72,6 +73,7 @@ function setScrollOverride(override: typeof scrollOverride) {
 function resetActiveSection() {
   activeStepId.value = null;
   activeSectionKey.value = null;
+  programmaticScrolling.value = false;
   scrollOverride = null;
 }
 
@@ -79,6 +81,7 @@ export function useActiveSection() {
   return {
     activeStepId,
     activeSectionKey,
+    programmaticScrolling,
     setActive,
     scrollTo,
     scrollToSection,

--- a/frontend/src/composables/useProgrammaticScroll.ts
+++ b/frontend/src/composables/useProgrammaticScroll.ts
@@ -1,0 +1,5 @@
+import type { InjectionKey, Ref } from "vue";
+
+export const PROGRAMMATIC_SCROLL_KEY: InjectionKey<Ref<boolean>> = Symbol(
+  "programmatic-scroll",
+);

--- a/frontend/tests/components/MediaItem.test.ts
+++ b/frontend/tests/components/MediaItem.test.ts
@@ -1,11 +1,32 @@
-import { defineComponent, h, ref } from "vue";
+import { defineComponent, h, nextTick, ref, readonly } from "vue";
 import { mountWithPlugins } from "../helpers";
 import MediaItem from "@/components/album/MediaItem.vue";
 import { provideAlbum } from "@/composables/useAlbum";
 import { STEP_ID_KEY, usePhotoFocus } from "@/composables/usePhotoFocus";
+import { PROGRAMMATIC_SCROLL_KEY } from "@/composables/useProgrammaticScroll";
 
 const mutateAsync = vi.fn();
 let playSpy: ReturnType<typeof vi.spyOn>;
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly callback: IntersectionObserverCallback;
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  trigger(isIntersecting: boolean) {
+    this.callback(
+      [{ isIntersecting, time: performance.now() } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
 
 vi.mock("@/queries/useVideoFrameMutation", () => ({
   useVideoFrameMutation: () => ({ mutateAsync }),
@@ -43,6 +64,32 @@ function mountVideoItem() {
   });
 }
 
+function mountPhotoItem(programmaticScrolling = ref(false)) {
+  const Wrapper = defineComponent({
+    setup() {
+      provideAlbum({
+        albumId: ref("album-1"),
+        colors: ref({}),
+        media: ref([{ name: "photo.jpg", width: 1920, height: 1080 }]),
+        tripStart: ref("2024-01-01"),
+        totalDays: ref(1),
+        upgradedMedia: ref(new Set<string>()),
+      });
+      return () => h(MediaItem, { media: "photo.jpg", alt: "Photo" });
+    },
+  });
+
+  return mountWithPlugins(Wrapper, {
+    global: {
+      provide: {
+        [STEP_ID_KEY as symbol]: 7,
+        [PROGRAMMATIC_SCROLL_KEY as symbol]: readonly(programmaticScrolling),
+      },
+    },
+    attachTo: document.body,
+  });
+}
+
 describe("MediaItem video controls", () => {
   beforeEach(() => {
     mutateAsync.mockResolvedValue(undefined);
@@ -55,6 +102,7 @@ describe("MediaItem video controls", () => {
   afterEach(() => {
     usePhotoFocus().blur();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   test("renders inline mobile video playback", () => {
@@ -114,5 +162,28 @@ describe("MediaItem video controls", () => {
       timestamp: 0,
     });
     expect(document.activeElement).toBe(root);
+  });
+
+  test("keeps an already assigned image src during programmatic scroll", async () => {
+    MockIntersectionObserver.instances = [];
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    const programmaticScrolling = ref(false);
+    const wrapper = mountPhotoItem(programmaticScrolling);
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve));
+    MockIntersectionObserver.instances.at(-1)?.trigger(true);
+    await nextTick();
+    const img = wrapper.get("img");
+
+    expect(img.attributes("src")).toBe(
+      "http://localhost:8000/api/v1/albums/album-1/media/photo.jpg?d=1920x1080",
+    );
+
+    programmaticScrolling.value = true;
+    await nextTick();
+
+    expect(img.attributes("src")).toBe(
+      "http://localhost:8000/api/v1/albums/album-1/media/photo.jpg?d=1920x1080",
+    );
   });
 });


### PR DESCRIPTION
- defer album, nav, cover-picker, unused-tray, and map-marker media fetches until relevant scroll containers expose them
- keep loaded album media sticky during programmatic scroll so visible images are not blanked
- split album media reads into a higher nginx rate-limit bucket without relaxing media PATCH requests