### PR TITLE
feat: instrument backend workflows

### DIFF
--- a/backend/app/api/v1/routes/google_photos.py
+++ b/backend/app/api/v1/routes/google_photos.py
@@ -31,6 +31,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import get_settings
 from app.core.db import get_engine
 from app.core.locks import try_advisory_lock
+from app.core.observability import start_span
 from app.logic.media_upgrade.phash_matching import MatchResult
 from app.logic.media_upgrade.pipeline import (
     UpgradeEvent,
@@ -413,7 +414,12 @@ async def match_media(
         tokens = _build_token_getter(http, _get_refresh_token(user))
         access_token = await tokens()
 
-        album, step_rows = await _snapshot_album_and_steps(user.id, aid)
+        with start_span(
+            "google_photos.load_album",
+            "Load album for media matching",
+            **{"app.workflow": "google_photos", "user.id": user.id, "album.id": aid},
+        ):
+            album, step_rows = await _snapshot_album_and_steps(user.id, aid)
 
         album_dir = _album_dir(user, aid)
         already_upgraded = dict(album.upgraded_media)
@@ -424,7 +430,12 @@ async def match_media(
             for s in step_rows
         }
 
-        items = await get_media_items(http.gphotos_picker, session_id, access_token)
+        with start_span(
+            "google_photos.fetch_picked_media",
+            "Fetch picked Google Photos media",
+            **{"app.workflow": "google_photos", "user.id": user.id, "album.id": aid},
+        ):
+            items = await get_media_items(http.gphotos_picker, session_id, access_token)
 
         try:
             async for event in run_matching(
@@ -481,7 +492,12 @@ async def upgrade_media(
                 "An upgrade is already running for this album.",
             )
 
-        album = await _snapshot_album(user.id, aid)
+        with start_span(
+            "google_photos.load_album",
+            "Load album for media upgrade",
+            **{"app.workflow": "google_photos", "user.id": user.id, "album.id": aid},
+        ):
+            album = await _snapshot_album(user.id, aid)
         valid_names = {m.name for m in album.media}
         already_upgraded = dict(album.upgraded_media)
 
@@ -491,10 +507,20 @@ async def upgrade_media(
         access_token = await tokens()
 
         all_items: list[PickedMediaItem] = []
-        for sid in body.session_ids:
-            all_items.extend(
-                await get_media_items(http.gphotos_picker, sid, access_token)
-            )
+        with start_span(
+            "google_photos.fetch_picked_media",
+            "Fetch picked Google Photos media",
+            **{
+                "app.workflow": "google_photos",
+                "user.id": user.id,
+                "album.id": aid,
+                "session.count": len(body.session_ids),
+            },
+        ):
+            for sid in body.session_ids:
+                all_items.extend(
+                    await get_media_items(http.gphotos_picker, sid, access_token)
+                )
         items_by_id = {item.id: item for item in all_items}
 
         async for event in run_upgrade(

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -26,6 +26,7 @@ from sqlalchemy.exc import IntegrityError
 from starlette.requests import ClientDisconnect
 
 from app.core.config import get_settings
+from app.core.observability import start_span
 from app.core.resources import MiB
 from app.logic.chunked_upload import upload_store
 from app.logic.eviction import run_eviction
@@ -114,50 +115,60 @@ async def _finalize_upload(  # noqa: PLR0913
     album_ids = [t.id for t in trips]
 
     try:
-        cancel_session(ps_user.id)
+        with start_span(
+            "upload.finalize",
+            "Finalize upload",
+            **{
+                "app.workflow": "upload",
+                "album.count": len(album_ids),
+                "new_user": existing is None,
+                "user.id": ps_user.id,
+            },
+        ):
+            cancel_session(ps_user.id)
 
-        if existing is not None:
-            existing.album_ids = album_ids
-            existing.living_location = ps_user.living_location
-            existing.first_name = existing.first_name or ps_user.first_name
-            session.add(existing)
-            await session.commit()
-            user = existing
-            logger.info(
-                "upload.completed",
-                user_id=user.id,
-                album_count=len(album_ids),
-                new_user=False,
-            )
-        else:
-            oauth = cast("OAuthIdentity", identity)
-            user = User(
-                id=ps_user.id,
-                first_name=oauth.first_name or ps_user.first_name or "Anonymous",
-                locale=ps_user.locale,
-                unit_is_km=ps_user.unit_is_km,
-                temperature_is_celsius=ps_user.temperature_is_celsius,
-                google_sub=oauth.sub if oauth.provider == "google" else None,
-                microsoft_sub=oauth.sub if oauth.provider == "microsoft" else None,
-                profile_image_url=(str(oauth.picture) if oauth.picture else None),
-                living_location=ps_user.living_location,
-                album_ids=album_ids,
-            )
-            session.add(user)
-            await session.commit()
-            login_session(request, user.id)
-            clear_pending_signup(request)
-            logger.info(
-                "upload.completed",
-                user_id=user.id,
-                album_count=len(album_ids),
-                new_user=True,
-            )
+            if existing is not None:
+                existing.album_ids = album_ids
+                existing.living_location = ps_user.living_location
+                existing.first_name = existing.first_name or ps_user.first_name
+                session.add(existing)
+                await session.commit()
+                user = existing
+                logger.info(
+                    "upload.completed",
+                    user_id=user.id,
+                    album_count=len(album_ids),
+                    new_user=False,
+                )
+            else:
+                oauth = cast("OAuthIdentity", identity)
+                user = User(
+                    id=ps_user.id,
+                    first_name=oauth.first_name or ps_user.first_name or "Anonymous",
+                    locale=ps_user.locale,
+                    unit_is_km=ps_user.unit_is_km,
+                    temperature_is_celsius=ps_user.temperature_is_celsius,
+                    google_sub=oauth.sub if oauth.provider == "google" else None,
+                    microsoft_sub=oauth.sub if oauth.provider == "microsoft" else None,
+                    profile_image_url=(str(oauth.picture) if oauth.picture else None),
+                    living_location=ps_user.living_location,
+                    album_ids=album_ids,
+                )
+                session.add(user)
+                await session.commit()
+                login_session(request, user.id)
+                clear_pending_signup(request)
+                logger.info(
+                    "upload.completed",
+                    user_id=user.id,
+                    album_count=len(album_ids),
+                    new_user=True,
+                )
 
-        target = user.folder
-        if target.exists():
-            await asyncio.to_thread(shutil.rmtree, target)
-        await asyncio.to_thread(temp_folder.rename, target)
+            target = user.folder
+            if target.exists():
+                await asyncio.to_thread(shutil.rmtree, target)
+            await asyncio.to_thread(temp_folder.rename, target)
     except Exception:
         await asyncio.to_thread(shutil.rmtree, temp_folder, ignore_errors=True)
         raise
@@ -178,9 +189,14 @@ async def upload_data(
     size = _check_upload_size(file)
     logger.info("upload.extracting", size_mb=size // MiB)
     try:
-        temp_folder, ps_user, trips = await asyncio.to_thread(
-            extract_and_scan, file.file
-        )
+        with start_span(
+            "upload.extract",
+            "Extract Polarsteps ZIP",
+            **{"app.workflow": "upload", "size.bytes": size},
+        ):
+            temp_folder, ps_user, trips = await asyncio.to_thread(
+                extract_and_scan, file.file
+            )
     except (BadZipFile, OSError, ValidationError) as e:
         logger.warning("upload.bad_zip", error_type=type(e).__name__)
         raise HTTPException(status.HTTP_406_NOT_ACCEPTABLE, detail="Bad ZIP") from e
@@ -275,9 +291,14 @@ async def complete_chunked_upload(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e)) from None
 
     try:
-        temp_folder, ps_user, trips = await asyncio.to_thread(
-            extract_and_scan, assembled
-        )
+        with start_span(
+            "upload.extract",
+            "Extract Polarsteps ZIP",
+            **{"app.workflow": "upload"},
+        ):
+            temp_folder, ps_user, trips = await asyncio.to_thread(
+                extract_and_scan, assembled
+            )
     except (BadZipFile, OSError, ValidationError) as e:
         logger.warning(
             "upload.bad_zip",
@@ -383,18 +404,25 @@ async def create_demo(
 async def _remove_user(
     user: User, session: SessionDep, request: Request, http: HttpClientsDep
 ) -> None:
-    cancel_session(user.id)
-    folder = user.folder
-    if user.google_photos_refresh_token:
-        try:
-            await http.gphotos_oauth.revoke_token(user.google_photos_refresh_token)
-        except (RevokeTokenError, httpx.HTTPError) as exc:
-            logger.warning("oauth.token_revoke_failed", error_type=type(exc).__name__)
-    await session.delete(user)
-    await session.commit()
-    await asyncio.to_thread(shutil.rmtree, folder, ignore_errors=True)
-    request.session.clear()
-    logger.info("user.deleted", user_id=user.id, is_demo=user.is_demo)
+    with start_span(
+        "user.delete",
+        "Delete user",
+        **{"app.workflow": "user_delete", "user.id": user.id, "is_demo": user.is_demo},
+    ):
+        cancel_session(user.id)
+        folder = user.folder
+        if user.google_photos_refresh_token:
+            try:
+                await http.gphotos_oauth.revoke_token(user.google_photos_refresh_token)
+            except (RevokeTokenError, httpx.HTTPError) as exc:
+                logger.warning(
+                    "oauth.token_revoke_failed", error_type=type(exc).__name__
+                )
+        await session.delete(user)
+        await session.commit()
+        await asyncio.to_thread(shutil.rmtree, folder, ignore_errors=True)
+        request.session.clear()
+        logger.info("user.deleted", user_id=user.id, is_demo=user.is_demo)
 
 
 @router.delete("/demo", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+import sentry_sdk
+
+if TYPE_CHECKING:
+    from sentry_sdk.tracing import Span
+
+
+def set_span_data(span: Span | None, **data: Any) -> None:
+    if span is None:
+        return
+    for key, value in data.items():
+        if value is not None:
+            span.set_data(key, value)
+
+
+@contextmanager
+def start_span(op: str, name: str, **data: Any) -> Iterator[Span]:
+    with sentry_sdk.start_span(op=op, name=name) as span:
+        set_span_data(span, **data)
+        yield span

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -13,6 +13,7 @@ import anyio
 import structlog
 
 from app.core.config import get_settings
+from app.core.observability import start_span
 
 logger = structlog.get_logger(__name__)
 
@@ -182,13 +183,22 @@ class UploadStore:
 
         chunks = sorted(session.dir.glob("[0-9][0-9][0-9][0-9]"))
         assembled = session.dir / "assembled.zip"
-        with assembled.open("wb") as out:
-            for chunk_path in chunks:
-                with chunk_path.open("rb") as src:
-                    shutil.copyfileobj(src, out)
+        with start_span(
+            "upload.assemble",
+            "Assemble chunked upload",
+            **{
+                "app.workflow": "upload",
+                "chunk.count": len(chunks),
+                "size.bytes": session.accumulated_bytes,
+            },
+        ):
+            with assembled.open("wb") as out:
+                for chunk_path in chunks:
+                    with chunk_path.open("rb") as src:
+                        shutil.copyfileobj(src, out)
 
-        for chunk_path in chunks:
-            chunk_path.unlink()
+            for chunk_path in chunks:
+                chunk_path.unlink()
 
         try:
             return assembled.open("rb"), session.dir

--- a/backend/app/logic/eviction.py
+++ b/backend/app/logic/eviction.py
@@ -8,6 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
 from app.core.db import get_engine
+from app.core.observability import set_span_data, start_span
 from app.core.resources import MiB
 from app.models.user import User
 
@@ -40,7 +41,20 @@ async def run_eviction(skip_uid: int) -> None:
     users_folder = s.USERS_FOLDER
     cap = s.MAX_STORAGE_BYTES
 
-    total, sizes = await asyncio.to_thread(_sizes_by_user, users_folder)
+    with start_span(
+        "eviction.scan",
+        "Scan storage for eviction",
+        **{"app.workflow": "eviction", "user.id": skip_uid},
+    ) as span:
+        total, sizes = await asyncio.to_thread(_sizes_by_user, users_folder)
+        set_span_data(
+            span,
+            **{
+                "storage.used_bytes": total,
+                "storage.limit_bytes": cap,
+                "user.count": len(sizes),
+            },
+        )
     if total <= cap:
         return
 
@@ -56,21 +70,37 @@ async def run_eviction(skip_uid: int) -> None:
         )
         candidates = result.all()
 
-    for user in candidates:
-        if total <= cap:
-            break
-        if user.id == skip_uid:
-            continue
-        folder_size = sizes.get(user.id, 0)
-        if folder_size == 0:
-            continue
+    removed = 0
+    with start_span(
+        "eviction.delete",
+        "Delete evicted user folders",
+        **{
+            "app.workflow": "eviction",
+            "storage.used_bytes": total,
+            "storage.limit_bytes": cap,
+            "candidate.count": len(candidates),
+        },
+    ) as span:
+        for user in candidates:
+            if total <= cap:
+                break
+            if user.id == skip_uid:
+                continue
+            folder_size = sizes.get(user.id, 0)
+            if folder_size == 0:
+                continue
 
-        await asyncio.to_thread(shutil.rmtree, user.folder, ignore_errors=True)
-        total -= folder_size
-        logger.info(
-            "eviction.user_removed",
-            user_id=user.id,
-            folder_size_mb=folder_size // MiB,
+            await asyncio.to_thread(shutil.rmtree, user.folder, ignore_errors=True)
+            total -= folder_size
+            removed += 1
+            logger.info(
+                "eviction.user_removed",
+                user_id=user.id,
+                folder_size_mb=folder_size // MiB,
+            )
+        set_span_data(
+            span,
+            **{"user.removed": removed, "storage.remaining_bytes": total},
         )
 
     logger.info("eviction.completed", storage_mb=total // MiB)

--- a/backend/app/logic/export.py
+++ b/backend/app/logic/export.py
@@ -14,6 +14,7 @@ import structlog
 from pydantic import BaseModel, Field
 from sqlmodel import col, select
 
+from app.core.observability import start_span
 from app.core.tokens import TokenStore
 from app.logic.layout.media import MEDIA_EXTENSIONS
 from app.models.album import Album
@@ -68,19 +69,24 @@ lifespan = _tokens.lifespan
 
 
 def _scan_media(trips_folder: Path, album_ids: list[str]) -> dict[str, list[Path]]:
-    result: dict[str, list[Path]] = {}
-    for aid in album_ids:
-        try:
-            paths = [
-                p
-                for p in (trips_folder / aid).iterdir()
-                if p.is_file() and p.suffix.lower() in MEDIA_EXTENSIONS
-            ]
-        except OSError:
-            continue
-        if paths:
-            result[aid] = paths
-    return result
+    with start_span(
+        "export.scan_media",
+        "Scan export media",
+        **{"app.workflow": "export", "album.count": len(album_ids)},
+    ):
+        result: dict[str, list[Path]] = {}
+        for aid in album_ids:
+            try:
+                paths = [
+                    p
+                    for p in (trips_folder / aid).iterdir()
+                    if p.is_file() and p.suffix.lower() in MEDIA_EXTENSIONS
+                ]
+            except OSError:
+                continue
+            if paths:
+                result[aid] = paths
+        return result
 
 
 def _write_json(zf: zipfile.ZipFile, arcname: str, data: Any) -> None:
@@ -100,39 +106,46 @@ def _build_zip(
     progress_callback: Callable[[int], None],
     stop: threading.Event,
 ) -> None:
-    files_done = 0
+    with start_span(
+        "export.build_zip",
+        "Build export ZIP",
+        **{"app.workflow": "export", "file.count": len(spec.albums_data)},
+    ):
+        files_done = 0
 
-    def tick() -> None:
-        nonlocal files_done
-        files_done += 1
-        if files_done % _PROGRESS_EVERY_N_FILES == 0:
-            progress_callback(files_done)
+        def tick() -> None:
+            nonlocal files_done
+            files_done += 1
+            if files_done % _PROGRESS_EVERY_N_FILES == 0:
+                progress_callback(files_done)
 
-    with zipfile.ZipFile(spec.dest, "w", zipfile.ZIP_DEFLATED, allowZip64=True) as zf:
-        _write_json(zf, f"{_EXPORT_NAME}/account.json", spec.account_data)
-        tick()
-
-        for album in spec.albums_data:
-            if stop.is_set():
-                return
-            aid: str = album["album"]["id"]
-            prefix = f"{_EXPORT_NAME}/albums/{aid}"
-
-            _write_json(zf, f"{prefix}/album.json", album["album"])
-            tick()
-            _write_json(zf, f"{prefix}/steps.json", album["steps"])
-            tick()
-            _write_json(zf, f"{prefix}/segments.json", album["segments"])
+        with zipfile.ZipFile(
+            spec.dest, "w", zipfile.ZIP_DEFLATED, allowZip64=True
+        ) as zf:
+            _write_json(zf, f"{_EXPORT_NAME}/account.json", spec.account_data)
             tick()
 
-            for fpath in spec.media_by_album.get(aid, ()):
+            for album in spec.albums_data:
                 if stop.is_set():
                     return
-                zf.write(fpath, f"{prefix}/media/{fpath.name}", zipfile.ZIP_STORED)
+                aid: str = album["album"]["id"]
+                prefix = f"{_EXPORT_NAME}/albums/{aid}"
+
+                _write_json(zf, f"{prefix}/album.json", album["album"])
+                tick()
+                _write_json(zf, f"{prefix}/steps.json", album["steps"])
+                tick()
+                _write_json(zf, f"{prefix}/segments.json", album["segments"])
                 tick()
 
-    if files_done % _PROGRESS_EVERY_N_FILES != 0:
-        progress_callback(files_done)
+                for fpath in spec.media_by_album.get(aid, ()):
+                    if stop.is_set():
+                        return
+                    zf.write(fpath, f"{prefix}/media/{fpath.name}", zipfile.ZIP_STORED)
+                    tick()
+
+        if files_done % _PROGRESS_EVERY_N_FILES != 0:
+            progress_callback(files_done)
 
 
 async def _drain_queue(
@@ -195,28 +208,37 @@ async def export_user_data(
 ) -> AsyncGenerator[ExportEvent]:
     logger.info("export.started", user_id=user.id)
 
-    albums = list((await session.exec(select(Album).where(Album.uid == user.id))).all())
-    album_ids_loaded = [a.id for a in albums]
-
-    steps_by_album: dict[str, list[Step]] = {aid: [] for aid in album_ids_loaded}
-    for step in (
-        await session.exec(
-            select(Step)
-            .where(Step.uid == user.id, col(Step.aid).in_(album_ids_loaded))
-            .order_by(col(Step.timestamp), col(Step.id))
+    with start_span(
+        "export.load_data",
+        "Load export data",
+        **{"app.workflow": "export", "user.id": user.id},
+    ):
+        albums = list(
+            (await session.exec(select(Album).where(Album.uid == user.id))).all()
         )
-    ).all():
-        steps_by_album[step.aid].append(step)
+        album_ids_loaded = [a.id for a in albums]
 
-    segments_by_album: dict[str, list[Segment]] = {aid: [] for aid in album_ids_loaded}
-    for segment in (
-        await session.exec(
-            select(Segment)
-            .where(Segment.uid == user.id, col(Segment.aid).in_(album_ids_loaded))
-            .order_by(col(Segment.start_time))
-        )
-    ).all():
-        segments_by_album[segment.aid].append(segment)
+        steps_by_album: dict[str, list[Step]] = {aid: [] for aid in album_ids_loaded}
+        for step in (
+            await session.exec(
+                select(Step)
+                .where(Step.uid == user.id, col(Step.aid).in_(album_ids_loaded))
+                .order_by(col(Step.timestamp), col(Step.id))
+            )
+        ).all():
+            steps_by_album[step.aid].append(step)
+
+        segments_by_album: dict[str, list[Segment]] = {
+            aid: [] for aid in album_ids_loaded
+        }
+        for segment in (
+            await session.exec(
+                select(Segment)
+                .where(Segment.uid == user.id, col(Segment.aid).in_(album_ids_loaded))
+                .order_by(col(Segment.start_time))
+            )
+        ).all():
+            segments_by_album[segment.aid].append(segment)
 
     # Serialize on the event loop - model_dump touches SQLAlchemy descriptors
     # which are not thread-safe, and there's no I/O here (data is pre-loaded).

--- a/backend/app/logic/media_upgrade/pipeline.py
+++ b/backend/app/logic/media_upgrade/pipeline.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
+from app.core.observability import set_span_data, start_span
 from app.core.resources import detect_cpu_count
 from app.core.worker_threads import run_sync
 from app.logic.layout.media import Media, MediaName, is_video, media_limiter
@@ -172,69 +173,110 @@ async def run_matching(  # noqa: PLR0913
     if already_upgraded is None:
         already_upgraded = {}
 
-    # Bucket Google items by step windows (fast, no I/O)
-    windows = build_step_windows(step_timestamps, step_ids)
-    google_by_window = bucket_by_window(google_items, windows)
-    all_window_items = [item for items in google_by_window.values() for item in items]
-    unique_items = deduplicate_items(all_window_items)
+    with start_span(
+        "google_photos.matching",
+        "Match Google Photos media",
+        **{
+            "app.workflow": "google_photos",
+            "picked_media.count": len(google_items),
+            "step.count": len(step_ids),
+        },
+    ) as span:
+        windows = build_step_windows(step_timestamps, step_ids)
+        google_by_window = bucket_by_window(google_items, windows)
+        all_window_items = [
+            item for items in google_by_window.values() for item in items
+        ]
+        unique_items = deduplicate_items(all_window_items)
 
-    # Only hash local media from steps that have picked Google items.
-    populated_steps = {sid for sid, items in google_by_window.items() if items}
-    media_names = [
-        name
-        for sid in step_ids
-        if sid in populated_steps
-        for name in media_by_step.get(sid, [])
-    ]
+        populated_steps = {sid for sid, items in google_by_window.items() if items}
+        media_names = [
+            name
+            for sid in step_ids
+            if sid in populated_steps
+            for name in media_by_step.get(sid, [])
+        ]
+        set_span_data(
+            span,
+            **{
+                "local_media.count": len(media_names),
+                "unique_google_media.count": len(unique_items),
+            },
+        )
 
-    # Phase 1: Hash local media (separate progress counter)
-    local_hashes: dict[MediaName, MediaHash] = {}
-    local_total = len(media_names)
-    local_tasks = [
-        asyncio.create_task(_hash_local_one(album_dir, n)) for n in media_names
-    ]
-    for i, coro in enumerate(asyncio.as_completed(local_tasks)):
-        name, h = await coro
-        if h is not None:
-            local_hashes[name] = h
-        yield MatchInProgress(phase="preparing", done=i + 1, total=local_total)
+        local_hashes: dict[MediaName, MediaHash] = {}
+        local_total = len(media_names)
+        with start_span(
+            "google_photos.hash_local",
+            "Hash local media",
+            **{"app.workflow": "google_photos", "local_media.count": local_total},
+        ):
+            local_tasks = [
+                asyncio.create_task(_hash_local_one(album_dir, n)) for n in media_names
+            ]
+            for i, coro in enumerate(asyncio.as_completed(local_tasks)):
+                name, h = await coro
+                if h is not None:
+                    local_hashes[name] = h
+                yield MatchInProgress(phase="preparing", done=i + 1, total=local_total)
 
-    # Phase 2: Download thumbnails and hash (progress scoped to picked items)
-    candidate_hashes: dict[GoogleMediaId, imagehash.ImageHash] = {}
-    cand_total = len(unique_items)
-    cand_tasks = [
-        asyncio.create_task(_hash_candidate_one(clients.gphotos_download, item, tokens))
-        for item in unique_items
-    ]
-    for i, coro in enumerate(asyncio.as_completed(cand_tasks)):
-        item_id, h = await coro
-        if h is not None:
-            candidate_hashes[item_id] = h
-        yield MatchInProgress(phase="matching", done=i + 1, total=cand_total)
+        candidate_hashes: dict[GoogleMediaId, imagehash.ImageHash] = {}
+        cand_total = len(unique_items)
+        with start_span(
+            "google_photos.hash_candidates",
+            "Hash Google Photos candidates",
+            **{"app.workflow": "google_photos", "picked_media.count": cand_total},
+        ):
+            cand_tasks = [
+                asyncio.create_task(
+                    _hash_candidate_one(clients.gphotos_download, item, tokens)
+                )
+                for item in unique_items
+            ]
+            for i, coro in enumerate(asyncio.as_completed(cand_tasks)):
+                item_id, h = await coro
+                if h is not None:
+                    candidate_hashes[item_id] = h
+                yield MatchInProgress(phase="matching", done=i + 1, total=cand_total)
 
-    # Phase 3: Hungarian match within windows + cross-step fallback (CPU only)
-    all_matches, matched_locals, matched_candidates = match_across_windows(
-        windows, google_by_window, media_names, local_hashes, candidate_hashes
-    )
-    cross_step_fallback(
-        all_matches,
-        matched_locals,
-        matched_candidates,
-        media_names,
-        local_hashes,
-        google_items,
-        candidate_hashes,
-    )
+        with start_span(
+            "google_photos.match_candidates",
+            "Match media candidates",
+            **{
+                "app.workflow": "google_photos",
+                "local_media.count": len(local_hashes),
+                "candidate_hash.count": len(candidate_hashes),
+            },
+        ):
+            all_matches, matched_locals, matched_candidates = match_across_windows(
+                windows, google_by_window, media_names, local_hashes, candidate_hashes
+            )
+            cross_step_fallback(
+                all_matches,
+                matched_locals,
+                matched_candidates,
+                media_names,
+                local_hashes,
+                google_items,
+                candidate_hashes,
+            )
 
-    for m in all_matches:
-        m.upgraded = already_upgraded.get(m.local_name) == m.google_id
+        for m in all_matches:
+            m.upgraded = already_upgraded.get(m.local_name) == m.google_id
+        set_span_data(
+            span,
+            **{
+                "matched.count": len(all_matches),
+                "unmatched.count": len(google_items) - len(all_matches),
+            },
+        )
 
-    yield MatchCompleted(
-        total_picked=len(google_items),
-        matched=len(all_matches),
-        unmatched=len(google_items) - len(all_matches),
-        matches=all_matches,
-    )
+        yield MatchCompleted(
+            total_picked=len(google_items),
+            matched=len(all_matches),
+            unmatched=len(google_items) - len(all_matches),
+            matches=all_matches,
+        )
 
 
 @validate_call(config={"arbitrary_types_allowed": True})
@@ -306,17 +348,27 @@ async def _persist_upgrade(
         return
     replaced = len(succeeded)
     try:
-        async with AsyncSession(get_engine(), expire_on_commit=False) as session:
-            album = await session.get_one(Album, (uid, aid))
-            album.media, album.upgraded_media = await refresh_upgraded_media(
-                album_dir,
-                matches,
-                album.media,
-                album.upgraded_media,
-                succeeded,
-            )
-            session.add(album)
-            await session.commit()
+        with start_span(
+            "google_photos.persist_upgrade",
+            "Persist Google Photos upgrade",
+            **{
+                "app.workflow": "google_photos",
+                "user.id": uid,
+                "album.id": aid,
+                "replaced.count": replaced,
+            },
+        ):
+            async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+                album = await session.get_one(Album, (uid, aid))
+                album.media, album.upgraded_media = await refresh_upgraded_media(
+                    album_dir,
+                    matches,
+                    album.media,
+                    album.upgraded_media,
+                    succeeded,
+                )
+                session.add(album)
+                await session.commit()
     except SQLAlchemyError:
         logger.warning(
             "media_upgrade.persist_failed",
@@ -340,16 +392,21 @@ async def _cleanup_picker_sessions(
     tokens: AccessTokenGetter,
 ) -> None:
     """Best-effort deletion of picker sessions after upgrade."""
-    try:
-        access_token = await tokens()
-    except httpx.HTTPError, RefreshTokenError:
-        logger.warning("google_photos.picker_cleanup_token_unavailable")
-        return
-    for sid in session_ids:
+    with start_span(
+        "google_photos.cleanup_picker_sessions",
+        "Clean up picker sessions",
+        **{"app.workflow": "google_photos", "session.count": len(session_ids)},
+    ):
         try:
-            await delete_picker_session(picker, sid, access_token)
-        except httpx.HTTPError:
-            logger.warning("google_photos.picker_session_delete_failed")
+            access_token = await tokens()
+        except httpx.HTTPError, RefreshTokenError:
+            logger.warning("google_photos.picker_cleanup_token_unavailable")
+            return
+        for sid in session_ids:
+            try:
+                await delete_picker_session(picker, sid, access_token)
+            except httpx.HTTPError:
+                logger.warning("google_photos.picker_session_delete_failed")
 
 
 def _needs_upgrade(
@@ -390,67 +447,93 @@ async def run_upgrade(  # noqa: PLR0913, C901
     skipped_names: set[MediaName] = set()
 
     try:
-        if total == 0:
-            yield UpgradeCompleted(replaced=0, skipped=0, failed=0)
-            return
+        with start_span(
+            "google_photos.upgrade",
+            "Upgrade Google Photos media",
+            **{
+                "app.workflow": "google_photos",
+                "user.id": uid,
+                "album.id": aid,
+                "match.count": len(matches),
+                "upgrade.count": total,
+            },
+        ) as span:
+            if total == 0:
+                set_span_data(span, result="empty")
+                yield UpgradeCompleted(replaced=0, skipped=0, failed=0)
+                return
 
-        async with _upgrade_tmp(album_dir) as tmp_dir:
+            async with _upgrade_tmp(album_dir) as tmp_dir:
 
-            async def _upgrade_one(match: MatchResult) -> MediaName | None:
-                item = google_items_by_id.get(match.google_id)
-                if not item:
+                async def _upgrade_one(match: MatchResult) -> MediaName | None:
+                    item = google_items_by_id.get(match.google_id)
+                    if not item:
+                        return None
+                    try:
+                        replaced = await _download_and_replace(
+                            clients.gphotos_download,
+                            match.local_name,
+                            item,
+                            album_dir,
+                            tmp_dir,
+                            tokens,
+                        )
+                    except (
+                        OSError,
+                        SyntaxError,
+                        httpx.HTTPError,
+                        RuntimeError,
+                        subprocess.SubprocessError,
+                    ):
+                        logger.exception("media_upgrade.item_failed")
+                        return None
+                    if replaced:
+                        return match.local_name
+                    skipped_names.add(match.local_name)
                     return None
-                try:
-                    replaced = await _download_and_replace(
-                        clients.gphotos_download,
-                        match.local_name,
-                        item,
-                        album_dir,
-                        tmp_dir,
-                        tokens,
-                    )
-                except (
-                    OSError,
-                    SyntaxError,
-                    httpx.HTTPError,
-                    RuntimeError,
-                    subprocess.SubprocessError,
+
+                with start_span(
+                    "google_photos.download_replace",
+                    "Download and replace media",
+                    **{"app.workflow": "google_photos", "upgrade.count": total},
                 ):
-                    logger.exception("media_upgrade.item_failed")
-                    return None
-                if replaced:
-                    return match.local_name
-                skipped_names.add(match.local_name)
-                return None
+                    tasks = [asyncio.create_task(_upgrade_one(m)) for m in to_upgrade]
+                    try:
+                        for i, coro in enumerate(asyncio.as_completed(tasks)):
+                            name = await coro
+                            if name:
+                                succeeded.add(name)
+                            yield DownloadInProgress(done=i + 1, total=total)
+                    finally:
+                        for t in tasks:
+                            t.cancel()
+                        # Wait for cancelled tasks before tmp cleanup runs.
+                        await asyncio.gather(*tasks, return_exceptions=True)
 
-            tasks = [asyncio.create_task(_upgrade_one(m)) for m in to_upgrade]
-            try:
-                for i, coro in enumerate(asyncio.as_completed(tasks)):
-                    name = await coro
-                    if name:
-                        succeeded.add(name)
-                    yield DownloadInProgress(done=i + 1, total=total)
-            finally:
-                for t in tasks:
-                    t.cancel()
-                # Wait for cancelled tasks before tmp cleanup runs.
-                await asyncio.gather(*tasks, return_exceptions=True)
-
-        failed_names = [
-            m.local_name
-            for m in to_upgrade
-            if m.local_name not in succeeded and m.local_name not in skipped_names
-        ]
-        if failed_names:
-            logger.warning(
-                "media_upgrade.completed_with_failures",
+            failed_names = [
+                m.local_name
+                for m in to_upgrade
+                if m.local_name not in succeeded and m.local_name not in skipped_names
+            ]
+            if failed_names:
+                logger.warning(
+                    "media_upgrade.completed_with_failures",
+                    failed=len(failed_names),
+                )
+            set_span_data(
+                span,
+                result="completed",
+                **{
+                    "replaced.count": len(succeeded),
+                    "skipped.count": len(skipped_names),
+                    "failed.count": len(failed_names),
+                },
+            )
+            yield UpgradeCompleted(
+                replaced=len(succeeded),
+                skipped=len(skipped_names),
                 failed=len(failed_names),
             )
-        yield UpgradeCompleted(
-            replaced=len(succeeded),
-            skipped=len(skipped_names),
-            failed=len(failed_names),
-        )
     except Exception as exc:  # noqa: BLE001
         logger.error(  # noqa: TRY400
             "media_upgrade.failed",

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -10,6 +10,7 @@ from playwright.async_api import Browser, Page, Playwright, async_playwright
 from pydantic import BaseModel, Field
 
 from app.core.config import get_settings
+from app.core.observability import set_span_data, start_span
 from app.core.resources import MiB, detect_memory_mb
 from app.core.tokens import TokenStore
 
@@ -161,7 +162,7 @@ async def _stream_pdf_to_file(page: Page, dest: Path) -> AsyncGenerator[int]:
             await cdp.detach()
 
 
-async def _render_pdf(  # noqa: C901
+async def _render_pdf(  # noqa: C901, PLR0915
     browser: Browser,
     aid: str,
     dest: Path,
@@ -173,11 +174,16 @@ async def _render_pdf(  # noqa: C901
     frontend_url = str(settings.FRONTEND_URL or settings.VITE_FRONTEND_URL).rstrip("/")
     yield PdfProgress(phase="loading", done=0)
 
-    context = await browser.new_context(
-        viewport={"width": 1920, "height": 1080},
-        device_scale_factor=2,
-        bypass_csp=True,
-    )
+    with start_span(
+        "pdf.browser_context",
+        "Create PDF browser context",
+        **{"app.workflow": "pdf", "album.id": aid, "pdf.dark": dark},
+    ):
+        context = await browser.new_context(
+            viewport={"width": 1920, "height": 1080},
+            device_scale_factor=2,
+            bypass_csp=True,
+        )
     try:
         await context.add_cookies(
             [
@@ -213,35 +219,53 @@ async def _render_pdf(  # noqa: C901
         await page.emulate_media(media="print")
         dark_param = "true" if dark else "false"
         url = f"{frontend_url}/print/{aid}?dark={dark_param}"
-        await page.goto(url, wait_until="domcontentloaded")
-        logger.info("pdf.dom_loaded", album_id=aid)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + 60
-        last_counts = (-1, -1)
-        while True:
-            ready = await page.evaluate("window.__PRINT_READY__ === true")
-            counts = (finished, started)
-            if counts != last_counts or ready:
-                last_counts = counts
-                yield PdfProgress(
-                    phase="loading",
-                    done=finished,
-                    total=started,
-                )
-            if ready:
-                break
-            if loop.time() > deadline:
-                raise TimeoutError("Timed out waiting for album to load")
-            await asyncio.sleep(0.5)
+        with start_span(
+            "pdf.load_page",
+            "Load print page",
+            **{"app.workflow": "pdf", "album.id": aid, "pdf.dark": dark},
+        ) as span:
+            await page.goto(url, wait_until="domcontentloaded")
+            logger.info("pdf.dom_loaded", album_id=aid)
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + 60
+            last_counts = (-1, -1)
+            while True:
+                ready = await page.evaluate("window.__PRINT_READY__ === true")
+                counts = (finished, started)
+                if counts != last_counts or ready:
+                    last_counts = counts
+                    yield PdfProgress(
+                        phase="loading",
+                        done=finished,
+                        total=started,
+                    )
+                if ready:
+                    break
+                if loop.time() > deadline:
+                    raise TimeoutError("Timed out waiting for album to load")
+                await asyncio.sleep(0.5)
+            set_span_data(
+                span,
+                **{
+                    "browser.request.started": started,
+                    "browser.request.finished": finished,
+                },
+            )
 
         yield PdfProgress(phase="rendering", done=0)
         size = 0
         last_reported = 0
-        async with aclosing(_stream_pdf_to_file(page, dest)) as stream:
-            async for size in stream:
-                if size - last_reported >= _PROGRESS_CHUNK_BYTES:
-                    yield PdfProgress(phase="rendering", done=size)
-                    last_reported = size
+        with start_span(
+            "pdf.print",
+            "Print PDF",
+            **{"app.workflow": "pdf", "album.id": aid, "pdf.dark": dark},
+        ) as span:
+            async with aclosing(_stream_pdf_to_file(page, dest)) as stream:
+                async for size in stream:
+                    if size - last_reported >= _PROGRESS_CHUNK_BYTES:
+                        yield PdfProgress(phase="rendering", done=size)
+                        last_reported = size
+            set_span_data(span, **{"pdf.size_bytes": size})
         yield PdfProgress(phase="rendering", done=size)
         logger.info("pdf.generated", album_id=aid, size_bytes=size)
 
@@ -261,8 +285,13 @@ async def render_album_pdf_stream(
     yield PdfQueued()
 
     try:
-        async with asyncio.timeout(_QUEUE_TIMEOUT):
-            await _render_sem.acquire()
+        with start_span(
+            "pdf.queue_wait",
+            "Wait for PDF render slot",
+            **{"app.workflow": "pdf", "album.id": aid},
+        ):
+            async with asyncio.timeout(_QUEUE_TIMEOUT):
+                await _render_sem.acquire()
     except TimeoutError:
         logger.warning(
             "pdf.queue_timeout",
@@ -278,20 +307,29 @@ async def render_album_pdf_stream(
     size = 0
     owned = False
     try:
-        async with asyncio.timeout(_RENDER_TIMEOUT):
-            async with aclosing(
-                _render_pdf(
-                    browser,
-                    aid,
-                    dest,
-                    session_cookie=session_cookie,
-                    dark=dark,
-                )
-            ) as events:
-                async for event in events:
-                    if isinstance(event, PdfProgress) and event.phase == "rendering":
-                        size = event.done
-                    yield event
+        with start_span(
+            "pdf.render",
+            "Render album PDF",
+            **{"app.workflow": "pdf", "album.id": aid, "pdf.dark": dark},
+        ) as span:
+            async with asyncio.timeout(_RENDER_TIMEOUT):
+                async with aclosing(
+                    _render_pdf(
+                        browser,
+                        aid,
+                        dest,
+                        session_cookie=session_cookie,
+                        dark=dark,
+                    )
+                ) as events:
+                    async for event in events:
+                        if (
+                            isinstance(event, PdfProgress)
+                            and event.phase == "rendering"
+                        ):
+                            size = event.done
+                        yield event
+            set_span_data(span, **{"pdf.size_bytes": size})
 
         if size == 0:
             yield PdfError(detail="PDF generation produced no output.")

--- a/backend/app/logic/segment_routes.py
+++ b/backend/app/logic/segment_routes.py
@@ -14,12 +14,14 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
 from app.core.locks import try_advisory_lock
+from app.core.observability import set_span_data, start_span
 from app.logic.route_matching import MATCHABLE_KINDS
 from app.models.segment import Segment
 from app.services.mapbox import match_segments_with_stats
 
 if TYPE_CHECKING:
     from fastapi import BackgroundTasks
+    from sentry_sdk.tracing import Span
     from sqlalchemy.sql.elements import ColumnElement
 
 logger = structlog.get_logger(__name__)
@@ -71,38 +73,57 @@ async def match_album_segment_routes(http: HttpClients, uid: int, aid: str) -> N
     lock_key = f"segment-route-match:{uid}:{aid}"
     started = time.perf_counter()
     try:
-        async with try_advisory_lock(lock_key) as acquired:
-            if not acquired:
-                logger.info(
-                    "route_enrichment.already_running",
-                    user_id=uid,
-                    album_id=aid,
-                )
-                return
-
-            async with AsyncSession(get_engine()) as session:
-                snapshots = await _unmatched_snapshots(session, uid, aid)
-                if not snapshots:
-                    _log_complete(uid, aid, started, RouteEnrichmentStats())
+        with start_span(
+            "route_enrichment.run",
+            "Run route enrichment",
+            **{"app.workflow": "route_enrichment", "user.id": uid, "album.id": aid},
+        ) as span:
+            async with try_advisory_lock(lock_key) as acquired:
+                if not acquired:
+                    set_span_data(span, result="already_running")
+                    logger.info(
+                        "route_enrichment.already_running",
+                        user_id=uid,
+                        album_id=aid,
+                    )
                     return
 
-                pairs = [(coords, profile) for _, coords, profile in snapshots]
-                routes, route_stats = await match_segments_with_stats(
-                    http.mapbox_matching,
-                    http.mapbox_directions,
-                    pairs,
-                )
+                async with AsyncSession(get_engine()) as session:
+                    snapshots = await _unmatched_snapshots(session, uid, aid)
+                    if not snapshots:
+                        stats = RouteEnrichmentStats()
+                        _set_route_span_data(span, stats, result="empty")
+                        _log_complete(uid, aid, started, stats)
+                        return
 
-                stats = RouteEnrichmentStats(candidates=len(snapshots))
-                stats.route_requests = route_stats.requests
-                stats.matching_requests = route_stats.matching_requests
-                stats.directions_requests = route_stats.directions_requests
-                for (key, _, _), route in zip(snapshots, routes, strict=True):
-                    if route:
-                        stats.matched += 1
-                        stats.updated += await _write_route(session, key, route)
-                await session.commit()
-                _log_complete(uid, aid, started, stats)
+                    pairs = [(coords, profile) for _, coords, profile in snapshots]
+                    with start_span(
+                        "route_enrichment.match",
+                        "Match segment routes",
+                        **{
+                            "app.workflow": "route_enrichment",
+                            "user.id": uid,
+                            "album.id": aid,
+                            "route.candidates": len(snapshots),
+                        },
+                    ):
+                        routes, route_stats = await match_segments_with_stats(
+                            http.mapbox_matching,
+                            http.mapbox_directions,
+                            pairs,
+                        )
+
+                    stats = RouteEnrichmentStats(candidates=len(snapshots))
+                    stats.route_requests = route_stats.requests
+                    stats.matching_requests = route_stats.matching_requests
+                    stats.directions_requests = route_stats.directions_requests
+                    for (key, _, _), route in zip(snapshots, routes, strict=True):
+                        if route:
+                            stats.matched += 1
+                            stats.updated += await _write_route(session, key, route)
+                    await session.commit()
+                    _set_route_span_data(span, stats, result="completed")
+                    _log_complete(uid, aid, started, stats)
     except Exception:
         logger.exception(
             "route_enrichment.failed",
@@ -114,6 +135,28 @@ async def match_album_segment_routes(http: HttpClients, uid: int, aid: str) -> N
 
 def _duration_ms(started: float) -> int:
     return round((time.perf_counter() - started) * 1000)
+
+
+def _set_route_span_data(
+    span: Span,
+    stats: RouteEnrichmentStats,
+    *,
+    result: str,
+) -> None:
+    set_span_data(
+        span,
+        result=result,
+        **{
+            "route.candidates": stats.candidates,
+            "route.matched": stats.matched,
+            "route.updated": stats.updated,
+            "route.skipped": stats.skipped,
+            "route.stale": stats.stale,
+            "route.requests": stats.route_requests,
+            "mapbox.matching_requests": stats.matching_requests,
+            "mapbox.directions_requests": stats.directions_requests,
+        },
+    )
 
 
 def _log_complete(

--- a/backend/app/logic/trip_pipeline.py
+++ b/backend/app/logic/trip_pipeline.py
@@ -14,6 +14,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import get_settings
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
+from app.core.observability import start_span
 from app.logic.demo_i18n import apply_overlay, load_overlay
 from app.logic.reconcile import reconcile_trip
 from app.logic.trip_processing import (
@@ -60,7 +61,12 @@ async def _process_trip(
     db_out: list[DbRow],
 ) -> AsyncIterator[ProcessingEvent]:
     aid = trip_dir.name
-    trip, locations = await asyncio.to_thread(load_trip_data, trip_dir)
+    with start_span(
+        "processing.load_trip",
+        "Load trip data",
+        **{"app.workflow": "processing", "album.id": aid},
+    ):
+        trip, locations = await asyncio.to_thread(load_trip_data, trip_dir)
     logger.info(
         "processing.trip_started",
         album_id=aid,
@@ -92,19 +98,40 @@ async def _process_trip(
             cover_name=final_cover_name,
         )
 
-    runner = asyncio.create_task(_phases())
-    async for event in drain_queue(runner, queue):
-        yield event
+    with start_span(
+        "processing.trip",
+        "Process trip",
+        **{
+            "app.workflow": "processing",
+            "user.id": user.id,
+            "album.id": aid,
+            "step.count": n,
+        },
+    ):
+        runner = asyncio.create_task(_phases())
+        async for event in drain_queue(runner, queue):
+            yield event
 
-    results = await runner
-    yield PhaseUpdate(phase="segments", done=0, total=1)
-    objects = await asyncio.to_thread(
-        build_trip_objects, user, aid, trip, locations, results
-    )
-    segments = [obj for obj in objects if isinstance(obj, Segment)]
-    yield PhaseUpdate(phase="segments", done=1, total=1)
-    yield count_segments(segments)
-    db_out.extend(objects)
+        results = await runner
+        yield PhaseUpdate(phase="segments", done=0, total=1)
+        with start_span(
+            "processing.build_objects",
+            "Build trip objects",
+            **{
+                "app.workflow": "processing",
+                "user.id": user.id,
+                "album.id": aid,
+                "step.count": n,
+                "location.count": len(locations),
+            },
+        ):
+            objects = await asyncio.to_thread(
+                build_trip_objects, user, aid, trip, locations, results
+            )
+        segments = [obj for obj in objects if isinstance(obj, Segment)]
+        yield PhaseUpdate(phase="segments", done=1, total=1)
+        yield count_segments(segments)
+        db_out.extend(objects)
 
 
 async def _load_existing(
@@ -117,17 +144,24 @@ async def _load_existing(
     if not user.album_ids:
         return {}, {}
 
-    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
-        albums = {
-            a.id: a
-            for a in (
-                await session.exec(select(Album).where(Album.uid == user.id))
-            ).all()
-        }
+    with start_span(
+        "processing.load_existing",
+        "Load existing albums",
+        **{"app.workflow": "processing", "user.id": user.id},
+    ):
+        async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+            albums = {
+                a.id: a
+                for a in (
+                    await session.exec(select(Album).where(Album.uid == user.id))
+                ).all()
+            }
 
-        steps_by_aid: dict[str, list[Step]] = defaultdict(list)
-        for s in (await session.exec(select(Step).where(Step.uid == user.id))).all():
-            steps_by_aid[s.aid].append(s)
+            steps_by_aid: dict[str, list[Step]] = defaultdict(list)
+            for s in (
+                await session.exec(select(Step).where(Step.uid == user.id))
+            ).all():
+                steps_by_aid[s.aid].append(s)
 
     return albums, dict(steps_by_aid)
 
@@ -136,9 +170,19 @@ async def _save_new(
     uid: int,
     objects: list[DbRow],
 ) -> None:
-    async with AsyncSession(get_engine()) as session:
-        session.add_all(objects)
-        await session.commit()
+    with start_span(
+        "processing.db_save",
+        "Save processing results",
+        **{
+            "app.workflow": "processing",
+            "user.id": uid,
+            "object.count": len(objects),
+            "new_user": True,
+        },
+    ):
+        async with AsyncSession(get_engine()) as session:
+            session.add_all(objects)
+            await session.commit()
     logger.info(
         "processing.db_saved",
         user_id=uid,
@@ -154,32 +198,44 @@ async def _save_reupload(
     existing_albums: dict[str, Album],
     trip_dirs: list[Path],
 ) -> None:
-    async with AsyncSession(get_engine()) as session:
-        if reconciled_aids:
-            await session.exec(
-                delete(Step)
-                .where(col(Step.uid) == uid)
-                .where(col(Step.aid).in_(reconciled_aids))
-            )
-            await session.exec(
-                delete(Segment)
-                .where(col(Segment.uid) == uid)
-                .where(col(Segment.aid).in_(reconciled_aids))
-            )
+    with start_span(
+        "processing.db_save",
+        "Save processing results",
+        **{
+            "app.workflow": "processing",
+            "user.id": uid,
+            "object.count": len(objects),
+            "album.count": len(trip_dirs),
+            "reconciled_album.count": len(reconciled_aids),
+            "new_user": False,
+        },
+    ):
+        async with AsyncSession(get_engine()) as session:
+            if reconciled_aids:
+                await session.exec(
+                    delete(Step)
+                    .where(col(Step.uid) == uid)
+                    .where(col(Step.aid).in_(reconciled_aids))
+                )
+                await session.exec(
+                    delete(Segment)
+                    .where(col(Segment.uid) == uid)
+                    .where(col(Segment.aid).in_(reconciled_aids))
+                )
 
-        current_aids = {d.name for d in trip_dirs}
-        orphan_aids = set(existing_albums) - current_aids
-        if orphan_aids:
-            await session.exec(
-                delete(Album)
-                .where(col(Album.uid) == uid)
-                .where(col(Album.id).in_(orphan_aids))
-            )
-        await session.flush()
+            current_aids = {d.name for d in trip_dirs}
+            orphan_aids = set(existing_albums) - current_aids
+            if orphan_aids:
+                await session.exec(
+                    delete(Album)
+                    .where(col(Album.uid) == uid)
+                    .where(col(Album.id).in_(orphan_aids))
+                )
+            await session.flush()
 
-        for obj in objects:
-            await session.merge(obj)
-        await session.commit()
+            for obj in objects:
+                await session.merge(obj)
+            await session.commit()
     logger.info(
         "processing.db_saved",
         user_id=uid,
@@ -214,51 +270,79 @@ async def run_processing(
 ) -> AsyncIterator[ProcessingEvent]:
     t0 = time.monotonic()
     trip_dirs = sorted(user.trips_folder.iterdir())
-    existing_albums, existing_steps = await _load_existing(user)
 
     all_objects: list[DbRow] = []
     reconciled_aids: set[str] = set()
-    try:
-        for trip_idx, trip_dir in enumerate(trip_dirs):
-            aid = trip_dir.name
-            yield TripStart(trip_index=trip_idx)
+    with start_span(
+        "processing.run",
+        "Run processing",
+        **{
+            "app.workflow": "processing",
+            "user.id": user.id,
+            "album.count": len(trip_dirs),
+        },
+    ):
+        existing_albums, existing_steps = await _load_existing(user)
+        try:
+            for trip_idx, trip_dir in enumerate(trip_dirs):
+                aid = trip_dir.name
+                yield TripStart(trip_index=trip_idx)
 
-            if aid in existing_albums:
-                async for event in reconcile_trip(
-                    http,
-                    user,
-                    trip_dir,
-                    existing_albums[aid],
-                    existing_steps.get(aid, []),
-                    all_objects,
-                ):
-                    yield event
-                reconciled_aids.add(aid)
+                if aid in existing_albums:
+                    with start_span(
+                        "processing.reconcile_trip",
+                        "Reconcile trip",
+                        **{
+                            "app.workflow": "processing",
+                            "user.id": user.id,
+                            "album.id": aid,
+                            "existing_step.count": len(existing_steps.get(aid, [])),
+                        },
+                    ):
+                        async for event in reconcile_trip(
+                            http,
+                            user,
+                            trip_dir,
+                            existing_albums[aid],
+                            existing_steps.get(aid, []),
+                            all_objects,
+                        ):
+                            yield event
+                    reconciled_aids.add(aid)
+                else:
+                    async for event in _process_trip(http, user, trip_dir, all_objects):
+                        yield event
+        except Exception:
+            logger.exception("processing.failed", user_id=user.id)
+            yield ErrorData()
+            return
+
+        _apply_demo_i18n(user, all_objects)
+
+        try:
+            if existing_albums:
+                await _save_reupload(
+                    user.id, all_objects, reconciled_aids, existing_albums, trip_dirs
+                )
             else:
-                async for event in _process_trip(http, user, trip_dir, all_objects):
-                    yield event
-    except Exception:
-        logger.exception("processing.failed", user_id=user.id)
-        yield ErrorData()
-        return
-
-    _apply_demo_i18n(user, all_objects)
-
-    try:
-        if existing_albums:
-            await _save_reupload(
-                user.id, all_objects, reconciled_aids, existing_albums, trip_dirs
-            )
-        else:
-            await _save_new(user.id, all_objects)
-    except SQLAlchemyError:
-        logger.exception("processing.db_save_failed", user_id=user.id)
-        yield ErrorData()
-        return
-    await asyncio.to_thread(_cleanup_metadata, user.folder, trip_dirs)
-    logger.info(
-        "processing.completed",
-        user_id=user.id,
-        trip_count=len(trip_dirs),
-        duration_s=time.monotonic() - t0,
-    )
+                await _save_new(user.id, all_objects)
+        except SQLAlchemyError:
+            logger.exception("processing.db_save_failed", user_id=user.id)
+            yield ErrorData()
+            return
+        with start_span(
+            "processing.cleanup",
+            "Clean processing metadata",
+            **{
+                "app.workflow": "processing",
+                "user.id": user.id,
+                "album.count": len(trip_dirs),
+            },
+        ):
+            await asyncio.to_thread(_cleanup_metadata, user.folder, trip_dirs)
+        logger.info(
+            "processing.completed",
+            user_id=user.id,
+            trip_count=len(trip_dirs),
+            duration_s=time.monotonic() - t0,
+        )

--- a/backend/app/logic/trip_processing.py
+++ b/backend/app/logic/trip_processing.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 
 from app.core.async_helpers import yield_completed
 from app.core.http_clients import HttpClients
+from app.core.observability import start_span
 from app.logic.country_colors import build_country_colors
 from app.logic.layout import Layout, build_step_layout
 from app.logic.layout.media import (
@@ -263,10 +264,19 @@ async def run_elevations(
     n_steps: int,
     queue: asyncio.Queue[PhaseUpdate | None],
 ) -> list[float]:
-    raw = await track_iter(
-        "elevations", n_steps, elevations(http.open_meteo, locs), queue
-    )
-    return list(await correct_peaks(http.overpass, locs, raw))
+    with start_span(
+        "processing.phase",
+        "Run elevations",
+        **{
+            "app.workflow": "processing",
+            "app.operation": "elevations",
+            "step.count": n_steps,
+        },
+    ):
+        raw = await track_iter(
+            "elevations", n_steps, elevations(http.open_meteo, locs), queue
+        )
+        return list(await correct_peaks(http.overpass, locs, raw))
 
 
 async def run_weather(
@@ -275,11 +285,20 @@ async def run_weather(
     n_steps: int,
     queue: asyncio.Queue[PhaseUpdate | None],
 ) -> dict[int, Weather]:
-    return dict(
-        await track_iter(
-            "weather", n_steps, build_weathers(http.open_meteo, steps), queue
+    with start_span(
+        "processing.phase",
+        "Run weather",
+        **{
+            "app.workflow": "processing",
+            "app.operation": "weather",
+            "step.count": n_steps,
+        },
+    ):
+        return dict(
+            await track_iter(
+                "weather", n_steps, build_weathers(http.open_meteo, steps), queue
+            )
         )
-    )
 
 
 def _pick_landscape_cover(trip_dir: Path) -> tuple[str, str]:
@@ -311,21 +330,26 @@ async def prepare_media(
     Polarsteps export isn't found locally, picks a landscape photo instead.
     Video posters and thumbnails are generated lazily on first request.
     """
-    await asyncio.to_thread(flatten_media, trip_dir)
+    with start_span(
+        "processing.prepare_media",
+        "Prepare media",
+        **{"app.workflow": "processing", "album.id": trip_dir.name},
+    ):
+        await asyncio.to_thread(flatten_media, trip_dir)
 
-    cover_dest = trip_dir / cover_name
-    if cover_dest.exists():
-        try:
-            cover_photo = await asyncio.to_thread(Media.load, cover_dest)
-            cover_orientation = cover_photo.orientation
-        except OSError, ValueError:
-            cover_orientation = "l"
-    else:
-        cover_name, cover_orientation = await asyncio.to_thread(
-            _pick_landscape_cover, trip_dir
-        )
+        cover_dest = trip_dir / cover_name
+        if cover_dest.exists():
+            try:
+                cover_photo = await asyncio.to_thread(Media.load, cover_dest)
+                cover_orientation = cover_photo.orientation
+            except OSError, ValueError:
+                cover_orientation = "l"
+        else:
+            cover_name, cover_orientation = await asyncio.to_thread(
+                _pick_landscape_cover, trip_dir
+            )
 
-    return cover_name, cover_orientation
+        return cover_name, cover_orientation
 
 
 async def drain_queue(
@@ -391,11 +415,22 @@ async def _media_pipeline(
     """
     aid = trip_dir.name
     n_steps = len(trip.all_steps)
-    layout_by_idx = dict(
-        await track_iter(
-            "layouts", n_steps, fetch_layouts(user, aid, trip.all_steps), queue
+    with start_span(
+        "processing.phase",
+        "Build layouts",
+        **{
+            "app.workflow": "processing",
+            "app.operation": "layouts",
+            "user.id": user.id,
+            "album.id": aid,
+            "step.count": n_steps,
+        },
+    ):
+        layout_by_idx = dict(
+            await track_iter(
+                "layouts", n_steps, fetch_layouts(user, aid, trip.all_steps), queue
+            )
         )
-    )
 
     cover_name, _cover_orientation = await prepare_media(trip_dir, cover_name)
 

--- a/backend/app/services/mapbox.py
+++ b/backend/app/services/mapbox.py
@@ -14,6 +14,7 @@ import structlog
 from pydantic import BaseModel
 
 from app.core.config import get_settings
+from app.core.observability import set_span_data, start_span
 from app.logic.route_matching import (
     Coords,
     is_sparse,
@@ -91,23 +92,34 @@ async def _fetch_matching(
     if stats is not None:
         stats.matching_requests += 1
     reduced = reduce_coords(coords, MATCH_MAX_COORDS)
-    try:
-        resp = await client.get(
-            f"{_MATCHING_URL}/{profile}/{_encode_coords(reduced)}",
-            params={
-                "geometries": "geojson",
-                "overview": "full",
-                "tidy": "true",
-                "access_token": token,
-            },
-        )
-        resp.raise_for_status()
-    except httpx.HTTPStatusError as e:
-        logger.warning(
-            "mapbox.matching_api_error",
-            status_code=e.response.status_code,
-        )
-        return None
+    with start_span(
+        "mapbox.matching",
+        "Mapbox Map Matching API",
+        **{
+            "app.workflow": "route_enrichment",
+            "route.profile": profile,
+            "point.count": len(coords),
+            "reduced_point.count": len(reduced),
+        },
+    ) as span:
+        try:
+            resp = await client.get(
+                f"{_MATCHING_URL}/{profile}/{_encode_coords(reduced)}",
+                params={
+                    "geometries": "geojson",
+                    "overview": "full",
+                    "tidy": "true",
+                    "access_token": token,
+                },
+            )
+            set_span_data(span, **{"http.status_code": resp.status_code})
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                "mapbox.matching_api_error",
+                status_code=e.response.status_code,
+            )
+            return None
     data = _MatchingResponse.model_validate_json(resp.content)
     if not data.matchings:
         return None
@@ -127,22 +139,32 @@ async def _fetch_directions(
 ) -> Coords | None:
     if stats is not None:
         stats.directions_requests += 1
-    try:
-        resp = await client.get(
-            f"{_DIRECTIONS_URL}/{profile}/{_encode_coords(coords)}",
-            params={
-                "geometries": "geojson",
-                "overview": "full",
-                "access_token": token,
-            },
-        )
-        resp.raise_for_status()
-    except httpx.HTTPStatusError as e:
-        logger.warning(
-            "mapbox.directions_api_error",
-            status_code=e.response.status_code,
-        )
-        return None
+    with start_span(
+        "mapbox.directions",
+        "Mapbox Directions API",
+        **{
+            "app.workflow": "route_enrichment",
+            "route.profile": profile,
+            "point.count": len(coords),
+        },
+    ) as span:
+        try:
+            resp = await client.get(
+                f"{_DIRECTIONS_URL}/{profile}/{_encode_coords(coords)}",
+                params={
+                    "geometries": "geojson",
+                    "overview": "full",
+                    "access_token": token,
+                },
+            )
+            set_span_data(span, **{"http.status_code": resp.status_code})
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                "mapbox.directions_api_error",
+                status_code=e.response.status_code,
+            )
+            return None
     data = _DirectionsResponse.model_validate_json(resp.content)
     if not data.routes:
         return None


### PR DESCRIPTION
- add a tiny backend observability helper for Sentry spans
- instrument upload, processing, PDF, export, route enrichment, Mapbox, Google Photos, deletion, and eviction workflows
- keep custom metrics deferred in favor of span attributes and Trace Explorer first