### PR TITLE
fix: limit media worker threads with anyio

### DIFF
--- a/backend/app/core/worker_threads.py
+++ b/backend/app/core/worker_threads.py
@@ -1,0 +1,17 @@
+import functools
+from collections.abc import Callable
+from typing import Any
+
+import anyio
+from anyio import to_thread
+
+
+async def run_sync[T](
+    func: Callable[..., T],
+    *args: Any,
+    limiter: anyio.CapacityLimiter | None = None,
+    **kwargs: Any,
+) -> T:
+    if kwargs:
+        func = functools.partial(func, **kwargs)
+    return await to_thread.run_sync(func, *args, limiter=limiter)

--- a/backend/app/logic/layout/builder.py
+++ b/backend/app/logic/layout/builder.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from collections.abc import AsyncIterable, Iterable, Sequence
 from itertools import batched
@@ -7,10 +6,11 @@ from pathlib import Path
 from typing import NamedTuple
 
 from app.core.async_helpers import yield_completed
+from app.core.worker_threads import run_sync
 from app.models.polarsteps import PSStep
 from app.models.user import User
 
-from .media import Media, MediaName, media_sem
+from .media import Media, MediaName, media_limiter
 
 
 class Layout(NamedTuple):
@@ -120,15 +120,14 @@ def _load_photos(folder: Path) -> list[Media]:
 async def _step_media(step_dir: Path) -> AsyncIterable[Media]:
     photo_folder = step_dir / "photos"
     if photo_folder.exists():
-        for photo in await asyncio.to_thread(_load_photos, photo_folder):
+        for photo in await run_sync(_load_photos, photo_folder, limiter=media_limiter):
             yield photo
 
     video_folder = step_dir / "videos"
     if video_folder.exists():
 
         async def _probe(p: Path) -> Media:
