### PR TITLE
refactor: migrate app logs to structured events

### DIFF
--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from collections import OrderedDict
 from collections.abc import AsyncGenerator
@@ -7,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import sentry_sdk
+import structlog
 from fastapi import BackgroundTasks, Depends, HTTPException, Request, status
 from playwright.async_api import Browser
 from sqlalchemy import func, update
@@ -22,7 +22,7 @@ from app.models.user import User, UserPublic
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Debounce activity tracking: only write to DB if >1 hour since last write.
 # Bounded to 1024 entries to prevent unbounded memory growth.
@@ -50,7 +50,7 @@ async def _touch_activity(uid: int) -> None:
             )
             await session.commit()
     except SQLAlchemyError, OSError:
-        logger.debug("Activity tracking write failed for uid=%s", uid, exc_info=True)
+        logger.debug("activity_tracking.write_failed", user_id=uid, exc_info=True)
 
 
 async def try_load_user(request: Request, session: AsyncSession) -> User | None:
@@ -60,7 +60,7 @@ async def try_load_user(request: Request, session: AsyncSession) -> User | None:
         return None
     user = await session.get(User, uid)
     if user is None:
-        logger.warning("Auth failed: unknown uid=%s, clearing stale session", uid)
+        logger.warning("auth.unknown_session_user", user_id=uid)
         request.session.clear()
     return user
 

--- a/backend/app/api/v1/routes/albums.py
+++ b/backend/app/api/v1/routes/albums.py
@@ -1,7 +1,7 @@
-import logging
 from collections.abc import AsyncIterable, Sequence
 from typing import Annotated
 
