### PR TITLE
ci: speed up `docker` and `e2e` CI job, skip jobs by paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,18 +88,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
         working-directory: frontend
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-      - run: bunx playwright install-deps chromium
-        working-directory: frontend
-      - if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install chromium
+      - run: bunx playwright install --with-deps --only-shell chromium
         working-directory: frontend
       - run: bun run test:e2e
         working-directory: frontend
@@ -161,18 +150,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
         working-directory: frontend
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-      - run: bunx playwright install-deps chromium
-        working-directory: frontend
-      - if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install chromium
+      - run: bunx playwright install --with-deps --only-shell chromium
         working-directory: frontend
       - uses: docker/setup-buildx-action@v4
       - name: Build images with GHA layer cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,59 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      docker: ${{ steps.filter.outputs.docker }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'scripts/regen-openapi.sh'
+              - 'scripts/generate_openapi.py'
+            frontend:
+              - 'frontend/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'backend/openapi.json'
+              - 'PRIVACY.md'
+              - 'TERMS.md'
+            docker:
+              - 'compose.yml'
+              - 'compose.override.yml'
+              - '.dockerignore'
+              - 'backend/Dockerfile'
+              - 'frontend/Dockerfile'
+              - 'backend/**'
+              - 'frontend/**'
+              - 'fixtures/demo/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'PRIVACY.md'
+              - 'TERMS.md'
+            ci:
+              - '.github/workflows/**'
+              - '.pre-commit-config.yaml'
+              - 'mise.toml'
+
   gitleaks:
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +76,11 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.ci == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -53,6 +110,8 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.ci == 'true'
     env:
       SECRET_KEY: ci
       SQLALCHEMY_DATABASE_URI: postgresql+psycopg://ci:ci@localhost:5432/ci
@@ -71,6 +130,8 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.ci == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -81,6 +142,11 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.ci == 'true'
     env:
       VITE_FRONTEND_URL: http://localhost
     steps:
@@ -101,6 +167,8 @@ jobs:
 
   test-migrations:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.ci == 'true'
     services:
       postgres:
         image: postgres:18
@@ -136,6 +204,12 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.docker == 'true' ||
+      needs.changes.outputs.ci == 'true'
     env:
       DOCKER_BUILD_RECORD_UPLOAD: false
       POSTGRES_PASSWORD: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     env:
+      DOCKER_BUILD_RECORD_UPLOAD: false
       POSTGRES_PASSWORD: ci
       POSTGRES_USER: ci
       POSTGRES_DB: ci
@@ -175,14 +176,27 @@ jobs:
         working-directory: frontend
       - uses: docker/setup-buildx-action@v4
       - name: Build images with GHA layer cache
+        if: github.event_name == 'pull_request'
         uses: docker/bake-action@v7
         with:
           source: .
           files: compose.yml
           load: true
           set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            backend.cache-from=type=gha,scope=backend,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            frontend.cache-from=type=gha,scope=frontend,repository=${{ github.repository }},ghtoken=${{ github.token }}
+      - name: Build images with GHA layer cache
+        if: github.event_name != 'pull_request'
+        uses: docker/bake-action@v7
+        with:
+          source: .
+          files: compose.yml
+          load: true
+          set: |
+            backend.cache-from=type=gha,scope=backend,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            backend.cache-to=type=gha,mode=min,scope=backend,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            frontend.cache-from=type=gha,scope=frontend,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            frontend.cache-to=type=gha,mode=max,scope=frontend,repository=${{ github.repository }},ghtoken=${{ github.token }}
       - run: docker compose up -d --no-build
       - name: Wait for backend health
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-workspace --package app
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/app/browsers
-RUN playwright install chromium --with-deps
+RUN playwright install --with-deps --only-shell chromium
 
 COPY ./backend/pyproject.toml ./backend/alembic.ini /app/backend/
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-workspace --package app
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/app/browsers
-RUN playwright install --with-deps --only-shell chromium
+RUN playwright install chromium --with-deps
 
 COPY ./backend/pyproject.toml ./backend/alembic.ini /app/backend/
 


### PR DESCRIPTION
- Split Docker BuildKit GHA cache scopes for backend and frontend.
- Stop PR Docker runs from exporting cache while keeping main as the cache writer.
- Reduce backend cache export size and disable Docker build record upload.