### PR TITLE
fix(ui): a11y polish

### DIFF
--- a/frontend/src/components/album/map/HikeMapPage.vue
+++ b/frontend/src/components/album/map/HikeMapPage.vue
@@ -334,11 +334,11 @@ watch(safeMarginMm, () => {
 
 <template>
   <div
-    role="img"
+    role="region"
     :aria-label="ariaLabel"
     class="page-container relative-position overflow-hidden"
   >
-    <div ref="hike-map" class="hike-map-canvas" aria-hidden="true" />
+    <div ref="hike-map" class="hike-map-canvas" />
     <div v-if="stats" class="stats-block">
       <div class="stats-bg" aria-hidden="true" />
       <div class="stat-distance" :style="{ color: countryColor }">

--- a/frontend/src/components/album/step/StepMetaPanel.vue
+++ b/frontend/src/components/album/step/StepMetaPanel.vue
@@ -64,7 +64,7 @@ function toDMS(decimal: number, isLat: boolean): string {
   const dStr = String(d).padStart(3, " ");
   const mStr = String(m).padStart(2, " ");
   const sStr = String(s).padStart(2, " ");
-  return `${dStr}° ${mStr}' ${sStr}" ${hemisphere}`;
+  return `${dStr}° ${mStr}′ ${sStr}″ ${hemisphere}`;
 }
 
 const coords = computed(() => ({

--- a/frontend/src/components/editor/UserMenu.vue
+++ b/frontend/src/components/editor/UserMenu.vue
@@ -84,7 +84,7 @@ async function handleDelete() {
       type="button"
       class="settings-trigger"
       :class="{ open: menuOpen }"
-      :aria-label="t('settings.menu')"
+      :aria-label="`${user.first_name} - ${t('settings.menu')}`"
       :aria-expanded="menuOpen"
       aria-haspopup="menu"
     >

--- a/frontend/src/components/editor/nav/NavCountryGroup.vue
+++ b/frontend/src/components/editor/nav/NavCountryGroup.vue
@@ -89,37 +89,39 @@ const allHidden = computed(() =>
       </q-item-section>
     </template>
 
-    <template
-      v-for="entry in group.entries"
-      :key="entry.type === 'step' ? entry.item.id : entry.key"
-    >
-      <NavMapItem
-        v-if="entry.type === 'map'"
-        :data-nav-section="entry.key"
-        :date-range="entry.dateRange"
-        :range-idx="entry.rangeIdx"
-        :active="sectionKeyMatchesRange(activeSectionKey, entry.dateRange)"
-        :steps="steps"
-        :colors="colors"
-        :format-map-range="formatMapRange"
-        @click="emit('scrollToMap', entry.dateRange)"
-        @delete="emit('deleteMap', entry.rangeIdx)"
-        @date-change="(idx, range) => emit('mapDateChange', idx, range)"
-      />
-      <NavStepItem
-        v-else
-        :data-nav-step="entry.item.id"
-        :name="entry.item.name"
-        :date="formatDate(entry.item.date, SHORT_DATE)"
-        :thumb="entry.item.thumb"
-        :color="entry.item.color"
-        :active="activeStepId === entry.item.id"
-        :hidden="hiddenSet.has(entry.item.id)"
-        :lazy-root="lazyRoot"
-        @click="emit('scrollToStep', entry.item.id)"
-        @toggle="emit('toggleStep', entry.item.id)"
-      />
-    </template>
+    <div :inert="!open">
+      <template
+        v-for="entry in group.entries"
+        :key="entry.type === 'step' ? entry.item.id : entry.key"
+      >
+        <NavMapItem
+          v-if="entry.type === 'map'"
+          :data-nav-section="entry.key"
+          :date-range="entry.dateRange"
+          :range-idx="entry.rangeIdx"
+          :active="sectionKeyMatchesRange(activeSectionKey, entry.dateRange)"
+          :steps="steps"
+          :colors="colors"
+          :format-map-range="formatMapRange"
+          @click="emit('scrollToMap', entry.dateRange)"
+          @delete="emit('deleteMap', entry.rangeIdx)"
+          @date-change="(idx, range) => emit('mapDateChange', idx, range)"
+        />
+        <NavStepItem
+          v-else
+          :data-nav-step="entry.item.id"
+          :name="entry.item.name"
+          :date="formatDate(entry.item.date, SHORT_DATE)"
+          :thumb="entry.item.thumb"
+          :color="entry.item.color"
+          :active="activeStepId === entry.item.id"
+          :hidden="hiddenSet.has(entry.item.id)"
+          :lazy-root="lazyRoot"
+          @click="emit('scrollToStep', entry.item.id)"
+          @toggle="emit('toggleStep', entry.item.id)"
+        />
+      </template>
+    </div>
   </q-expansion-item>
 </template>
 

--- a/frontend/src/components/editor/nav/NavDateFilter.vue
+++ b/frontend/src/components/editor/nav/NavDateFilter.vue
@@ -115,6 +115,7 @@ function clearFilter() {
     class="nav-chip"
     :aria-label="t('nav.dateFilter')"
     aria-haspopup="dialog"
+    :aria-expanded="isOpen"
     @click.stop
   >
     <q-icon :name="symOutlinedCalendarMonth" size="var(--type-xs)" />

--- a/frontend/src/components/register/ZipUploader.vue
+++ b/frontend/src/components/register/ZipUploader.vue
@@ -288,7 +288,7 @@ function reset() {
         @drop.prevent="onDrop"
       >
         <q-icon :name="symOutlinedLuggage" size="3rem" class="drop-zone-icon" />
-        <span class="text-body2 text-muted">{{ t("register.dropZone") }}</span>
+        <span class="text-body2">{{ t("register.dropZone") }}</span>
       </div>
 
       <!-- Progress bar (uploading) -->

--- a/frontend/src/composables/useHikeBoundaryDrag.ts
+++ b/frontend/src/composables/useHikeBoundaryDrag.ts
@@ -93,6 +93,10 @@ export function setupBoundaryHandles(
 
     const el = document.createElement("div");
     el.className = HANDLE_CLASS;
+    el.setAttribute(
+      "aria-label",
+      t(ep.handle === "start" ? "hike.adjustStart" : "hike.adjustEnd"),
+    );
     if (!adjacentOutline) el.classList.add("static");
 
     const marker = new mapboxgl.Marker({

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -135,7 +135,9 @@
   },
   "hike": {
     "mapLabel": "Hike route map",
-    "elevationProfile": "Elevation profile"
+    "elevationProfile": "Elevation profile",
+    "adjustStart": "Adjust hike start",
+    "adjustEnd": "Adjust hike end"
   },
   "overview": {
     "title": "Trip overview",

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -135,7 +135,9 @@
   },
   "hike": {
     "mapLabel": "מפת מסלול טרק",
-    "elevationProfile": "פרופיל גובה"
+    "elevationProfile": "פרופיל גובה",
+    "adjustStart": "התאמת תחילת הטרק",
+    "adjustEnd": "התאמת סיום הטרק"
   },
   "overview": {
     "title": "סקירת הטיול",


### PR DESCRIPTION
| Item | What changed |
|------|--------------|
| Hike map role | `HikeMapPage` outer wrapper was `role="img"`, which made the elevation chart, distance stats, and (after this PR) drag handles presentational to AT. Switched to `role="region"`. Also dropped `aria-hidden="true"` on the inner canvas so boundary handle markers reach AT. |
| DMS coordinates | `StepMetaPanel.toDMS` now emits prime/double-prime (`U+2032`/`U+2033`) instead of ASCII `'`/`"`. |
| Collapsed nav groups | `NavCountryGroup` wraps its expanded body in `<div :inert="!open">`, so contained step/map buttons leave the tab order when the country is collapsed. |
| Drop-zone hint contrast | `ZipUploader` drop hint dropped the `text-muted` class - inherits default `--text` color, passing WCAG AA on both themes. |
| User chip aria-label | `UserMenu` trigger now reads `${first_name} - Settings` so screen readers announce the user identity that's visible. |
| Filter chip aria-expanded | `NavDateFilter` chip binds `:aria-expanded="isOpen"` from the picker state. |
| Hike drag handles | `useHikeBoundaryDrag` sets distinct, localized aria-labels (`hike.adjustStart` / `hike.adjustEnd`) on each handle. |
