### PR TITLE
feat: add structured backend logging foundation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,4 +48,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--log-config", "app/core/uvicorn_logging.json"]

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,7 +1,10 @@
 import logging
 import sys
+from collections.abc import MutableMapping
+from typing import Any
 
-from rich.logging import RichHandler
+import structlog
+from asgi_correlation_id import correlation_id
 
 _NOISY = (
     "sqlalchemy.engine",
@@ -15,25 +18,101 @@ _NOISY = (
 # Loggers that should print to terminal but not propagate to Sentry.
 # Sentry's LoggingIntegration is configured to skip these in main.py.
 SENTRY_IGNORED = ("uvicorn.access",)
+_ACCESS_LOG_HEALTH_PATHS = {"/api/v1/health"}
 
 
-def setup_logging(*, use_rich: bool, log_level: str = "INFO") -> None:
-    if use_rich:
-        handler = RichHandler(
-            rich_tracebacks=True,
-            tracebacks_show_locals=True,
-            markup=True,
-            show_path=True,
+class _HealthAccessFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        path = _uvicorn_access_path(record)
+        return path not in _ACCESS_LOG_HEALTH_PATHS
+
+
+def _add_request_id(
+    _logger: logging.Logger,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    if request_id := correlation_id.get():
+        event_dict["request_id"] = request_id
+    return event_dict
+
+
+def _drop_color_message_key(
+    _logger: logging.Logger,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    event_dict.pop("color_message", None)
+    return event_dict
+
+
+def _uvicorn_access_path(record: logging.LogRecord) -> str | None:
+    args = record.args
+    if isinstance(args, tuple) and len(args) >= 3 and isinstance(args[2], str):
+        return args[2]
+    return None
+
+
+def setup_logging(*, use_console: bool, log_level: str = "INFO") -> None:
+    level = getattr(logging, log_level.upper())
+    timestamper = structlog.processors.TimeStamper(fmt="iso", utc=True)
+    shared_processors: list[structlog.types.Processor] = [
+        _add_request_id,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.ExtraAdder(),
+        _drop_color_message_key,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        timestamper,
+        structlog.processors.StackInfoRenderer(),
+    ]
+    exception_processors: list[structlog.types.Processor] = []
+
+    renderer: structlog.types.Processor
+    if use_console:
+        renderer = structlog.dev.ConsoleRenderer(
+            colors=True,
+            exception_formatter=structlog.dev.plain_traceback,
         )
     else:
-        handler = logging.StreamHandler(sys.stderr)
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
-        )
+        exception_processors.append(structlog.processors.format_exc_info)
+        renderer = structlog.processors.JSONRenderer()
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            *shared_processors,
+            *exception_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=[*shared_processors, *exception_processors],
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+    )
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(formatter)
 
     logging.basicConfig(level=logging.WARNING, handlers=[handler], force=True)
-    logging.getLogger("app").setLevel(getattr(logging, log_level.upper()))
+    logging.getLogger("app").setLevel(level)
+
     logging.getLogger("uvicorn").setLevel(logging.INFO)
-    logging.getLogger("uvicorn.access").setLevel(logging.INFO)
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.setLevel(logging.INFO)
+    access_logger.filters = [
+        f for f in access_logger.filters if not isinstance(f, _HealthAccessFilter)
+    ]
+    access_logger.addFilter(_HealthAccessFilter())
     for name in _NOISY:
         logging.getLogger(name).setLevel(logging.WARNING)
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.propagate = True

--- a/backend/app/core/uvicorn_logging.json
+++ b/backend/app/core/uvicorn_logging.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "handlers": {
+    "null": {
+      "class": "logging.NullHandler"
+    }
+  },
+  "loggers": {
+    "uvicorn": {
+      "handlers": ["null"],
+      "propagate": false
+    },
+    "uvicorn.error": {
+      "handlers": ["null"],
+      "propagate": false
+    },
+    "uvicorn.access": {
+      "handlers": ["null"],
+      "propagate": false
+    }
+  }
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 import sentry_sdk
+from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     from fastapi.routing import APIRoute
 
 settings = get_settings()
-setup_logging(use_rich=settings.ENVIRONMENT == "local", log_level=settings.LOG_LEVEL)
+setup_logging(use_console=settings.ENVIRONMENT == "local", log_level=settings.LOG_LEVEL)
 
 if settings.SENTRY_DSN:
 
@@ -99,6 +100,8 @@ app = FastAPI(
     generate_unique_id_function=custom_generate_unique_id,
     lifespan=lifespan,
 )
+
+app.add_middleware(CorrelationIdMiddleware)
 
 if settings.all_cors_origins:
     app.add_middleware(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "Pillow~=12.0",
     "pydantic~=2.0",
     "pydantic-settings~=2.0",
-    "rich~=15.0",
     "fastapi[standard]<1",
     "python-multipart<1",
     "uvicorn<1",
@@ -36,6 +35,8 @@ dependencies = [
     "sqlalchemy-dlock>=0.8.1",
     "av~=17.0",
     "anyio~=4.13",
+    "structlog~=25.0",
+    "asgi-correlation-id~=4.3",
 ]
 
 [dependency-groups]

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -9,7 +9,7 @@ services:
     restart: "no"
     ports:
       - "127.0.0.1:8000:8000"
-    command: sh -c "alembic upgrade head && uvicorn app.main:app --reload --host 0.0.0.0 --proxy-headers"
+    command: sh -c "alembic upgrade head && uvicorn app.main:app --reload --host 0.0.0.0 --proxy-headers --log-config app/core/uvicorn_logging.json"
     develop:
       watch:
         - path: ./backend

--- a/compose.yml
+++ b/compose.yml
@@ -51,7 +51,13 @@ services:
           cpus: "2.0"
           pids: 512
     networks: [backend, frontend]
-    command: sh -c "alembic upgrade head && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers"
+    command:
+      - sh
+      - -c
+      - >
+        alembic upgrade head &&
+        uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+        --proxy-headers --log-config app/core/uvicorn_logging.json
     depends_on:
       db:
         condition: service_healthy

--- a/mise.toml
+++ b/mise.toml
@@ -30,7 +30,7 @@ run = [
 [tasks."dev:backend"]
 description = "Start backend dev server"
 dir = "backend"
-run = "uv run fastapi dev"
+run = "uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8000 --proxy-headers --log-config app/core/uvicorn_logging.json"
 depends = ["db:migrate"]
 
 [tasks."dev:frontend"]

--- a/uv.lock
+++ b/uv.lock
@@ -103,6 +103,7 @@ dependencies = [
     { name = "alembic" },
     { name = "alembic-postgresql-enum" },
     { name = "anyio" },
+    { name = "asgi-correlation-id" },
     { name = "av" },
     { name = "coloraide" },
     { name = "fastapi", extra = ["standard"] },
@@ -123,13 +124,13 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
-    { name = "rich" },
     { name = "scipy" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "simplification" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-dlock" },
     { name = "sqlmodel" },
+    { name = "structlog" },
     { name = "uvicorn" },
 ]
 
@@ -153,6 +154,7 @@ requires-dist = [
     { name = "alembic", specifier = "~=1.12" },
     { name = "alembic-postgresql-enum", specifier = ">=1.10.0" },
     { name = "anyio", specifier = "~=4.13" },
+    { name = "asgi-correlation-id", specifier = "~=4.3" },
     { name = "av", specifier = "~=17.0" },
     { name = "coloraide", specifier = "~=8.7" },
     { name = "fastapi", extras = ["standard"], specifier = "<1" },
@@ -173,13 +175,13 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "~=2.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "~=2.0" },
     { name = "python-multipart", specifier = "<1" },
-    { name = "rich", specifier = "~=15.0" },
     { name = "scipy", specifier = "~=1.15" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "~=2.35" },
     { name = "simplification", specifier = "~=0.7" },
     { name = "sqlalchemy", specifier = "~=2.0" },
     { name = "sqlalchemy-dlock", specifier = ">=0.8.1" },
     { name = "sqlmodel", specifier = "<1" },
+    { name = "structlog", specifier = "~=25.0" },
     { name = "uvicorn", specifier = "<1" },
 ]
 
@@ -195,6 +197,19 @@ dev = [
     { name = "syrupy", specifier = "~=5.0" },
     { name = "ty", specifier = "<1" },
     { name = "vulture", specifier = ">=2.16" },
+]
+
+[[package]]
+name = "asgi-correlation-id"
+version = "4.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ff/a6538245ac1eaa7733ec6740774e9d5add019e2c63caa29e758c16c0afdd/asgi_correlation_id-4.3.4.tar.gz", hash = "sha256:ea6bc310380373cb9f731dc2e8b2b6fb978a76afe33f7a2384f697b8d6cd811d", size = 20075, upload-time = "2024-10-17T11:44:30.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ab/6936e2663c47a926e0659437b9333ad87d1ff49b1375d239026e0a268eba/asgi_correlation_id-4.3.4-py3-none-any.whl", hash = "sha256:36ce69b06c7d96b4acb89c7556a4c4f01a972463d3d49c675026cbbd08e9a0a2", size = 15262, upload-time = "2024-10-17T11:44:28.739Z" },
 ]
 
 [[package]]
@@ -1460,6 +1475,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- add structlog plus asgi-correlation-id as the backend logging foundation
- route app, stdlib, and Uvicorn logs through one structlog formatter
- add Uvicorn log config for pre-import/reload startup handoff
- keep local console logs human-readable and production logs JSON-ready
- filter /api/v1/health access logs and drop Uvicorn color-only log extras