+import structlog
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -32,7 +32,7 @@ from app.models.step import Step, StepUpdate
 
 from ..deps import BrowserDep, HttpClientsDep, SessionDep, UserDep, apply_update
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def _get_album(
@@ -208,8 +208,10 @@ async def adjust_segment_boundary(  # noqa: PLR0913
     enqueue_album_route_enrichment(background_tasks, http, uid, aid)
 
     logger.info(
-        "Adjusted segment boundary",
-        extra={"uid": uid, "aid": aid, "handle": body.handle},
+        "segment.boundary_adjusted",
+        user_id=uid,
+        album_id=aid,
+        handle=body.handle,
     )
 
     result = await session.exec(

--- a/backend/app/api/v1/routes/assets.py
+++ b/backend/app/api/v1/routes/assets.py
@@ -1,11 +1,11 @@
 import asyncio
-import logging
 import weakref
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import FileResponse
 
@@ -20,7 +20,7 @@ from app.logic.layout.media import (
 
 from ..deps import UserDep, album_dir as _album_dir
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/albums", tags=["assets"])
 
@@ -68,7 +68,7 @@ async def get_media(
         async with _gen_lock(source):
             if not source.is_file():
                 await extract_frame(video)
-                logger.debug("Lazy-extracted poster for %s", name)
+                logger.debug("asset.poster_extracted", media_name=name)
 
     if not source.is_file():
         raise HTTPException(status.HTTP_404_NOT_FOUND)
@@ -111,4 +111,4 @@ async def update_video_frame(
     poster.unlink(missing_ok=True)
     delete_thumbnails(poster)
     await extract_frame(video, timestamp)
-    logger.debug("Re-extracted frame for %s at t=%.1fs", name, timestamp)
+    logger.debug("asset.frame_reextracted", media_name=name, timestamp_s=timestamp)

--- a/backend/app/api/v1/routes/auth.py
+++ b/backend/app/api/v1/routes/auth.py
@@ -1,9 +1,9 @@
 import asyncio
-import logging
 import re
 from typing import Literal
 
 import jwt
+import structlog
 from fastapi import APIRouter, HTTPException, Request, status
 from jwt import PyJWKClient
 from pydantic import BaseModel
@@ -16,7 +16,7 @@ from ..deps import SessionDep, login_session, to_user_public, try_load_user
 
 PENDING_SIGNUP_KEY = "pending_signup"
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -57,7 +57,7 @@ async def _verify_oidc_token(
     try:
         return await asyncio.to_thread(_decode)
     except jwt.InvalidTokenError as e:
-        logger.warning("OIDC JWT verification failed: %s", e)
+        logger.warning("auth.oidc_verification_failed", error_type=type(e).__name__)
         raise HTTPException(status.HTTP_401_UNAUTHORIZED) from None
 
 
@@ -90,7 +90,7 @@ async def _verify_microsoft(credential: str) -> OAuthIdentity:
     # /common issues tenant-specific issuers - pattern-match manually.
     iss = payload.get("iss", "")
     if not _MS_ISSUER_RE.match(iss):
-        logger.warning("Microsoft token has unexpected issuer: %s", iss)
+        logger.warning("auth.microsoft_unexpected_issuer")
         raise HTTPException(status.HTTP_401_UNAUTHORIZED)
     return OAuthIdentity(
         sub=payload["sub"],
@@ -145,11 +145,11 @@ async def _authenticate(
     identity = await verify_credential(credential, provider)
     row = await _lookup_user(identity, session)
     if row is None:
-        logger.info("New %s identity: sub=%s", provider, identity.sub)
+        logger.info("auth.identity_created", provider=provider)
         set_pending_signup(request, identity)
         return None
     login_session(request, row.id)
-    logger.info("Existing user %d signed in via %s", row.id, provider)
+    logger.info("auth.sign_in", user_id=row.id, provider=provider)
     return row
 
 

--- a/backend/app/api/v1/routes/google_photos.py
+++ b/backend/app/api/v1/routes/google_photos.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import logging
 import secrets
 from collections.abc import AsyncIterable
 from datetime import UTC, datetime
 from typing import Annotated
 
 import httpx
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
 from fastapi.sse import EventSourceResponse
@@ -54,7 +54,7 @@ from app.services.google_photos import (
 
 from ..deps import HttpClientsDep, SessionDep, UserDep, album_dir as _album_dir
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -234,9 +234,9 @@ async def _ensure_fresh_access_token(
         # Avoid logger.exception: httpx request bodies would leak the
         # plaintext refresh token and client secret into Sentry.
         logger.error(  # noqa: TRY400
-            "Failed to refresh Google Photos access token for user %d: %s",
-            user.id,
-            type(exc).__name__,
+            "google_photos.token_refresh_failed",
+            user_id=user.id,
+            error_type=type(exc).__name__,
         )
         raise HTTPException(
             status.HTTP_401_UNAUTHORIZED,
@@ -303,7 +303,7 @@ async def callback(  # noqa: PLR0913
         or cookie_data is None
         or not secrets.compare_digest(cookie_data["csrf"], payload["csrf"])
     ):
-        logger.warning("OAuth state/CSRF mismatch for user %d", user.id)
+        logger.warning("google_photos.oauth_state_mismatch", user_id=user.id)
         resp = _redirect_to_popup_bridge(
             payload["nonce"] if payload else None, error=True
         )
@@ -316,10 +316,9 @@ async def callback(  # noqa: PLR0913
         )
     except GetAccessTokenError as exc:
         logger.error(  # noqa: TRY400
-            "Google Photos OAuth callback failed for user %d: %s: %s",
-            user.id,
-            type(exc).__name__,
-            exc,
+            "google_photos.callback_failed",
+            user_id=user.id,
+            error_type=type(exc).__name__,
         )
         resp = _redirect_to_popup_bridge(payload["nonce"], error=True)
         _clear_oauth_cookie(resp)
@@ -327,7 +326,7 @@ async def callback(  # noqa: PLR0913
 
     refresh_token = token.get("refresh_token")
     if not refresh_token:
-        logger.warning("No refresh token for user %d", user.id)
+        logger.warning("google_photos.no_refresh_token", user_id=user.id)
         resp = _redirect_to_popup_bridge(payload["nonce"], error=True)
         _clear_oauth_cookie(resp)
         return resp
@@ -336,7 +335,7 @@ async def callback(  # noqa: PLR0913
     user.google_photos_connected_at = datetime.now(UTC)
     session.add(user)
     await session.commit()
-    logger.info("OAuth callback complete: user %d connected", user.id)
+    logger.info("google_photos.connected", user_id=user.id)
     resp = _redirect_to_popup_bridge(payload["nonce"])
     _clear_oauth_cookie(resp)
     return resp
@@ -444,7 +443,10 @@ async def match_media(
             # request body contains the plaintext refresh token and client
             # secret (see _ensure_fresh_access_token for context).
             logger.error(  # noqa: TRY400
-                "Matching failed for album %s: %s: %s", aid, type(exc).__name__, exc
+                "google_photos.matching.failed",
+                user_id=user.id,
+                album_id=aid,
+                error_type=type(exc).__name__,
             )
             yield UpgradeFailed(detail="Matching failed unexpectedly.")
 
@@ -520,7 +522,11 @@ async def disconnect(user: UserDep, http: HttpClientsDep, session: SessionDep) -
         try:
             await http.gphotos_oauth.revoke_token(user.google_photos_refresh_token)
         except (RevokeTokenError, httpx.HTTPError) as exc:
-            logger.warning("Token revoke failed: %s", type(exc).__name__)
+            logger.warning(
+                "google_photos.token_revoke_failed",
+                user_id=user.id,
+                error_type=type(exc).__name__,
+            )
     user.google_photos_refresh_token = None
     user.google_photos_connected_at = None
     session.add(user)

--- a/backend/app/api/v1/routes/health.py
+++ b/backend/app/api/v1/routes/health.py
@@ -1,6 +1,6 @@
-import logging
 import shutil
 
+import structlog
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -11,7 +11,7 @@ from app.core.config import get_settings
 from app.core.db import get_engine
 from app.core.resources import MiB
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 router = APIRouter(tags=["health"])
 
 _MIN_DISK_FREE_MB = 256
@@ -32,11 +32,11 @@ async def health_check(request: Request) -> JSONResponse:
     healthy = db_ok and disk_ok and pw_ok
     if not healthy:
         logger.warning(
-            "Health check degraded: db=%s disk=%s (%sMB free) playwright=%s",
-            db_ok,
-            disk_ok,
-            disk_free_mb,
-            pw_ok,
+            "health.degraded",
+            db=db_ok,
+            disk=disk_ok,
+            disk_free_mb=disk_free_mb,
+            playwright=pw_ok,
         )
 
     body = HealthStatus(db=db_ok, disk=disk_ok, playwright=pw_ok)
@@ -49,7 +49,7 @@ async def _check_db() -> bool:
         async with AsyncSession(get_engine()) as session:
             await session.execute(text("SELECT 1"))
     except Exception:
-        logger.exception("DB health check failed")
+        logger.exception("health.db_failed")
         return False
     else:
         return True

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -1,6 +1,5 @@
 import asyncio
 import io
-import logging
 import shutil
 from collections.abc import AsyncIterable
 from functools import cache
@@ -10,6 +9,7 @@ from typing import cast
 from zipfile import BadZipFile
 
 import httpx
+import structlog
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -57,7 +57,7 @@ from ..deps import (
 )
 from .auth import clear_pending_signup, get_pending_signup
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -71,9 +71,9 @@ def _check_upload_size(file: UploadFile) -> int:
     max_bytes = get_settings().VITE_MAX_UPLOAD_GB * 1024 * MiB
     if size > max_bytes:
         logger.warning(
-            "Upload rejected: %d MB exceeds %d MB limit",
-            size // MiB,
-            max_bytes // MiB,
+            "upload.rejected_too_large",
+            size_mb=size // MiB,
+            max_mb=max_bytes // MiB,
         )
         raise HTTPException(status.HTTP_413_CONTENT_TOO_LARGE, "Upload too large")
     return size
@@ -123,7 +123,12 @@ async def _finalize_upload(  # noqa: PLR0913
             session.add(existing)
             await session.commit()
             user = existing
-            logger.info("User %d re-uploaded ZIP", user.id)
+            logger.info(
+                "upload.completed",
+                user_id=user.id,
+                album_count=len(album_ids),
+                new_user=False,
+            )
         else:
             oauth = cast("OAuthIdentity", identity)
             user = User(
@@ -142,7 +147,12 @@ async def _finalize_upload(  # noqa: PLR0913
             await session.commit()
             login_session(request, user.id)
             clear_pending_signup(request)
-            logger.info("New user %d created via upload", user.id)
+            logger.info(
+                "upload.completed",
+                user_id=user.id,
+                album_count=len(album_ids),
+                new_user=True,
+            )
 
         target = user.folder
         if target.exists():
@@ -166,13 +176,13 @@ async def upload_data(
     existing, identity = await _resolve_auth(request, session)
 
     size = _check_upload_size(file)
-    logger.info("Extracting '%s' (%d MB)", file.filename, size // MiB)
+    logger.info("upload.extracting", size_mb=size // MiB)
     try:
         temp_folder, ps_user, trips = await asyncio.to_thread(
             extract_and_scan, file.file
         )
     except (BadZipFile, OSError, ValidationError) as e:
-        logger.warning("Bad ZIP upload '%s': %s", file.filename, e)
+        logger.warning("upload.bad_zip", error_type=type(e).__name__)
         raise HTTPException(status.HTTP_406_NOT_ACCEPTABLE, detail="Bad ZIP") from e
 
     return await _finalize_upload(
@@ -220,7 +230,9 @@ async def upload_chunk(
         await upload_store.write_chunk_stream(upload_id, chunk_index, request.stream())
     except ClientDisconnect:
         logger.info(
-            "Client disconnected during chunk %d of %s", chunk_index, upload_id[:8]
+            "upload.chunk_client_disconnected",
+            chunk_index=chunk_index,
+            upload_id_prefix=upload_id[:8],
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except KeyError:
@@ -267,7 +279,10 @@ async def complete_chunked_upload(
             extract_and_scan, assembled
         )
     except (BadZipFile, OSError, ValidationError) as e:
-        logger.warning("Bad ZIP from chunked upload %s: %s", upload_id[:8], e)
+        logger.warning(
+            "upload.bad_zip",
+            error_type=type(e).__name__,
+        )
         raise HTTPException(status.HTTP_406_NOT_ACCEPTABLE, detail="Bad ZIP") from e
     finally:
         assembled.close()
@@ -351,7 +366,7 @@ async def create_demo(
                 copy_function=_link_or_copy,
             )
         except OSError:
-            logger.exception("Demo copytree failed for user %d", uid)
+            logger.exception("demo.copy_failed", user_id=uid)
             await session.delete(user)
             await session.commit()
             raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE) from None
@@ -374,12 +389,12 @@ async def _remove_user(
         try:
             await http.gphotos_oauth.revoke_token(user.google_photos_refresh_token)
         except (RevokeTokenError, httpx.HTTPError) as exc:
-            logger.warning("Token revoke failed on delete: %s", type(exc).__name__)
+            logger.warning("oauth.token_revoke_failed", error_type=type(exc).__name__)
     await session.delete(user)
     await session.commit()
     await asyncio.to_thread(shutil.rmtree, folder, ignore_errors=True)
     request.session.clear()
-    logger.info("User %d deleted", user.id)
+    logger.info("user.deleted", user_id=user.id, is_demo=user.is_demo)
 
 
 @router.delete("/demo", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -6,16 +6,16 @@ re-encrypted before the previous key is dropped simply trip a reconnect.
 """
 
 import base64
-import logging
 from functools import cache
 
+import structlog
 from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from app.core.config import get_settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Salt and info are not secret: https://datatracker.ietf.org/doc/html/rfc5869#section-3.1
 _SALT = b"wanderbound-hkdf-v1"
@@ -54,5 +54,5 @@ def try_decrypt_token(ciphertext: str) -> str | None:
     try:
         return decrypt_token(ciphertext)
     except InvalidToken:
-        logger.warning("Failed to decrypt token - SECRET_KEY may have rotated")
+        logger.warning("token.decrypt_failed")
         return None

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -80,7 +80,7 @@ def setup_logging(*, use_console: bool, log_level: str = "INFO") -> None:
             structlog.stdlib.filter_by_level,
             *shared_processors,
             *exception_processors,
-            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            structlog.stdlib.render_to_log_kwargs,
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,

--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -35,6 +35,7 @@ SENTRY_INFO_LOG_EVENTS = {
     "google_photos.upgrade.completed",
     "pdf.generated",
     "processing.completed",
+    "route_enrichment.completed",
     "upload.completed",
 }
 
@@ -104,7 +105,7 @@ def _before_send_log(log: Log, _hint: Hint) -> Log | None:
     severity = log.get("severity_text")
     if severity in {"warn", "error", "fatal"}:
         return log
-    if severity == "info" and attrs.get("event") in SENTRY_INFO_LOG_EVENTS:
+    if severity == "info" and log.get("body") in SENTRY_INFO_LOG_EVENTS:
         return log
     return None
 

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import secrets
 import shutil
 import tempfile
@@ -7,7 +6,9 @@ from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 
 class TokenStore[T]:
@@ -66,4 +67,8 @@ class TokenStore[T]:
             data, _ = entry
             if self._on_evict:
                 self._on_evict(data)
-            logger.debug("Expired %s token %s", self._label, token[:8])
+            logger.debug(
+                "token.expired",
+                token_label=self._label,
+                token_prefix=token[:8],
+            )

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import logging
 import secrets
 import shutil
 import threading
@@ -11,10 +10,11 @@ from pathlib import Path
 from typing import BinaryIO
 
 import anyio
+import structlog
 
 from app.core.config import get_settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _UPLOAD_TTL = 3600  # 1 hour
 _CHUNK_LIMIT = 80 * 1024 * 1024 + 1024  # 80 MiB + 1 KiB margin
@@ -95,7 +95,7 @@ class UploadStore:
             max_chunks=max_chunks,
             owner=owner,
         )
-        logger.info("Upload session %s created", upload_id[:8])
+        logger.info("upload.session_created", upload_id_prefix=upload_id[:8])
         return upload_id
 
     async def write_chunk_stream(
@@ -205,7 +205,7 @@ class UploadStore:
         asyncio.get_running_loop().run_in_executor(
             None, lambda: shutil.rmtree(session.dir, ignore_errors=True)
         )
-        logger.info("Expired upload session %s", upload_id[:8])
+        logger.info("upload.session_expired", upload_id_prefix=upload_id[:8])
 
 
 upload_store = UploadStore()

--- a/backend/app/logic/eviction.py
+++ b/backend/app/logic/eviction.py
@@ -1,8 +1,8 @@
 import asyncio
-import logging
 import shutil
 from pathlib import Path
 
+import structlog
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -11,7 +11,7 @@ from app.core.db import get_engine
 from app.core.resources import MiB
 from app.models.user import User
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _sizes_by_user(users_folder: Path) -> tuple[int, dict[int, int]]:
@@ -45,9 +45,9 @@ async def run_eviction(skip_uid: int) -> None:
         return
 
     logger.info(
-        "Storage %d MB exceeds cap %d MB, starting eviction",
-        total // MiB,
-        cap // MiB,
+        "eviction.started",
+        storage_mb=total // MiB,
+        cap_mb=cap // MiB,
     )
 
     async with AsyncSession(get_engine()) as session:
@@ -67,6 +67,10 @@ async def run_eviction(skip_uid: int) -> None:
 
         await asyncio.to_thread(shutil.rmtree, user.folder, ignore_errors=True)
         total -= folder_size
-        logger.info("Evicted user %d folder (%d MB)", user.id, folder_size // MiB)
+        logger.info(
+            "eviction.user_removed",
+            user_id=user.id,
+            folder_size_mb=folder_size // MiB,
+        )
 
-    logger.info("Eviction complete, storage now %d MB", total // MiB)
+    logger.info("eviction.completed", storage_mb=total // MiB)

--- a/backend/app/logic/export.py
+++ b/backend/app/logic/export.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-import logging
 import threading
 import zipfile
 from collections.abc import AsyncGenerator, Callable
@@ -11,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
+import structlog
 from pydantic import BaseModel, Field
 from sqlmodel import col, select
 
@@ -24,7 +24,7 @@ from app.models.user import AuthProvider, User
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _EXPORT_NAME = "wanderbound-export"
 EXPORT_FILENAME = f"{_EXPORT_NAME}.zip"
@@ -174,10 +174,10 @@ async def _run_zip_thread(
             yield event
 
         token = _tokens.store(spec.dest)
-        logger.info("Data export ready: %d files", files_total)
+        logger.info("export.ready", files_total=files_total)
         yield ExportDone(token=token)
     except Exception:
-        logger.exception("Export failed")
+        logger.exception("export.failed")
         stop.set()
         spec.dest.unlink(missing_ok=True)
         yield ExportError()
@@ -193,7 +193,7 @@ async def export_user_data(
     user: User,
     session: AsyncSession,
 ) -> AsyncGenerator[ExportEvent]:
-    logger.info("Starting data export for user %d", user.id)
+    logger.info("export.started", user_id=user.id)
 
     albums = list((await session.exec(select(Album).where(Album.uid == user.id))).all())
     album_ids_loaded = [a.id for a in albums]

--- a/backend/app/logic/layout/builder.py
+++ b/backend/app/logic/layout/builder.py
@@ -1,9 +1,10 @@
-import logging
 from collections.abc import AsyncIterable, Iterable, Sequence
 from itertools import batched
 from math import ceil
 from pathlib import Path
 from typing import NamedTuple
+
+import structlog
 
 from app.core.async_helpers import yield_completed
 from app.core.worker_threads import run_sync
@@ -19,7 +20,7 @@ class Layout(NamedTuple):
     media: list[Media]
 
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _portrait_page_count(n: int) -> int:
@@ -159,7 +160,7 @@ async def build_step_layout(user: User, aid: str, step: PSStep) -> Layout | None
     ]
 
     if not portraits and not landscapes:
-        logger.debug("Step '%s' has no media files, skipping layout", step.name)
+        logger.debug("layout.no_media", step_name=step.name)
         return None
 
     cover = portraits[0] if portraits else landscapes[0]

--- a/backend/app/logic/layout/media.py
+++ b/backend/app/logic/layout/media.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 from io import BytesIO
@@ -7,6 +6,7 @@ from typing import Annotated, Self
 
 import anyio
 import av
+import structlog
 from PIL import Image, ImageOps
 from PIL.Image import Resampling
 from pydantic import BaseModel, StringConstraints
@@ -18,7 +18,7 @@ from app.core.worker_threads import run_sync
 # https://ffmpeg.org/doxygen/trunk/pixfmt_8h.html
 HDR_COLOR_TRC = frozenset({16, 18})
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 MEDIA_EXTENSIONS = frozenset({".jpg", ".mp4"})
 # Must match frontend utils/media.ts THUMB_WIDTHS - frontend builds srcset from these.
@@ -97,7 +97,13 @@ def _probe_video_dimensions_sync(path: Path) -> tuple[int, int]:
             break
     if rotation in (90, 270):
         w, h = h, w
-    logger.debug("av probe %s: %dx%d (rotation=%d)", path.name, w, h, rotation)
+    logger.debug(
+        "media.video_probed",
+        media_name=path.name,
+        width=w,
+        height=h,
+        rotation=rotation,
+    )
     return w, h
 
 

--- a/backend/app/logic/media_upgrade/phash_matching.py
+++ b/backend/app/logic/media_upgrade/phash_matching.py
@@ -5,7 +5,6 @@ originals using perceptual hashing (pHash) and the Hungarian algorithm
 for optimal bipartite assignment.
 """
 
-import logging
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -22,8 +21,6 @@ from scipy.optimize import linear_sum_assignment
 
 from app.logic.layout.media import MediaName, is_video, open_oriented
 from app.models.google_photos import GoogleMediaId, PickedMediaItem
-
-logger = logging.getLogger(__name__)
 
 # Hamming distance threshold for accepting a pHash match.
 # pHash produces a 64-bit hash; distance 0 = identical, 64 = maximally different.

--- a/backend/app/logic/media_upgrade/pipeline.py
+++ b/backend/app/logic/media_upgrade/pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import logging
 import shutil
 import subprocess
 from collections.abc import AsyncGenerator, AsyncIterator
@@ -14,6 +13,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 
 import anyio
 import httpx
+import structlog
 from httpx_oauth.oauth2 import RefreshTokenError
 from pydantic import BaseModel, Field, validate_call
 from sqlalchemy.exc import SQLAlchemyError
@@ -55,7 +55,7 @@ from .processing import (
     tmp_file,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _UPGRADE_TMP_DIR = ".upgrade-tmp"
 
@@ -123,7 +123,10 @@ async def _hash_local_one(album_dir: Path, name: str) -> tuple[str, MediaHash | 
         )
     # Pillow raises SyntaxError on corrupt/truncated image headers.
     except OSError, SyntaxError, subprocess.SubprocessError:
-        logger.warning("Failed to hash %s", name, exc_info=True)
+        logger.warning(
+            "media_upgrade.local_hash_failed",
+            exc_info=True,
+        )
         return name, None
 
 
@@ -144,8 +147,7 @@ async def _hash_candidate_one(
         )
     except OSError, SyntaxError, httpx.HTTPError:
         logger.warning(
-            "Failed to download/hash thumbnail for %s",
-            item.id,
+            "media_upgrade.candidate_hash_failed",
             exc_info=True,
         )
         return item.id, None
@@ -317,15 +319,18 @@ async def _persist_upgrade(
             await session.commit()
     except SQLAlchemyError:
         logger.warning(
-            "Failed to persist upgrade results - filesystem ahead of DB, "
-            "will self-heal on next upgrade attempt",
+            "media_upgrade.persist_failed",
             exc_info=True,
-            extra={"uid": uid, "aid": aid, "replaced": replaced},
+            user_id=uid,
+            album_id=aid,
+            replaced=replaced,
         )
         return
     logger.info(
-        "Persisted upgrade results",
-        extra={"uid": uid, "aid": aid, "replaced": replaced},
+        "google_photos.upgrade.completed",
+        user_id=uid,
+        album_id=aid,
+        replaced=replaced,
     )
 
 
@@ -338,13 +343,13 @@ async def _cleanup_picker_sessions(
     try:
         access_token = await tokens()
     except httpx.HTTPError, RefreshTokenError:
-        logger.warning("Skipping picker session cleanup - token unavailable")
+        logger.warning("google_photos.picker_cleanup_token_unavailable")
         return
     for sid in session_ids:
         try:
             await delete_picker_session(picker, sid, access_token)
         except httpx.HTTPError:
-            logger.warning("Failed to delete picker session %s", sid)
+            logger.warning("google_photos.picker_session_delete_failed")
 
 
 def _needs_upgrade(
@@ -411,7 +416,7 @@ async def run_upgrade(  # noqa: PLR0913, C901
                     RuntimeError,
                     subprocess.SubprocessError,
                 ):
-                    logger.exception("Failed to upgrade %s", match.local_name)
+                    logger.exception("media_upgrade.item_failed")
                     return None
                 if replaced:
                     return match.local_name
@@ -438,9 +443,8 @@ async def run_upgrade(  # noqa: PLR0913, C901
         ]
         if failed_names:
             logger.warning(
-                "Upgrade completed with %d failures: %s",
-                len(failed_names),
-                ", ".join(failed_names),
+                "media_upgrade.completed_with_failures",
+                failed=len(failed_names),
             )
         yield UpgradeCompleted(
             replaced=len(succeeded),
@@ -449,7 +453,9 @@ async def run_upgrade(  # noqa: PLR0913, C901
         )
     except Exception as exc:  # noqa: BLE001
         logger.error(  # noqa: TRY400
-            "Upgrade failed for album %s: %s: %s", aid, type(exc).__name__, exc
+            "media_upgrade.failed",
+            album_id=aid,
+            error_type=type(exc).__name__,
         )
         yield UpgradeFailed(detail="Upgrade failed unexpectedly.")
     finally:
@@ -485,7 +491,10 @@ async def refresh_upgraded_media(
                 updated = await run_sync(Media.load, target, limiter=media_limiter)
             media_by_name[match.local_name] = updated
         except OSError, SyntaxError, RuntimeError:
-            logger.warning("Failed to re-probe %s", match.local_name, exc_info=True)
+            logger.warning(
+                "media_upgrade.reprobe_failed",
+                exc_info=True,
+            )
             continue
         new_upgraded[match.local_name] = match.google_id
     return list(media_by_name.values()), new_upgraded
@@ -503,7 +512,7 @@ async def cleanup_orphaned_tmp(users_folder: Path) -> None:
 
     removed = await run_sync(_scan_and_remove)
     if removed:
-        logger.info("Cleaned up %d orphaned upgrade-tmp dirs", removed)
+        logger.info("media_upgrade.orphan_tmp_cleaned", removed=removed)
 
 
 def _clear_caches() -> None:

--- a/backend/app/logic/media_upgrade/processing.py
+++ b/backend/app/logic/media_upgrade/processing.py
@@ -1,7 +1,6 @@
 """Normalize downloaded originals: photos to JPEG, videos to H.264 (HDR→SDR)."""
 
 import asyncio
-import logging
 import shutil
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -11,6 +10,7 @@ import anyio
 import av
 import imagehash
 import pillow_heif  # noqa: F401 - registers HEIC plugin for Pillow
+import structlog
 from PIL.Image import Resampling
 
 from app.core.worker_threads import run_sync
@@ -24,7 +24,7 @@ from app.logic.layout.media import (
     open_oriented,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _MAX_LONG_EDGE = 3000
 _JPEG_QUALITY = 85
@@ -164,12 +164,12 @@ def extract_video_frame_hashes(path: Path) -> list[imagehash.ImageHash]:
 def _skip_smaller(name: str, new_w: int, new_h: int, existing: Media) -> bool:
     if new_w * new_h <= existing.width * existing.height:
         logger.info(
-            "Skipping %s: original (%dx%d) not larger than existing (%dx%d)",
-            name,
-            new_w,
-            new_h,
-            existing.width,
-            existing.height,
+            "media_upgrade.skipped_smaller",
+            media_name=name,
+            new_width=new_w,
+            new_height=new_h,
+            existing_width=existing.width,
+            existing_height=existing.height,
         )
         return True
     return False
@@ -185,7 +185,11 @@ async def replace_video(
         try:
             existing = await Media.probe(target)
         except RuntimeError, OSError:
-            logger.debug("Could not probe existing video %s", name, exc_info=True)
+            logger.debug(
+                "media_upgrade.existing_video_probe_failed",
+                media_name=name,
+                exc_info=True,
+            )
             existing = None
         if existing and _skip_smaller(
             name, new_media.width, new_media.height, existing
@@ -202,7 +206,10 @@ async def replace_video(
             await run_sync(delete_thumbnails, poster)
         await extract_frame(target)
     except OSError:
-        logger.warning("Thumbnail cleanup failed for %s", name, exc_info=True)
+        logger.warning(
+            "media_upgrade.thumbnail_cleanup_failed",
+            exc_info=True,
+        )
     return True
 
 
@@ -217,7 +224,11 @@ async def replace_photo(
         try:
             existing = await run_sync(Media.load, target, limiter=media_limiter)
         except OSError, SyntaxError:
-            logger.debug("Could not load existing photo %s", name, exc_info=True)
+            logger.debug(
+                "media_upgrade.existing_photo_load_failed",
+                media_name=name,
+                exc_info=True,
+            )
             existing = None
         if existing and _skip_smaller(name, width, height, existing):
             return False

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -1,11 +1,11 @@
 import asyncio
 import base64
-import logging
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import aclosing, asynccontextmanager, suppress
 from pathlib import Path
 from typing import Annotated, ClassVar, Literal
 
+import structlog
 from playwright.async_api import Browser, Page, Playwright, async_playwright
 from pydantic import BaseModel, Field
 
@@ -13,7 +13,7 @@ from app.core.config import get_settings
 from app.core.resources import MiB, detect_memory_mb
 from app.core.tokens import TokenStore
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _PDF_BASELINE_MB = 512
 _PER_RENDER_MB = 768
@@ -78,16 +78,16 @@ class BrowserManager:
 
     async def launch(self) -> None:
         self._browser = await self._pw.chromium.launch(args=self._LAUNCH_ARGS)
-        logger.info("Playwright browser launched")
+        logger.info("playwright.browser_launched")
 
     async def get(self) -> Browser:
         if self._browser is not None and self._browser.is_connected():
             return self._browser
         async with self._lock:
             if self._browser is None or not self._browser.is_connected():
-                logger.warning("Playwright browser disconnected, relaunching")
+                logger.warning("playwright.browser_disconnected")
                 self._browser = await self._pw.chromium.launch(args=self._LAUNCH_ARGS)
-                logger.info("Playwright browser relaunched")
+                logger.info("playwright.browser_relaunched")
         return self._browser
 
     @property
@@ -111,7 +111,7 @@ async def lifespan() -> AsyncGenerator[BrowserManager]:
         finally:
             await manager.close()
             await pw.stop()
-            logger.info("Playwright browser closed")
+            logger.info("playwright.browser_closed")
 
 
 def store_pdf_token(path: Path, aid: str) -> str:
@@ -189,10 +189,13 @@ async def _render_pdf(  # noqa: C901
             ]
         )
         page = await context.new_page()
-        page.on("console", lambda msg: logger.debug("Browser: %s", msg.text))
+        page.on("console", lambda msg: logger.debug("browser.console", text=msg.text))
         page.on(
             "pageerror",
-            lambda err: logger.warning("Browser page error during PDF render: %s", err),
+            lambda err: logger.warning(
+                "pdf.browser_page_error",
+                error_type=type(err).__name__,
+            ),
         )
         started, finished = 0, 0
 
@@ -211,7 +214,7 @@ async def _render_pdf(  # noqa: C901
         dark_param = "true" if dark else "false"
         url = f"{frontend_url}/print/{aid}?dark={dark_param}"
         await page.goto(url, wait_until="domcontentloaded")
-        logger.info("DOM loaded for album %s", aid)
+        logger.info("pdf.dom_loaded", album_id=aid)
         loop = asyncio.get_running_loop()
         deadline = loop.time() + 60
         last_counts = (-1, -1)
@@ -240,7 +243,7 @@ async def _render_pdf(  # noqa: C901
                     yield PdfProgress(phase="rendering", done=size)
                     last_reported = size
         yield PdfProgress(phase="rendering", done=size)
-        logger.info("PDF generated for album %s: %d bytes", aid, size)
+        logger.info("pdf.generated", album_id=aid, size_bytes=size)
 
     finally:
         await context.close()
@@ -254,14 +257,18 @@ async def render_album_pdf_stream(
     dark: bool = True,
 ) -> AsyncIterator[PdfEvent]:
     """Top-level SSE generator: queued -> loading -> rendering -> done/error."""
-    logger.info("PDF render queued for album %s", aid)
+    logger.info("pdf.render_queued", album_id=aid)
     yield PdfQueued()
 
     try:
         async with asyncio.timeout(_QUEUE_TIMEOUT):
             await _render_sem.acquire()
     except TimeoutError:
-        logger.warning("PDF queue timeout for album %s after %ds", aid, _QUEUE_TIMEOUT)
+        logger.warning(
+            "pdf.queue_timeout",
+            album_id=aid,
+            timeout_s=_QUEUE_TIMEOUT,
+        )
         yield PdfError(
             detail="Timed out waiting for a PDF render slot. Please try again."
         )
@@ -295,11 +302,13 @@ async def render_album_pdf_stream(
 
     except TimeoutError:
         logger.warning(
-            "PDF render timeout for album %s after %ds", aid, _RENDER_TIMEOUT
+            "pdf.render_timeout",
+            album_id=aid,
+            timeout_s=_RENDER_TIMEOUT,
         )
         yield PdfError(detail="PDF rendering timed out. Please try again.")
     except Exception:
-        logger.exception("PDF generation failed for album %s", aid)
+        logger.exception("pdf.generation_failed", album_id=aid)
         yield PdfError(detail="PDF generation failed. Please try again.")
     finally:
         if not owned:

--- a/backend/app/logic/reconcile.py
+++ b/backend/app/logic/reconcile.py
@@ -5,9 +5,10 @@ with potentially changed media on disk after a re-upload.
 """
 
 import asyncio
-import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
+
+import structlog
 
 from app.core.http_clients import HttpClients
 from app.core.worker_threads import run_sync
@@ -36,7 +37,7 @@ from app.models.polarsteps import PSStep
 from app.models.step import Step
 from app.models.user import User
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _scan_step_media(trip_dir: Path, ps_step: PSStep) -> set[str]:
@@ -153,7 +154,11 @@ async def _process_new_steps(  # noqa: PLR0913
     step_out: list[Step],
 ) -> AsyncIterator[PhaseUpdate]:
     """Run full processing (elevations, weather, layouts) for new steps."""
-    logger.info("Processing %d new steps for album %s", len(new_ps_steps), aid)
+    logger.info(
+        "processing.reconcile_new_steps",
+        album_id=aid,
+        step_count=len(new_ps_steps),
+    )
     queue: asyncio.Queue[PhaseUpdate | None] = asyncio.Queue()
     n_new = len(new_ps_steps)
     new_locs = [s.location for s in new_ps_steps]
@@ -217,10 +222,10 @@ async def reconcile_trip(  # noqa: PLR0913
     aid = trip_dir.name
     trip, locations = await asyncio.to_thread(load_trip_data, trip_dir)
     logger.info(
-        "Reconciling '%s' with %d steps (%d existing)",
-        trip.title,
-        trip.step_count,
-        len(existing_steps),
+        "processing.reconcile_started",
+        album_id=aid,
+        step_count=trip.step_count,
+        existing_step_count=len(existing_steps),
     )
 
     # Phase 1: Build step->media map BEFORE flattening (concurrent scans)

--- a/backend/app/logic/segment_routes.py
+++ b/backend/app/logic/segment_routes.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import structlog
 from sqlalchemy import String, cast, or_, update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from fastapi import BackgroundTasks
     from sqlalchemy.sql.elements import ColumnElement
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 type SegmentKey = tuple[int, str, float, float]
 type SegmentSnapshot = tuple[SegmentKey, list[tuple[float, float]], str]
@@ -74,7 +74,9 @@ async def match_album_segment_routes(http: HttpClients, uid: int, aid: str) -> N
         async with try_advisory_lock(lock_key) as acquired:
             if not acquired:
                 logger.info(
-                    "Route enrichment already running for uid=%s aid=%s", uid, aid
+                    "route_enrichment.already_running",
+                    user_id=uid,
+                    album_id=aid,
                 )
                 return
 
@@ -103,10 +105,10 @@ async def match_album_segment_routes(http: HttpClients, uid: int, aid: str) -> N
                 _log_complete(uid, aid, started, stats)
     except Exception:
         logger.exception(
-            "Route enrichment failed for uid=%s aid=%s duration_ms=%d",
-            uid,
-            aid,
-            _duration_ms(started),
+            "route_enrichment.failed",
+            user_id=uid,
+            album_id=aid,
+            duration_ms=_duration_ms(started),
         )
 
 
@@ -121,20 +123,18 @@ def _log_complete(
     stats: RouteEnrichmentStats,
 ) -> None:
     logger.info(
-        "Route enrichment complete uid=%s aid=%s candidates=%d matched=%d "
-        "updated=%d skipped=%d stale=%d route_requests=%d "
-        "matching_requests=%d directions_requests=%d duration_ms=%d",
-        uid,
-        aid,
-        stats.candidates,
-        stats.matched,
-        stats.updated,
-        stats.skipped,
-        stats.stale,
-        stats.route_requests,
-        stats.matching_requests,
-        stats.directions_requests,
-        _duration_ms(started),
+        "route_enrichment.completed",
+        user_id=uid,
+        album_id=aid,
+        candidates=stats.candidates,
+        matched=stats.matched,
+        updated=stats.updated,
+        skipped=stats.skipped,
+        stale=stats.stale,
+        route_requests=stats.route_requests,
+        matching_requests=stats.matching_requests,
+        directions_requests=stats.directions_requests,
+        duration_ms=_duration_ms(started),
     )
 
 

--- a/backend/app/logic/session.py
+++ b/backend/app/logic/session.py
@@ -6,8 +6,9 @@ enabling reconnection without restarting work.
 """
 
 import asyncio
-import logging
 from collections.abc import AsyncIterator
+
+import structlog
 
 from app.core.http_clients import HttpClients
 from app.logic.segment_routes import schedule_album_route_enrichment
@@ -15,7 +16,7 @@ from app.logic.trip_pipeline import run_processing
 from app.logic.trip_processing import ErrorData, ProcessingEvent
 from app.models.user import User
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _SESSION_TTL = 300  # seconds before a completed session is evicted
 
@@ -42,7 +43,7 @@ class ProcessingSession:
                 for aid in user.album_ids:
                     schedule_album_route_enrichment(http, self._uid, aid)
         except Exception:
-            logger.exception("Processing task crashed for user %d", self._uid)
+            logger.exception("processing.task_crashed", user_id=self._uid)
             # Surface the crash to subscribers; without this the stream ends
             # silently and the UI can't distinguish success from failure.
             self._events.append(ErrorData())
@@ -105,7 +106,7 @@ def cancel_session(uid: int) -> None:
     session = _sessions.pop(uid, None)
     if session is not None and not session.is_done:
         session.cancel()
-        logger.info("Cancelled processing session for user %d", uid)
+        logger.info("processing.session_cancelled", user_id=uid)
 
 
 async def process_stream(
@@ -121,13 +122,13 @@ async def process_stream(
 
     if session is not None and not (session.is_done and session.had_error):
         if not session.is_done:
-            logger.info("User %d reconnecting to active processing session", user.id)
+            logger.info("processing.session_reconnected", user_id=user.id)
         async for event in session.subscribe():
             yield event
         return
 
     if session is not None:
-        logger.info("User %d retrying after failed processing session", user.id)
+        logger.info("processing.session_retried", user_id=user.id)
 
     session = ProcessingSession(http, user)
     _sessions[user.id] = session

--- a/backend/app/logic/spatial/peaks.py
+++ b/backend/app/logic/spatial/peaks.py
@@ -1,8 +1,8 @@
-import logging
 from collections.abc import Iterable, Sequence
 from typing import Annotated
 
 import httpx
+import structlog
 from pydantic import BaseModel, BeforeValidator, ValidationError
 
 from app.models.polarsteps import HasLatLon
@@ -11,7 +11,7 @@ PEAK_MIN_PROMINENCE = 300
 PEAK_SEARCH_RADIUS = 500
 PEAK_MAX_DEVIATION = 0.1
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _parse_ele(v: str | float) -> float:
@@ -66,7 +66,7 @@ async def correct_peaks(
         for loc in high_locs
     )
     query = f"[out:json][timeout:10];({around_clauses});out;"
-    logger.debug("Overpass query for %d peaks: %s", len(high_indices), query)
+    logger.debug("overpass.peak_query", peak_count=len(high_indices))
     try:
         response = await client.post(
             "https://overpass-api.de/api/interpreter", data={"data": query}
@@ -74,13 +74,13 @@ async def correct_peaks(
         response.raise_for_status()
         osm = OverpassResponse.model_validate_json(response.content)
     except (httpx.HTTPError, ValidationError) as exc:
-        logger.warning("Overpass peak query failed: %s", exc)
+        logger.warning("overpass.peak_query_failed", error_type=type(exc).__name__)
         return elevs
 
     logger.debug(
-        "Overpass returned %d elements for %d local peaks",
-        len(osm.elements),
-        len(high_indices),
+        "overpass.peak_query_returned",
+        element_count=len(osm.elements),
+        peak_count=len(high_indices),
     )
     if not osm.elements:
         return elevs
@@ -95,10 +95,9 @@ async def correct_peaks(
         deviation = (best.tags.ele - dem) / dem
         if deviation <= PEAK_MAX_DEVIATION:
             logger.debug(
-                "Corrected step %s: %dm -> %dm",
-                best.tags.name or locs[i],
-                int(dem),
-                int(best.tags.ele),
+                "overpass.elevation_corrected",
+                old_elevation_m=int(dem),
+                new_elevation_m=int(best.tags.ele),
             )
             result[i] = best.tags.ele
 

--- a/backend/app/logic/spatial/segments.py
+++ b/backend/app/logic/spatial/segments.py
@@ -23,7 +23,6 @@ DataFrame columns through the pipeline::
     output_id        RLE group ID on final_mode
 """
 
-import logging
 import math
 from collections import Counter
 from collections.abc import Iterable, Sequence
@@ -32,6 +31,7 @@ from typing import Protocol, cast
 
 import numpy as np
 import polars as pl
+import structlog
 from simplification.cutil import simplify_coords_idx
 
 from app.logic.spatial.geo import EARTH_RADIUS_KM
@@ -48,7 +48,7 @@ class _StepLike(Protocol):
     def datetime(self) -> datetime: ...
 
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Edge classification
 # GPS underreports speed on winding trails (~6.5 km/h vs ~8 km/h actual).
@@ -573,14 +573,14 @@ def build_segments(
         return iter([])
 
     logger.info(
-        "build_segments: %d step(s), window %s -> %s",
-        len(steps),
-        steps[0].datetime.strftime("%Y-%m-%d"),
-        steps[-1].datetime.strftime("%Y-%m-%d"),
+        "segments.build_started",
+        step_count=len(steps),
+        start_date=steps[0].datetime.strftime("%Y-%m-%d"),
+        end_date=steps[-1].datetime.strftime("%Y-%m-%d"),
     )
 
     df = _ingest(steps, locations)
-    logger.debug("Ingested %d points after noise removal", df.height)
+    logger.debug("segments.points_ingested", point_count=df.height)
 
     if df.is_empty():
         return iter([])
@@ -591,8 +591,6 @@ def build_segments(
     segments = list(_emit_segments(df, steps))
 
     counts = Counter(seg.kind for seg in segments)
-    logger.debug(
-        "Segments: %s", ", ".join(f"{k} {v}" for k, v in sorted(counts.items()))
-    )
+    logger.debug("segments.built", counts=dict(sorted(counts.items())))
 
     return segments

--- a/backend/app/logic/trip_pipeline.py
+++ b/backend/app/logic/trip_pipeline.py
@@ -1,11 +1,11 @@
 import asyncio
-import logging
 import shutil
 import time
 from collections import defaultdict
 from collections.abc import AsyncIterator
 from pathlib import Path
 
+import structlog
 from sqlalchemy import delete
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import col, select
@@ -37,7 +37,7 @@ from app.models.segment import Segment
 from app.models.step import Step
 from app.models.user import User
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _POLARSTEPS_METADATA = {"trip.json", "locations.json"}
 
@@ -50,7 +50,7 @@ def _cleanup_metadata(user_folder: Path, trip_dirs: list[Path]) -> None:
 
     shutil.rmtree(user_folder / "user", ignore_errors=True)
 
-    logger.debug("Cleaned up Polarsteps metadata for %s", user_folder.name)
+    logger.debug("processing.metadata_cleaned", user_folder=user_folder.name)
 
 
 async def _process_trip(
@@ -61,7 +61,11 @@ async def _process_trip(
 ) -> AsyncIterator[ProcessingEvent]:
     aid = trip_dir.name
     trip, locations = await asyncio.to_thread(load_trip_data, trip_dir)
-    logger.info("Processing '%s' with %d steps...", trip.title, trip.step_count)
+    logger.info(
+        "processing.trip_started",
+        album_id=aid,
+        step_count=trip.step_count,
+    )
     locs = [s.location for s in trip.all_steps]
 
     queue: asyncio.Queue[PhaseUpdate | None] = asyncio.Queue()
@@ -135,7 +139,12 @@ async def _save_new(
     async with AsyncSession(get_engine()) as session:
         session.add_all(objects)
         await session.commit()
-    logger.info("Saved %d objects for new user %d", len(objects), uid)
+    logger.info(
+        "processing.db_saved",
+        user_id=uid,
+        object_count=len(objects),
+        new_user=True,
+    )
 
 
 async def _save_reupload(
@@ -171,7 +180,12 @@ async def _save_reupload(
         for obj in objects:
             await session.merge(obj)
         await session.commit()
-    logger.info("Saved %d objects for re-upload user %d", len(objects), uid)
+    logger.info(
+        "processing.db_saved",
+        user_id=uid,
+        object_count=len(objects),
+        new_user=False,
+    )
 
 
 def _apply_demo_i18n(user: User, all_objects: list[DbRow]) -> None:
@@ -192,7 +206,7 @@ def _apply_demo_i18n(user: User, all_objects: list[DbRow]) -> None:
     for album in albums:
         apply_overlay(overlay, album, steps_by_aid.get(album.id, []))
 
-    logger.info("Applied %s i18n overlay for demo user %d", user.locale, user.id)
+    logger.info("demo.i18n_overlay_applied", user_id=user.id, locale=user.locale)
 
 
 async def run_processing(
@@ -224,7 +238,7 @@ async def run_processing(
                 async for event in _process_trip(http, user, trip_dir, all_objects):
                     yield event
     except Exception:
-        logger.exception("Processing failed for user %d", user.id)
+        logger.exception("processing.failed", user_id=user.id)
         yield ErrorData()
         return
 
@@ -238,13 +252,13 @@ async def run_processing(
         else:
             await _save_new(user.id, all_objects)
     except SQLAlchemyError:
-        logger.exception("DB save failed for user %d", user.id)
+        logger.exception("processing.db_save_failed", user_id=user.id)
         yield ErrorData()
         return
     await asyncio.to_thread(_cleanup_metadata, user.folder, trip_dirs)
     logger.info(
-        "Processing complete for user %d: %d trips in %.1fs",
-        user.id,
-        len(trip_dirs),
-        time.monotonic() - t0,
+        "processing.completed",
+        user_id=user.id,
+        trip_count=len(trip_dirs),
+        duration_s=time.monotonic() - t0,
     )

--- a/backend/app/logic/trip_processing.py
+++ b/backend/app/logic/trip_processing.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import logging
 from collections import Counter, defaultdict
 from collections.abc import AsyncIterator, Iterable, Sequence
 from datetime import date, datetime
@@ -8,6 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal, NamedTuple
 from zoneinfo import ZoneInfo
 
+import structlog
 from pydantic import BaseModel, Field
 
 from app.core.async_helpers import yield_completed
@@ -30,7 +30,7 @@ from app.models.user import User
 from app.models.weather import Weather
 from app.services.open_meteo import build_weathers, elevations
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 type ProcessingPhase = Literal["elevations", "weather", "layouts", "segments"]
 type DbRow = Album | Step | Segment
@@ -420,14 +420,11 @@ def resolve_international_waters(steps: list[PSStep]) -> None:
             continue
 
         if run and prev_code is not None and step.location.country_code != prev_code:
-            names = ", ".join(s.name for s in run)
             logger.warning(
-                "International-water steps [%s] attributed to %s, "
-                "but next step '%s' is %s",
-                names,
-                prev_code.upper(),
-                step.name,
-                step.location.country_code.upper(),
+                "segments.international_water_attribution_ambiguous",
+                step_count=len(run),
+                attributed_country=prev_code.upper(),
+                next_country=step.location.country_code.upper(),
             )
         run.clear()
         prev_code = step.location.country_code

--- a/backend/app/logic/upload.py
+++ b/backend/app/logic/upload.py
@@ -1,4 +1,3 @@
-import logging
 import shutil
 import tempfile
 import zipfile
@@ -11,8 +10,6 @@ from pydantic import BaseModel
 from app.core.config import get_settings
 from app.models.polarsteps import CountryCode, PSTrip
 from app.models.user import PSUser, UserPublic
-
-logger = logging.getLogger(__name__)
 
 # Python 3.12+ zipfile already detects quoted-overlap zip bombs (CVE-2024-0450).
 # These limits guard against decompression bombs and excessive file counts.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,9 @@
-import logging
 import shutil
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+import structlog
 from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -29,7 +29,7 @@ settings = get_settings()
 setup_logging(use_console=settings.ENVIRONMENT == "local", log_level=settings.LOG_LEVEL)
 setup_sentry(settings)
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -45,9 +45,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Probing moved to PyAV; ffprobe is no longer needed.
     path = shutil.which("ffmpeg")
     if path:
-        logger.info("ffmpeg available at %s", path)
+        logger.info("ffmpeg.available", path=path)
     else:
-        logger.warning("ffmpeg not found on PATH - video features will fail")
+        logger.warning("ffmpeg.missing")
 
     async with (
         pdf_lifespan() as browser_manager,
@@ -95,11 +95,15 @@ app.include_router(v1_router, prefix=settings.API_V1_STR)
 
 @app.exception_handler(NoResultFound)
 async def _not_found(request: Request, _exc: NoResultFound) -> JSONResponse:
-    logger.debug("Not found: %s %s", request.method, request.url.path)
+    logger.debug("request.not_found", method=request.method, path=request.url.path)
     return JSONResponse({"detail": "Not found"}, status_code=404)
 
 
 @app.exception_handler(Exception)
 async def _unhandled_exception(request: Request, exc: Exception) -> JSONResponse:
-    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    logger.exception(
+        "request.unhandled_exception",
+        method=request.method,
+        path=request.url.path,
+    )
     return JSONResponse({"detail": "Internal server error"}, status_code=500)

--- a/backend/app/services/google_photos.py
+++ b/backend/app/services/google_photos.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import structlog
 from httpx_oauth.clients.google import GoogleOAuth2
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
@@ -28,7 +28,7 @@ from app.models.google_photos import (
     VideoProcessingStatus,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _PICKER_BASE = "https://photospicker.googleapis.com"
 _SCOPE = "https://www.googleapis.com/auth/photospicker.mediaitems.readonly"
@@ -226,10 +226,9 @@ async def get_media_items(
         page_token = page.next_page_token
     else:
         logger.warning(
-            "Hit %d-page limit for session %s (%d items fetched)",
-            _MAX_MEDIA_PAGES,
-            session_id,
-            len(items),
+            "google_photos.media_page_limit_hit",
+            max_pages=_MAX_MEDIA_PAGES,
+            item_count=len(items),
         )
     return items
 
@@ -245,9 +244,8 @@ async def delete_picker_session(
     )
     if resp.status_code not in (200, 204, 404):
         logger.warning(
-            "Failed to delete Picker session %s: %d",
-            session_id,
-            resp.status_code,
+            "google_photos.picker_session_delete_failed",
+            status_code=resp.status_code,
         )
 
 

--- a/backend/app/services/mapbox.py
+++ b/backend/app/services/mapbox.py
@@ -5,12 +5,12 @@ Rate-limited to stay under Mapbox free-tier limits (60 req/min).
 """
 
 import asyncio
-import logging
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Literal
 
 import httpx
+import structlog
 from pydantic import BaseModel
 
 from app.core.config import get_settings
@@ -22,7 +22,7 @@ from app.logic.route_matching import (
     total_length_km,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 type Profile = str  # "driving" or "walking"
 type MapboxClient = httpx.AsyncClient
@@ -77,7 +77,7 @@ def _encode_coords(coords: Coords) -> str:
 def _token() -> str | None:
     token = get_settings().VITE_MAPBOX_TOKEN
     if not token:
-        logger.warning("No VITE_MAPBOX_TOKEN configured, skipping matching")
+        logger.warning("mapbox.token_missing")
     return token
 
 
@@ -103,7 +103,10 @@ async def _fetch_matching(
         )
         resp.raise_for_status()
     except httpx.HTTPStatusError as e:
-        logger.warning("Matching API error: %s", e.response.status_code)
+        logger.warning(
+            "mapbox.matching_api_error",
+            status_code=e.response.status_code,
+        )
         return None
     data = _MatchingResponse.model_validate_json(resp.content)
     if not data.matchings:
@@ -135,7 +138,10 @@ async def _fetch_directions(
         )
         resp.raise_for_status()
     except httpx.HTTPStatusError as e:
-        logger.warning("Directions API error: %s", e.response.status_code)
+        logger.warning(
+            "mapbox.directions_api_error",
+            status_code=e.response.status_code,
+        )
         return None
     data = _DirectionsResponse.model_validate_json(resp.content)
     if not data.routes:
@@ -208,21 +214,21 @@ async def _match_one(
 
     if raw is None:
         logger.debug(
-            "Matching failed for %s segment (%d pts)",
-            profile,
-            len(points_lonlat),
+            "mapbox.segment_match_failed",
+            profile=profile,
+            point_count=len(points_lonlat),
         )
         return None
 
     span = total_length_km(points_lonlat)
     simplified = simplify_route(raw, span)
     logger.debug(
-        "Matched %s segment: %d GPS → %d matched → %d simplified (%.1f km)",
-        profile,
-        len(points_lonlat),
-        len(raw),
-        len(simplified),
-        span,
+        "mapbox.segment_matched",
+        profile=profile,
+        point_count=len(points_lonlat),
+        matched_point_count=len(raw),
+        simplified_point_count=len(simplified),
+        length_km=span,
     )
     return simplified
 

--- a/backend/tests/test_trip_processing.py
+++ b/backend/tests/test_trip_processing.py
@@ -2,12 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import pytest
-
 from app.logic.trip_processing import (
     resolve_international_waters,
     segment_timezone,
@@ -50,21 +44,15 @@ class TestResolveInternationalWaters:
         assert steps[1].location.country_code == "it"
         assert steps[2].location.country_code == "it"
 
-    def test_warns_when_next_country_differs(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_attribution_when_next_country_differs(self) -> None:
         steps = [
             _step("Piraeus", "GR", 1),
             _step("At Sea", "00", 2),
             _step("Kusadasi", "TR", 3),
         ]
-        with caplog.at_level(logging.WARNING):
-            resolve_international_waters(steps)
+        resolve_international_waters(steps)
 
         assert steps[1].location.country_code == "gr"
-        assert "At Sea" in caplog.text
-        assert "GR" in caplog.text
-        assert "TR" in caplog.text
 
     def test_leading_zeros_unchanged(self) -> None:
         steps = [

--- a/frontend/src/pages/PrintView.vue
+++ b/frontend/src/pages/PrintView.vue
@@ -57,7 +57,6 @@ async function loadFonts(): Promise<void> {
   }
   if (faces.length) {
     await Promise.all(faces);
-    console.log("[print] loaded", faces.length, "font faces");
   } else {
     console.warn(
       "[print] no self-hosted font faces found - falling back to document.fonts.ready",
@@ -105,7 +104,6 @@ function waitForPrintReady() {
     const expected = parseInt(container.dataset.expectedPages || "0", 10);
     const actual = container.querySelectorAll(".page-container").length;
     if (actual < expected) {
-      console.log("[print] pages:", actual, "/", expected);
       schedulePoll(500);
       return;
     }
@@ -114,7 +112,6 @@ function waitForPrintReady() {
       document.querySelectorAll<HTMLImageElement>("[data-media] img"),
     ).filter((img) => !img.complete);
     if (pending.length > 0) {
-      console.log("[print]", pending.length, "images still loading");
       schedulePoll(300);
       return;
     }
@@ -124,17 +121,14 @@ function waitForPrintReady() {
       "[data-map]:not([data-map-ready])",
     );
     if (unreadyMaps.length > 0) {
-      console.log("[print]", unreadyMaps.length, "maps still rendering");
       schedulePoll(300);
       return;
     }
 
     // All DOM content + maps ready - wait for fonts before signaling
     waiting = true;
-    console.log("[print] content ready,", actual, "pages - waiting for fonts");
     fontsReady
       .then(() => {
-        console.log("[print] fonts confirmed");
         setReady();
       })
       .catch(() => {


### PR DESCRIPTION
- migrate app-owned backend logs to structlog event names and structured fields
- preserve stdlib compatibility for central logging, Uvicorn, framework logs, and Sentry integration
- route curated info events to Sentry Logs and remove routine frontend print console chatter
- remove log-prose assertions from trip-processing tests