-            async with media_sem:
-                return await Media.probe(p)
+            return await Media.probe(p)
 
         async for result in yield_completed(
             _probe(p) for p in video_folder.iterdir() if p.suffix.lower() == ".mp4"

--- a/backend/app/logic/layout/media.py
+++ b/backend/app/logic/layout/media.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -6,12 +5,14 @@ from io import BytesIO
 from pathlib import Path
 from typing import Annotated, Self
 
+import anyio
 import av
 from PIL import Image, ImageOps
 from PIL.Image import Resampling
 from pydantic import BaseModel, StringConstraints
 
 from app.core.resources import detect_memory_mb
+from app.core.worker_threads import run_sync
 
 # PQ (HDR10) and HLG values of AVColorTransferCharacteristic.
 # https://ffmpeg.org/doxygen/trunk/pixfmt_8h.html
@@ -28,7 +29,9 @@ THUMB_QUALITY = 80
 _MEDIA_BASELINE_MB = 400  # Python process + other services sharing the container
 _PER_MEDIA_OP_MB = 80  # Pillow load + resize + save
 _media_budget = max(256, detect_memory_mb() - _MEDIA_BASELINE_MB)
-media_sem = asyncio.Semaphore(max(4, min(40, _media_budget // _PER_MEDIA_OP_MB)))
+media_limiter = anyio.CapacityLimiter(
+    max(4, min(40, _media_budget // _PER_MEDIA_OP_MB))
+)
 
 
 @contextmanager
@@ -53,8 +56,9 @@ def _generate_thumbnail_sync(source: Path, width: int) -> Path | None:
 
 
 async def generate_thumbnail(source: Path, width: int) -> Path | None:
-    async with media_sem:
-        return await asyncio.to_thread(_generate_thumbnail_sync, source, width)
+    return await run_sync(
+        _generate_thumbnail_sync, source, width, limiter=media_limiter
+    )
 
 
 def delete_thumbnails(path: Path) -> None:
@@ -98,7 +102,7 @@ def _probe_video_dimensions_sync(path: Path) -> tuple[int, int]:
 
 
 async def _video_dimensions(path: Path) -> tuple[int, int]:
-    return await asyncio.to_thread(_probe_video_dimensions_sync, path)
+    return await run_sync(_probe_video_dimensions_sync, path, limiter=media_limiter)
 
 
 class Media(BaseModel):
@@ -185,7 +189,6 @@ def _extract_frame_sync(video: Path, timestamp: float) -> Path:
 
 async def extract_frame(video: Path, timestamp: float | None = None) -> Path:
     if timestamp is None:
-        duration = await asyncio.to_thread(_video_duration_sync, video)
+        duration = await run_sync(_video_duration_sync, video, limiter=media_limiter)
         timestamp = duration / 2
-    async with media_sem:
-        return await asyncio.to_thread(_extract_frame_sync, video, timestamp)
+    return await run_sync(_extract_frame_sync, video, timestamp, limiter=media_limiter)

--- a/backend/app/logic/media_upgrade/pipeline.py
+++ b/backend/app/logic/media_upgrade/pipeline.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
+import anyio
 import httpx
 from httpx_oauth.oauth2 import RefreshTokenError
 from pydantic import BaseModel, Field, validate_call
@@ -24,7 +25,8 @@ if TYPE_CHECKING:
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
 from app.core.resources import detect_cpu_count
-from app.logic.layout.media import Media, MediaName, is_video
+from app.core.worker_threads import run_sync
+from app.logic.layout.media import Media, MediaName, is_video, media_limiter
 from app.models.album import Album
 from app.models.google_photos import GoogleMediaId, PickedMediaItem, PickerSessionId
 from app.services.google_photos import (
@@ -58,11 +60,9 @@ logger = logging.getLogger(__name__)
 _UPGRADE_TMP_DIR = ".upgrade-tmp"
 
 
-# @cache keeps the semaphore lazy so it binds to the running event loop, not
-# import time. (Download concurrency is capped on the httpx client itself.)
 @functools.cache
-def _hash_sem() -> asyncio.Semaphore:
-    return asyncio.Semaphore(min(8, detect_cpu_count()))
+def _hash_limiter() -> anyio.CapacityLimiter:
+    return anyio.CapacityLimiter(min(8, detect_cpu_count()))
 
 
 class MatchInProgress(BaseModel):
@@ -114,10 +114,13 @@ async def _hash_local_one(album_dir: Path, name: str) -> tuple[str, MediaHash | 
     if not path.exists():
         return name, None
     try:
-        async with _hash_sem():
-            if is_video(name):
-                return name, await asyncio.to_thread(extract_video_frame_hashes, path)
-            return name, await asyncio.to_thread(compute_phash_from_path, path)
+        if is_video(name):
+            return name, await run_sync(
+                extract_video_frame_hashes, path, limiter=_hash_limiter()
+            )
+        return name, await run_sync(
+            compute_phash_from_path, path, limiter=_hash_limiter()
+        )
     # Pillow raises SyntaxError on corrupt/truncated image headers.
     except OSError, SyntaxError, subprocess.SubprocessError:
         logger.warning("Failed to hash %s", name, exc_info=True)
@@ -136,7 +139,9 @@ async def _hash_candidate_one(
         thumb_bytes = await download_media_bytes(
             download, item.media_file.base_url, access_token, param=thumb_param
         )
-        return item.id, await asyncio.to_thread(compute_phash_from_bytes, thumb_bytes)
+        return item.id, await run_sync(
+            compute_phash_from_bytes, thumb_bytes, limiter=_hash_limiter()
+        )
     except OSError, SyntaxError, httpx.HTTPError:
         logger.warning(
             "Failed to download/hash thumbnail for %s",
@@ -273,11 +278,11 @@ async def _download_and_replace(  # noqa: PLR0913
 async def _upgrade_tmp(album_dir: Path) -> AsyncIterator[Path]:
     """Create and clean up the per-album tmp dir used during upgrade."""
     tmp_dir = album_dir / _UPGRADE_TMP_DIR
-    await asyncio.to_thread(functools.partial(tmp_dir.mkdir, exist_ok=True))
+    await run_sync(tmp_dir.mkdir, exist_ok=True)
     try:
         yield tmp_dir
     finally:
-        await asyncio.to_thread(shutil.rmtree, tmp_dir, ignore_errors=True)
+        await run_sync(shutil.rmtree, tmp_dir, ignore_errors=True)
 
 
 async def _persist_upgrade(
@@ -477,7 +482,7 @@ async def refresh_upgraded_media(
             if is_video(match.local_name):
                 updated = await Media.probe(target)
             else:
-                updated = await asyncio.to_thread(Media.load, target)
+                updated = await run_sync(Media.load, target, limiter=media_limiter)
             media_by_name[match.local_name] = updated
         except OSError, SyntaxError, RuntimeError:
             logger.warning("Failed to re-probe %s", match.local_name, exc_info=True)
@@ -496,11 +501,11 @@ async def cleanup_orphaned_tmp(users_folder: Path) -> None:
             count += 1
         return count
 
-    removed = await asyncio.to_thread(_scan_and_remove)
+    removed = await run_sync(_scan_and_remove)
     if removed:
         logger.info("Cleaned up %d orphaned upgrade-tmp dirs", removed)
 
 
 def _clear_caches() -> None:
-    """Reset cached semaphores (for test isolation across event loops)."""
-    _hash_sem.cache_clear()
+    """Reset cached limiters (for test isolation across event loops)."""
+    _hash_limiter.cache_clear()

--- a/backend/app/logic/media_upgrade/processing.py
+++ b/backend/app/logic/media_upgrade/processing.py
@@ -13,12 +13,14 @@ import imagehash
 import pillow_heif  # noqa: F401 - registers HEIC plugin for Pillow
 from PIL.Image import Resampling
 
+from app.core.worker_threads import run_sync
 from app.logic.layout.media import (
     HDR_COLOR_TRC,
     Media,
     delete_thumbnails,
     extract_frame,
     frame_to_oriented_image,
+    media_limiter,
     open_oriented,
 )
 
@@ -77,7 +79,7 @@ def _detect_hdr(path: Path) -> bool:
 async def process_video(input_path: Path, output: Path) -> None:
     # Transcoding stays on ffmpeg CLI; PyAV would need a hand-built filter
     # graph + encoder loop for zscale/tonemap/scale/x264/AAC/faststart.
-    is_hdr = await asyncio.to_thread(_detect_hdr, input_path)
+    is_hdr = await run_sync(_detect_hdr, input_path, limiter=media_limiter)
 
     scale_filter = (
         f"scale='min({_MAX_LONG_EDGE},iw)':'min({_MAX_LONG_EDGE},ih)'"
@@ -132,7 +134,7 @@ async def process_video(input_path: Path, output: Path) -> None:
         raise RuntimeError(f"ffmpeg re-encode failed: {stderr.decode()}")
 
     # -fs truncates mid-stream, producing a corrupt container. Treat as failure.
-    size = await asyncio.to_thread(lambda: output.stat().st_size)
+    size = (await run_sync(output.stat)).st_size
     if size >= _MAX_OUTPUT_BYTES:
         msg = f"ffmpeg output hit {_MAX_OUTPUT_BYTES}-byte cap"
         raise RuntimeError(msg)
@@ -190,14 +192,14 @@ async def replace_video(
         ):
             return False
 
-        await asyncio.to_thread(shutil.move, tmp, target)
+        await run_sync(shutil.move, tmp, target)
 
     # Video already replaced on disk - thumbnail/poster cleanup is best-effort.
     try:
-        await asyncio.to_thread(delete_thumbnails, target)
+        await run_sync(delete_thumbnails, target)
         poster = target.with_suffix(".jpg")
-        if await asyncio.to_thread(poster.exists):
-            await asyncio.to_thread(delete_thumbnails, poster)
+        if await run_sync(poster.exists):
+            await run_sync(delete_thumbnails, poster)
         await extract_frame(target)
     except OSError:
         logger.warning("Thumbnail cleanup failed for %s", name, exc_info=True)
@@ -208,17 +210,19 @@ async def replace_photo(
     name: str, raw_path: Path, tmp_path: Path, target: Path
 ) -> bool:
     async with tmp_file(tmp_path) as tmp:
-        width, height = await asyncio.to_thread(process_photo_sync, raw_path, tmp)
+        width, height = await run_sync(
+            process_photo_sync, raw_path, tmp, limiter=media_limiter
+        )
 
         try:
-            existing = await asyncio.to_thread(Media.load, target)
+            existing = await run_sync(Media.load, target, limiter=media_limiter)
         except OSError, SyntaxError:
             logger.debug("Could not load existing photo %s", name, exc_info=True)
             existing = None
         if existing and _skip_smaller(name, width, height, existing):
             return False
 
-        await asyncio.to_thread(shutil.move, tmp, target)
+        await run_sync(shutil.move, tmp, target)
 
-    await asyncio.to_thread(delete_thumbnails, target)
+    await run_sync(delete_thumbnails, target)
     return True

--- a/backend/app/logic/reconcile.py
+++ b/backend/app/logic/reconcile.py
@@ -10,8 +10,9 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 from app.core.http_clients import HttpClients
+from app.core.worker_threads import run_sync
 from app.logic.layout import Layout
-from app.logic.layout.media import Media, media_sem, normalize_name
+from app.logic.layout.media import Media, media_limiter, normalize_name
 from app.logic.trip_processing import (
     DbRow,
     PhaseUpdate,
@@ -111,11 +112,10 @@ async def _probe_media(
         to_probe.update(f for f in step_obj.unused if f not in known)
 
     async def _probe(name: str) -> Media:
-        async with media_sem:
-            try:
-                return await asyncio.to_thread(Media.load, trip_dir / name)
-            except OSError, ValueError:
-                return Media(name=name, width=1920, height=1080)
+        try:
+            return await run_sync(Media.load, trip_dir / name, limiter=media_limiter)
+        except OSError, ValueError:
+            return Media(name=name, width=1920, height=1080)
 
     probed = await asyncio.gather(*[_probe(f) for f in to_probe])
     merged = dict(known)

--- a/backend/tests/test_worker_threads.py
+++ b/backend/tests/test_worker_threads.py
@@ -1,0 +1,31 @@
+import threading
+import time
+
+import anyio
+
+from app.core.worker_threads import run_sync
+
+
+async def test_run_sync_respects_capacity_limiter() -> None:
+    limiter = anyio.CapacityLimiter(1)
+    active = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def work() -> None:
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.01)
+        with lock:
+            active -= 1
+
+    async def run_work() -> None:
+        await run_sync(work, limiter=limiter)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(run_work)
+        tg.start_soon(run_work)
+
+    assert peak == 1


### PR DESCRIPTION
- Add a small AnyIO-backed worker-thread helper with limiter support.
- Move media probing, thumbnailing, upgrade processing, and pHash work onto named AnyIO capacity limiters.