### PR TITLE
fix: clean up hike mapbox lifecycle

### DIFF
--- a/frontend/src/components/album/map/HikeMapPage.vue
+++ b/frontend/src/components/album/map/HikeMapPage.vue
@@ -16,7 +16,14 @@ import { getCountryColor, ensureSatelliteContrast } from "../colors";
 import along from "@turf/along";
 import { lineString } from "@turf/helpers";
 import turfLength from "@turf/length";
-import { useId, useTemplateRef, computed, ref, watch, onUnmounted } from "vue";
+import {
+  useId,
+  useTemplateRef,
+  computed,
+  ref,
+  watch,
+  onBeforeUnmount,
+} from "vue";
 import { useI18n } from "vue-i18n";
 import mapboxgl from "mapbox-gl";
 import ElevationProfile from "./ElevationProfile.vue";
@@ -70,7 +77,7 @@ const fullHikeSegment = computed(() =>
 let cleanupHandles: (() => void) | null = null;
 let pendingIdleHandler: (() => void) | null = null;
 let lastAllCoords: [number, number][] = [];
-onUnmounted(() => {
+onBeforeUnmount(() => {
   cleanupHandles?.();
   if (pendingIdleHandler && map.value) {
     map.value.off("idle", pendingIdleHandler);
@@ -327,11 +334,11 @@ watch(safeMarginMm, () => {
 
 <template>
   <div
-    ref="hike-map"
     role="img"
     :aria-label="ariaLabel"
     class="page-container relative-position overflow-hidden"
   >
+    <div ref="hike-map" class="hike-map-canvas" aria-hidden="true" />
     <div v-if="stats" class="stats-block">
       <div class="stats-bg" aria-hidden="true" />
       <div class="stat-distance" :style="{ color: countryColor }">
@@ -377,6 +384,11 @@ watch(safeMarginMm, () => {
 </template>
 
 <style lang="scss" scoped>
+.hike-map-canvas {
+  position: absolute;
+  inset: 0;
+}
+
 // SVG gradient overlay pinned to the bottom of the page, extending past
 // the page edge to eliminate satellite slivers. Uses SVG stop-opacity
 // instead of CSS alpha functions - Skia's PDF backend renders CSS alpha

--- a/frontend/src/components/album/map/map-segments.css
+++ b/frontend/src/components/album/map/map-segments.css
@@ -26,6 +26,7 @@
 
 .map-step-marker {
   /* width/height set inline by drawSegmentsAndMarkers (scales with step count) */
+  pointer-events: none;
   border-radius: 50%;
   border: 0.125rem solid rgba(255, 255, 255, 0.9);
   background-color: #333;

--- a/frontend/src/components/album/map/mapSegments.ts
+++ b/frontend/src/components/album/map/mapSegments.ts
@@ -38,6 +38,18 @@ function cleanup(m: mapboxgl.Map) {
     .forEach((el) => el.remove());
 }
 
+function withTerrainDetached<T>(m: mapboxgl.Map, fn: () => T): T {
+  const terrain = m.getTerrain();
+  if (!terrain) return fn();
+
+  m.setTerrain(null);
+  try {
+    return fn();
+  } finally {
+    m.setTerrain(terrain);
+  }
+}
+
 export function addLine(
   m: mapboxgl.Map,
   id: string,
@@ -284,6 +296,15 @@ interface DrawResult {
 
 /** Draw segments and step markers. Returns all coords for fitBounds + hike endpoint info. */
 export function drawSegmentsAndMarkers(
+  m: mapboxgl.Map,
+  options: DrawOptions,
+): DrawResult {
+  return options.skipCleanup
+    ? drawSegmentsAndMarkersInner(m, options)
+    : withTerrainDetached(m, () => drawSegmentsAndMarkersInner(m, options));
+}
+
+function drawSegmentsAndMarkersInner(
   m: mapboxgl.Map,
   options: DrawOptions,
 ): DrawResult {

--- a/frontend/tests/components/mapSegments.test.ts
+++ b/frontend/tests/components/mapSegments.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { drawSegmentsAndMarkers } from "@/components/album/map/mapSegments";
+import type { Segment } from "@/client";
+
+function makeMap() {
+  const container = document.createElement("div");
+  return {
+    addLayer: vi.fn(),
+    addSource: vi.fn(),
+    getContainer: vi.fn(() => container),
+    getLayer: vi.fn(() => true),
+    getSource: vi.fn(() => ({ setData: vi.fn() })),
+    getStyle: vi.fn(() => ({ layers: [{ id: "seg-old" }] })),
+    getTerrain: vi.fn(() => ({ source: "mapbox-dem" })),
+    removeLayer: vi.fn(),
+    removeSource: vi.fn(),
+    setTerrain: vi.fn(),
+  };
+}
+
+const segment: Segment = {
+  uid: 1,
+  aid: "a1",
+  start_time: 0,
+  end_time: 1,
+  kind: "driving",
+  timezone_id: "UTC",
+  points: [
+    { lat: 1, lon: 2, time: 0 },
+    { lat: 3, lon: 4, time: 1 },
+  ],
+  route: null,
+};
+
+describe("drawSegmentsAndMarkers", () => {
+  it("temporarily detaches terrain while replacing segment sources", () => {
+    const map = makeMap();
+
+    drawSegmentsAndMarkers(map as never, {
+      segments: [segment],
+      steps: [],
+      albumId: "a1",
+    });
+
+    expect(map.setTerrain).toHaveBeenNthCalledWith(1, null);
+    expect(map.removeSource).toHaveBeenCalledWith("seg-old");
+    expect(map.setTerrain).toHaveBeenLastCalledWith({ source: "mapbox-dem" });
+  });
+});


### PR DESCRIPTION
- move HikeMap overlays out of the Mapbox container so the Mapbox-managed element starts empty
- detach and restore terrain around segment source replacement to avoid terrain/source removal races
- clean up hike idle handlers before map removal and make static step markers non-interactive