### PR TITLE
ci: align release versions with deployments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
+          fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - id: app-version
+        run: echo "value=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -44,8 +47,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=${{ steps.app-version.outputs.value }}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' }}
       - uses: docker/build-push-action@v7
         with:
           context: .
@@ -53,6 +57,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.app-version.outputs.value }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
 
@@ -83,8 +89,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=${{ steps.app-version.outputs.value }}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' }}
       - uses: docker/build-push-action@v7
         with:
           context: .
@@ -165,7 +172,7 @@ jobs:
           ignore_empty: true
           disable_telemetry: true
 
-  create-release:
+  create-github-release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-backend, build-frontend]
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1
+ARG APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
 
 COPY --from=ghcr.io/astral-sh/uv:0.9 /uv /uvx /bin/
 


### PR DESCRIPTION
- tag published backend and frontend images with the shared app version from git describe
- pass the same app version into backend builds for Sentry release attribution
- keep latest image updates limited to successful main CI publishes
- rename the tag-only release job to create-github-releas