### PR TITLE
feat: media upload

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter
 
-from .routes import albums, assets, auth, google_photos, health, users
+from .routes import albums, assets, auth, google_photos, health, media_imports, users
 
 router = APIRouter()
 router.include_router(health.router)
 router.include_router(auth.router)
 router.include_router(users.router)
 router.include_router(albums.router)
+router.include_router(media_imports.router)
 router.include_router(assets.router)
 router.include_router(google_photos.router)

--- a/backend/app/api/v1/routes/media_imports.py
+++ b/backend/app/api/v1/routes/media_imports.py
@@ -27,10 +27,12 @@ from app.logic.media_import import (
     import_upload_files,
     persist_imported_media,
     process_saved_media,
+    validate_import_target,
 )
 from app.models.album import Album
 from app.models.google_photos import PickerSessionId
 from app.services.google_photos import (
+    DownloadTooLargeError,
     create_picker_session,
     download_media_to_file,
     get_media_items,
@@ -187,6 +189,16 @@ async def _persist_google_import(
         )
 
 
+async def _validate_google_import_target(
+    uid: int,
+    aid: str,
+    request: GoogleImportRequest,
+) -> None:
+    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+        album = await session.get_one(Album, (uid, aid))
+        await validate_import_target(session, album=album, request=request)
+
+
 @router.post(
     "/google",
     response_class=EventSourceResponse,
@@ -207,6 +219,7 @@ async def import_google_media(  # noqa: PLR0913
 
     written: list[Path] = []
     try:
+        await _validate_google_import_target(user.id, aid, body)
         with tempfile.TemporaryDirectory(
             dir=album_dir(user, aid), prefix=".import-google-"
         ) as tmp:
@@ -230,10 +243,17 @@ async def import_google_media(  # noqa: PLR0913
                 saved=saved,
             )
             names = await _persist_google_import(user.id, aid, body, imported)
+            written = []
             yield ImportCompleted(names=names)
-    except OverflowError as exc:
+    except (OverflowError, DownloadTooLargeError) as exc:
+        await cleanup_imported_paths(written)
+        yield ImportFailed(detail=str(exc))
+    except ValueError as exc:
         await cleanup_imported_paths(written)
         yield ImportFailed(detail=str(exc))
     except Exception:  # noqa: BLE001
         await cleanup_imported_paths(written)
         yield ImportFailed(detail="Media import failed unexpectedly.")
+    except BaseException:
+        await cleanup_imported_paths(written)
+        raise

--- a/backend/app/api/v1/routes/media_imports.py
+++ b/backend/app/api/v1/routes/media_imports.py
@@ -8,7 +8,10 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from fastapi.sse import EventSourceResponse
 from pydantic import BaseModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.db import get_engine
+from app.logic.layout.media import Media, MediaName
 from app.logic.media_import import (
     MAX_IMPORT_ITEMS,
     MAX_PHOTO_BYTES,
@@ -20,8 +23,10 @@ from app.logic.media_import import (
     ImportInProgress,
     ImportRequest,
     SavedInput,
-    import_saved_media,
+    cleanup_imported_paths,
     import_upload_files,
+    persist_imported_media,
+    process_saved_media,
 )
 from app.models.album import Album
 from app.models.google_photos import PickerSessionId
@@ -67,6 +72,17 @@ def _require_google_import_available(user: UserDep) -> None:
 
 
 GoogleImportAlbumDep = Annotated[Album, Depends(_get_album_or_404)]
+
+
+async def _snapshot_google_import_album(aid: str, user: UserDep) -> Album:
+    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+        album = await session.get(Album, (user.id, aid))
+        if album is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Album not found")
+        return album
+
+
+GoogleImportStreamAlbumDep = Annotated[Album, Depends(_snapshot_google_import_album)]
 
 
 async def _get_google_import_access_token(
@@ -139,18 +155,36 @@ async def _download_google_items(
     for index, item in enumerate(items):
         path = temp_dir / f"google-{index}"
         max_bytes = MAX_VIDEO_BYTES if item.type == "VIDEO" else MAX_PHOTO_BYTES
+        param = "=dv" if item.type == "VIDEO" else "=d"
         await download_media_to_file(
             http.gphotos_picker,
             item.media_file.base_url,
             access_token,
             path,
             max_bytes=max_bytes,
+            param=param,
         )
         size = path.stat().st_size
         total += size
         if total > MAX_VIDEO_BYTES:
             raise OverflowError("Import is too large")
         yield SavedInput(path=path, size=size)
+
+
+async def _persist_google_import(
+    uid: int,
+    aid: str,
+    request: GoogleImportRequest,
+    imported: list[Media],
+) -> list[MediaName]:
+    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+        album = await session.get_one(Album, (uid, aid))
+        return await persist_imported_media(
+            session,
+            album=album,
+            request=request,
+            imported=imported,
+        )
 
 
 @router.post(
@@ -162,11 +196,16 @@ async def import_google_media(  # noqa: PLR0913
     aid: str,
     body: GoogleImportRequest,
     user: UserDep,
-    session: SessionDep,
     http: HttpClientsDep,
-    album: GoogleImportAlbumDep,
+    album: GoogleImportStreamAlbumDep,
     access_token: GoogleImportAccessTokenDep,
 ) -> AsyncIterable[ImportEvent]:
+    aid = album.id
+    if body.context == "step" and body.step_id is None:
+        yield ImportFailed(detail="step_id is required for step imports")
+        return
+
+    written: list[Path] = []
     try:
         with tempfile.TemporaryDirectory(
             dir=album_dir(user, aid), prefix=".import-google-"
@@ -186,15 +225,15 @@ async def import_google_media(  # noqa: PLR0913
                     total=0,
                 )
 
-            names = await import_saved_media(
-                session,
-                album=album,
+            imported, written = await process_saved_media(
                 album_dir=album_dir(user, aid),
-                request=body,
                 saved=saved,
             )
+            names = await _persist_google_import(user.id, aid, body, imported)
             yield ImportCompleted(names=names)
     except OverflowError as exc:
+        await cleanup_imported_paths(written)
         yield ImportFailed(detail=str(exc))
     except Exception:  # noqa: BLE001
+        await cleanup_imported_paths(written)
         yield ImportFailed(detail="Media import failed unexpectedly.")

--- a/backend/app/api/v1/routes/media_imports.py
+++ b/backend/app/api/v1/routes/media_imports.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterable, AsyncIterator
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from fastapi.sse import EventSourceResponse
 from pydantic import BaseModel
 
@@ -64,6 +64,20 @@ def _require_google_import_available(user: UserDep) -> None:
             status.HTTP_400_BAD_REQUEST,
             "Google Photos not connected. Please authorize first.",
         )
+
+
+GoogleImportAlbumDep = Annotated[Album, Depends(_get_album_or_404)]
+
+
+async def _get_google_import_access_token(
+    user: UserDep,
+    http: HttpClientsDep,
+) -> str:
+    _require_google_import_available(user)
+    return await _ensure_fresh_access_token(http, user)
+
+
+GoogleImportAccessTokenDep = Annotated[str, Depends(_get_google_import_access_token)]
 
 
 @router.post("/device")
@@ -144,17 +158,15 @@ async def _download_google_items(
     response_class=EventSourceResponse,
     responses={200: {"model": list[ImportEvent]}},
 )
-async def import_google_media(
+async def import_google_media(  # noqa: PLR0913
     aid: str,
     body: GoogleImportRequest,
     user: UserDep,
     session: SessionDep,
     http: HttpClientsDep,
+    album: GoogleImportAlbumDep,
+    access_token: GoogleImportAccessTokenDep,
 ) -> AsyncIterable[ImportEvent]:
-    album = await _get_album_or_404(aid, user, session)
-    _require_google_import_available(user)
-    access_token = await _ensure_fresh_access_token(http, user)
-
     try:
         with tempfile.TemporaryDirectory(
             dir=album_dir(user, aid), prefix=".import-google-"

--- a/backend/app/api/v1/routes/media_imports.py
+++ b/backend/app/api/v1/routes/media_imports.py
@@ -155,37 +155,34 @@ async def import_google_media(
     _require_google_import_available(user)
     access_token = await _ensure_fresh_access_token(http, user)
 
-    async def _events() -> AsyncIterator[ImportEvent]:
-        try:
-            with tempfile.TemporaryDirectory(
-                dir=album_dir(user, aid), prefix=".import-google-"
-            ) as tmp:
-                temp_dir = Path(tmp)
-                saved: list[SavedInput] = []
-                async for item in _download_google_items(
-                    http=http,
-                    access_token=access_token,
-                    session_id=body.session_id,
-                    temp_dir=temp_dir,
-                ):
-                    saved.append(item)
-                    yield ImportInProgress(
-                        phase="downloading",
-                        done=len(saved),
-                        total=0,
-                    )
-
-                names = await import_saved_media(
-                    session,
-                    album=album,
-                    album_dir=album_dir(user, aid),
-                    request=body,
-                    saved=saved,
+    try:
+        with tempfile.TemporaryDirectory(
+            dir=album_dir(user, aid), prefix=".import-google-"
+        ) as tmp:
+            temp_dir = Path(tmp)
+            saved: list[SavedInput] = []
+            async for item in _download_google_items(
+                http=http,
+                access_token=access_token,
+                session_id=body.session_id,
+                temp_dir=temp_dir,
+            ):
+                saved.append(item)
+                yield ImportInProgress(
+                    phase="downloading",
+                    done=len(saved),
+                    total=0,
                 )
-                yield ImportCompleted(names=names)
-        except OverflowError as exc:
-            yield ImportFailed(detail=str(exc))
-        except Exception:  # noqa: BLE001
-            yield ImportFailed(detail="Media import failed unexpectedly.")
 
-    return _events()
+            names = await import_saved_media(
+                session,
+                album=album,
+                album_dir=album_dir(user, aid),
+                request=body,
+                saved=saved,
+            )
+            yield ImportCompleted(names=names)
+    except OverflowError as exc:
+        yield ImportFailed(detail=str(exc))
+    except Exception:  # noqa: BLE001
+        yield ImportFailed(detail="Media import failed unexpectedly.")

--- a/backend/app/api/v1/routes/media_imports.py
+++ b/backend/app/api/v1/routes/media_imports.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import tempfile
+from collections.abc import AsyncIterable, AsyncIterator
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
+from fastapi.sse import EventSourceResponse
+from pydantic import BaseModel
+
+from app.logic.media_import import (
+    MAX_IMPORT_ITEMS,
+    MAX_PHOTO_BYTES,
+    MAX_VIDEO_BYTES,
+    ImportCompleted,
+    ImportContext,
+    ImportEvent,
+    ImportFailed,
+    ImportInProgress,
+    ImportRequest,
+    SavedInput,
+    import_saved_media,
+    import_upload_files,
+)
+from app.models.album import Album
+from app.models.google_photos import PickerSessionId
+from app.services.google_photos import (
+    create_picker_session,
+    download_media_to_file,
+    get_media_items,
+)
+
+from ..deps import HttpClientsDep, SessionDep, UserDep, album_dir
+from .google_photos import _ensure_fresh_access_token
+
+router = APIRouter(prefix="/albums/{aid}/media-imports", tags=["media-imports"])
+
+
+class PickerSessionResponse(BaseModel):
+    session_id: PickerSessionId
+    picker_uri: str
+
+
+class GoogleImportRequest(ImportRequest):
+    session_id: PickerSessionId
+
+
+async def _get_album_or_404(aid: str, user: UserDep, session: SessionDep) -> Album:
+    album = await session.get(Album, (user.id, aid))
+    if album is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Album not found")
+    return album
+
+
+def _require_google_import_available(user: UserDep) -> None:
+    if not user.google_sub:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Google Photos import requires a Google account",
+        )
+    if user.google_photos_connected_at is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Google Photos not connected. Please authorize first.",
+        )
+
+
+@router.post("/device")
+async def import_device_media(  # noqa: PLR0913
+    aid: str,
+    user: UserDep,
+    session: SessionDep,
+    context: Annotated[ImportContext, Form()],
+    files: Annotated[list[UploadFile], File()],
+    step_id: Annotated[int | None, Form()] = None,
+) -> ImportCompleted:
+    album = await _get_album_or_404(aid, user, session)
+    try:
+        request = ImportRequest(context=context, step_id=step_id)
+        names = await import_upload_files(
+            session,
+            album=album,
+            album_dir=album_dir(user, aid),
+            request=request,
+            files=files,
+        )
+    except OverflowError as exc:
+        raise HTTPException(status.HTTP_413_CONTENT_TOO_LARGE, str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from None
+    return ImportCompleted(names=names)
+
+
+@router.post("/google/session")
+async def create_google_import_session(
+    aid: str,
+    user: UserDep,
+    session: SessionDep,
+    http: HttpClientsDep,
+) -> PickerSessionResponse:
+    await _get_album_or_404(aid, user, session)
+    _require_google_import_available(user)
+    access_token = await _ensure_fresh_access_token(http, user)
+    picker = await create_picker_session(
+        http.gphotos_picker,
+        access_token,
+        max_item_count=MAX_IMPORT_ITEMS,
+    )
+    return PickerSessionResponse(session_id=picker.id, picker_uri=picker.picker_uri)
+
+
+async def _download_google_items(
+    *,
+    http: HttpClientsDep,
+    access_token: str,
+    session_id: PickerSessionId,
+    temp_dir: Path,
+) -> AsyncIterator[SavedInput]:
+    items = await get_media_items(http.gphotos_picker, session_id, access_token)
+    if len(items) > MAX_IMPORT_ITEMS:
+        raise OverflowError("Too many files")
+
+    total = 0
+    for index, item in enumerate(items):
+        path = temp_dir / f"google-{index}"
+        max_bytes = MAX_VIDEO_BYTES if item.type == "VIDEO" else MAX_PHOTO_BYTES
+        await download_media_to_file(
+            http.gphotos_picker,
+            item.media_file.base_url,
+            access_token,
+            path,
+            max_bytes=max_bytes,
+        )
+        size = path.stat().st_size
+        total += size
+        if total > MAX_VIDEO_BYTES:
+            raise OverflowError("Import is too large")
+        yield SavedInput(path=path, size=size)
+
+
+@router.post(
+    "/google",
+    response_class=EventSourceResponse,
+    responses={200: {"model": list[ImportEvent]}},
+)
+async def import_google_media(
+    aid: str,
+    body: GoogleImportRequest,
+    user: UserDep,
+    session: SessionDep,
+    http: HttpClientsDep,
+) -> AsyncIterable[ImportEvent]:
+    album = await _get_album_or_404(aid, user, session)
+    _require_google_import_available(user)
+    access_token = await _ensure_fresh_access_token(http, user)
+
+    async def _events() -> AsyncIterator[ImportEvent]:
+        try:
+            with tempfile.TemporaryDirectory(
+                dir=album_dir(user, aid), prefix=".import-google-"
+            ) as tmp:
+                temp_dir = Path(tmp)
+                saved: list[SavedInput] = []
+                async for item in _download_google_items(
+                    http=http,
+                    access_token=access_token,
+                    session_id=body.session_id,
+                    temp_dir=temp_dir,
+                ):
+                    saved.append(item)
+                    yield ImportInProgress(
+                        phase="downloading",
+                        done=len(saved),
+                        total=0,
+                    )
+
+                names = await import_saved_media(
+                    session,
+                    album=album,
+                    album_dir=album_dir(user, aid),
+                    request=body,
+                    saved=saved,
+                )
+                yield ImportCompleted(names=names)
+        except OverflowError as exc:
+            yield ImportFailed(detail=str(exc))
+        except Exception:  # noqa: BLE001
+            yield ImportFailed(detail="Media import failed unexpectedly.")
+
+    return _events()

--- a/backend/app/logic/media_import.py
+++ b/backend/app/logic/media_import.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import tempfile
+import uuid
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Literal
+
+import anyio
+import pillow_heif  # noqa: F401 - registers HEIC plugin for Pillow
+from PIL import Image, UnidentifiedImageError
+from pydantic import BaseModel, Field
+
+from app.core.resources import MiB
+from app.core.worker_threads import run_sync
+from app.logic.layout.media import Media, MediaName, extract_frame, media_limiter
+from app.logic.media_upgrade.processing import process_photo_sync, process_video
+from app.models.album import Album
+from app.models.step import Step
+
+if TYPE_CHECKING:
+    from fastapi import UploadFile
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+ImportContext = Literal["step", "cover"]
+
+MAX_IMPORT_ITEMS = 50
+MAX_PHOTO_BYTES = 200 * MiB
+MAX_VIDEO_BYTES = 2 * 1024 * MiB
+MAX_BATCH_BYTES = MAX_VIDEO_BYTES
+_READ_SIZE = 1024 * 1024
+
+
+class ImportRequest(BaseModel):
+    context: ImportContext
+    step_id: int | None = None
+
+
+class ImportInProgress(BaseModel):
+    type: Literal["import_in_progress"] = "import_in_progress"
+    phase: str
+    done: int
+    total: int
+
+
+class ImportCompleted(BaseModel):
+    type: Literal["import_completed"] = "import_completed"
+    names: list[MediaName]
+
+
+class ImportFailed(BaseModel):
+    type: Literal["import_failed"] = "import_failed"
+    detail: str
+
+
+ImportEvent = Annotated[
+    ImportInProgress | ImportCompleted | ImportFailed,
+    Field(discriminator="type"),
+]
+
+
+@dataclass
+class SavedInput:
+    path: Path
+    size: int
+
+
+def _generated_name(suffix: Literal[".jpg", ".mp4"]) -> MediaName:
+    return f"{uuid.uuid4()}_{uuid.uuid4()}{suffix}"
+
+
+async def save_uploads(files: list[UploadFile], temp_dir: Path) -> list[SavedInput]:
+    if not files:
+        raise ValueError("No files selected")
+    if len(files) > MAX_IMPORT_ITEMS:
+        raise OverflowError("Too many files")
+
+    saved: list[SavedInput] = []
+    total = 0
+    for index, file in enumerate(files):
+        path = temp_dir / f"input-{index}"
+        size = 0
+        async with await anyio.open_file(path, "wb") as out:
+            while chunk := await file.read(_READ_SIZE):
+                size += len(chunk)
+                total += len(chunk)
+                if size > MAX_VIDEO_BYTES or total > MAX_BATCH_BYTES:
+                    raise OverflowError("Import is too large")
+                await out.write(chunk)
+        saved.append(SavedInput(path=path, size=size))
+    return saved
+
+
+def _process_photo(raw: Path, output: Path) -> tuple[int, int]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", Image.DecompressionBombWarning)
+        return process_photo_sync(raw, output)
+
+
+async def _import_one(raw: SavedInput, album_dir: Path) -> tuple[Media, Path]:
+    name = _generated_name(".jpg")
+    output = album_dir / name
+    try:
+        width, height = await run_sync(
+            _process_photo, raw.path, output, limiter=media_limiter
+        )
+        if raw.size > MAX_PHOTO_BYTES:
+            output.unlink(missing_ok=True)
+            raise OverflowError("Photo exceeds maximum size")
+        return Media(name=name, width=width, height=height), output
+    except (
+        UnidentifiedImageError,
+        Image.DecompressionBombError,
+        Image.DecompressionBombWarning,
+        OSError,
+        SyntaxError,
+    ):
+        output.unlink(missing_ok=True)
+
+    name = _generated_name(".mp4")
+    output = album_dir / name
+    try:
+        await process_video(raw.path, output)
+        media = await Media.probe(output)
+        await extract_frame(output)
+        media.name = name
+    except RuntimeError, OSError, ValueError:
+        output.unlink(missing_ok=True)
+        output.with_suffix(".jpg").unlink(missing_ok=True)
+        raise ValueError("Unsupported or corrupt media") from None
+    else:
+        return media, output
+
+
+async def import_saved_media(
+    session: AsyncSession,
+    *,
+    album: Album,
+    album_dir: Path,
+    request: ImportRequest,
+    saved: list[SavedInput],
+) -> list[MediaName]:
+    if request.context == "step" and request.step_id is None:
+        raise ValueError("step_id is required for step imports")
+
+    imported: list[Media] = []
+    written: list[Path] = []
+    try:
+        for item in saved:
+            media, path = await _import_one(item, album_dir)
+            imported.append(media)
+            written.append(path)
+
+        names = [m.name for m in imported]
+        album.media = [*album.media, *imported]
+        session.add(album)
+
+        if request.context == "step":
+            step = await session.get_one(Step, (album.uid, album.id, request.step_id))
+            step.unused = [*names, *step.unused]
+            session.add(step)
+
+        await session.commit()
+    except Exception:
+        for path in written:
+            await run_sync(path.unlink, missing_ok=True)
+            if path.suffix == ".mp4":
+                await run_sync(path.with_suffix(".jpg").unlink, missing_ok=True)
+        raise
+    else:
+        return names
+
+
+async def import_upload_files(
+    session: AsyncSession,
+    *,
+    album: Album,
+    album_dir: Path,
+    request: ImportRequest,
+    files: list[UploadFile],
+) -> list[MediaName]:
+    await run_sync(album_dir.mkdir, parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=album_dir, prefix=".import-") as tmp:
+        temp_dir = Path(tmp)
+        saved = await save_uploads(files, temp_dir)
+        return await import_saved_media(
+            session,
+            album=album,
+            album_dir=album_dir,
+            request=request,
+            saved=saved,
+        )

--- a/backend/app/logic/media_import.py
+++ b/backend/app/logic/media_import.py
@@ -144,6 +144,28 @@ async def import_saved_media(
     if request.context == "step" and request.step_id is None:
         raise ValueError("step_id is required for step imports")
 
+    written: list[Path] = []
+    try:
+        imported, written = await process_saved_media(
+            album_dir=album_dir,
+            saved=saved,
+        )
+        return await persist_imported_media(
+            session,
+            album=album,
+            request=request,
+            imported=imported,
+        )
+    except Exception:
+        await cleanup_imported_paths(written)
+        raise
+
+
+async def process_saved_media(
+    *,
+    album_dir: Path,
+    saved: list[SavedInput],
+) -> tuple[list[Media], list[Path]]:
     imported: list[Media] = []
     written: list[Path] = []
     try:
@@ -151,25 +173,40 @@ async def import_saved_media(
             media, path = await _import_one(item, album_dir)
             imported.append(media)
             written.append(path)
-
-        names = [m.name for m in imported]
-        album.media = [*album.media, *imported]
-        session.add(album)
-
-        if request.context == "step":
-            step = await session.get_one(Step, (album.uid, album.id, request.step_id))
-            step.unused = [*names, *step.unused]
-            session.add(step)
-
-        await session.commit()
     except Exception:
-        for path in written:
-            await run_sync(path.unlink, missing_ok=True)
-            if path.suffix == ".mp4":
-                await run_sync(path.with_suffix(".jpg").unlink, missing_ok=True)
+        await cleanup_imported_paths(written)
         raise
-    else:
-        return names
+    return imported, written
+
+
+async def persist_imported_media(
+    session: AsyncSession,
+    *,
+    album: Album,
+    request: ImportRequest,
+    imported: list[Media],
+) -> list[MediaName]:
+    if request.context == "step" and request.step_id is None:
+        raise ValueError("step_id is required for step imports")
+
+    names = [m.name for m in imported]
+    album.media = [*album.media, *imported]
+    session.add(album)
+
+    if request.context == "step":
+        step = await session.get_one(Step, (album.uid, album.id, request.step_id))
+        step.unused = [*names, *step.unused]
+        session.add(step)
+
+    await session.commit()
+    return names
+
+
+async def cleanup_imported_paths(written: list[Path]) -> None:
+    for path in written:
+        await run_sync(path.unlink, missing_ok=True)
+        if path.suffix == ".mp4":
+            await run_sync(path.with_suffix(".jpg").unlink, missing_ok=True)
 
 
 async def import_upload_files(

--- a/backend/app/logic/media_import.py
+++ b/backend/app/logic/media_import.py
@@ -11,6 +11,7 @@ import anyio
 import pillow_heif  # noqa: F401 - registers HEIC plugin for Pillow
 from PIL import Image, UnidentifiedImageError
 from pydantic import BaseModel, Field
+from sqlmodel import select
 
 from app.core.resources import MiB
 from app.core.worker_threads import run_sync
@@ -105,10 +106,6 @@ async def _import_one(raw: SavedInput, album_dir: Path) -> tuple[Media, Path]:
         width, height = await run_sync(
             _process_photo, raw.path, output, limiter=media_limiter
         )
-        if raw.size > MAX_PHOTO_BYTES:
-            output.unlink(missing_ok=True)
-            raise OverflowError("Photo exceeds maximum size")
-        return Media(name=name, width=width, height=height), output
     except (
         UnidentifiedImageError,
         Image.DecompressionBombError,
@@ -117,6 +114,14 @@ async def _import_one(raw: SavedInput, album_dir: Path) -> tuple[Media, Path]:
         SyntaxError,
     ):
         output.unlink(missing_ok=True)
+    except BaseException:
+        output.unlink(missing_ok=True)
+        raise
+    else:
+        if raw.size > MAX_PHOTO_BYTES:
+            output.unlink(missing_ok=True)
+            raise OverflowError("Photo exceeds maximum size")
+        return Media(name=name, width=width, height=height), output
 
     name = _generated_name(".mp4")
     output = album_dir / name
@@ -129,6 +134,10 @@ async def _import_one(raw: SavedInput, album_dir: Path) -> tuple[Media, Path]:
         output.unlink(missing_ok=True)
         output.with_suffix(".jpg").unlink(missing_ok=True)
         raise ValueError("Unsupported or corrupt media") from None
+    except BaseException:
+        output.unlink(missing_ok=True)
+        output.with_suffix(".jpg").unlink(missing_ok=True)
+        raise
     else:
         return media, output
 
@@ -141,8 +150,7 @@ async def import_saved_media(
     request: ImportRequest,
     saved: list[SavedInput],
 ) -> list[MediaName]:
-    if request.context == "step" and request.step_id is None:
-        raise ValueError("step_id is required for step imports")
+    await validate_import_target(session, album=album, request=request)
 
     written: list[Path] = []
     try:
@@ -150,15 +158,18 @@ async def import_saved_media(
             album_dir=album_dir,
             saved=saved,
         )
-        return await persist_imported_media(
+        names = await persist_imported_media(
             session,
             album=album,
             request=request,
             imported=imported,
         )
-    except Exception:
+        written = []
+    except BaseException:
         await cleanup_imported_paths(written)
         raise
+    else:
+        return names
 
 
 async def process_saved_media(
@@ -173,7 +184,7 @@ async def process_saved_media(
             media, path = await _import_one(item, album_dir)
             imported.append(media)
             written.append(path)
-    except Exception:
+    except BaseException:
         await cleanup_imported_paths(written)
         raise
     return imported, written
@@ -186,27 +197,61 @@ async def persist_imported_media(
     request: ImportRequest,
     imported: list[Media],
 ) -> list[MediaName]:
-    if request.context == "step" and request.step_id is None:
-        raise ValueError("step_id is required for step imports")
+    await validate_import_target(session, album=album, request=request)
 
+    album = await session.get_one(
+        Album,
+        (album.uid, album.id),
+        with_for_update=True,
+        populate_existing=True,
+    )
     names = [m.name for m in imported]
     album.media = [*album.media, *imported]
     session.add(album)
 
     if request.context == "step":
-        step = await session.get_one(Step, (album.uid, album.id, request.step_id))
+        result = await session.exec(
+            select(Step)
+            .where(
+                Step.uid == album.uid,
+                Step.aid == album.id,
+                Step.id == request.step_id,
+            )
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+        step = result.one_or_none()
+        if step is None:
+            raise ValueError("Step not found")
         step.unused = [*names, *step.unused]
         session.add(step)
 
-    await session.commit()
+    with anyio.CancelScope(shield=True):
+        await session.commit()
     return names
 
 
 async def cleanup_imported_paths(written: list[Path]) -> None:
-    for path in written:
-        await run_sync(path.unlink, missing_ok=True)
-        if path.suffix == ".mp4":
-            await run_sync(path.with_suffix(".jpg").unlink, missing_ok=True)
+    with anyio.CancelScope(shield=True):
+        for path in written:
+            await run_sync(path.unlink, missing_ok=True)
+            if path.suffix == ".mp4":
+                await run_sync(path.with_suffix(".jpg").unlink, missing_ok=True)
+
+
+async def validate_import_target(
+    session: AsyncSession,
+    *,
+    album: Album,
+    request: ImportRequest,
+) -> None:
+    if request.context != "step":
+        return
+    if request.step_id is None:
+        raise ValueError("step_id is required for step imports")
+    step = await session.get(Step, (album.uid, album.id, request.step_id))
+    if step is None:
+        raise ValueError("Step not found")
 
 
 async def import_upload_files(
@@ -217,6 +262,7 @@ async def import_upload_files(
     request: ImportRequest,
     files: list[UploadFile],
 ) -> list[MediaName]:
+    await validate_import_target(session, album=album, request=request)
     await run_sync(album_dir.mkdir, parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=album_dir, prefix=".import-") as tmp:
         temp_dir = Path(tmp)

--- a/backend/app/services/google_photos.py
+++ b/backend/app/services/google_photos.py
@@ -156,12 +156,18 @@ def _to_media_file(raw: _RawMediaFile) -> GoogleMediaFile:
 
 
 async def create_picker_session(
-    client: httpx.AsyncClient, access_token: AccessToken
+    client: httpx.AsyncClient,
+    access_token: AccessToken,
+    *,
+    max_item_count: int | None = None,
 ) -> PickerSession:
+    body: dict[str, object] = {}
+    if max_item_count is not None:
+        body["pickingConfig"] = {"maxItemCount": str(max_item_count)}
     resp = await client.post(
         f"{_PICKER_BASE}/v1/sessions",
         headers=_picker_headers(access_token),
-        json={},
+        json=body,
     )
     resp.raise_for_status()
     data = _SessionResponse.model_validate_json(resp.content)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1282,6 +1282,24 @@
             "description": "Successful Response",
             "content": {
               "text/event-stream": {
+                "itemSchema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "string"
+                    },
+                    "event": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "retry": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                },
                 "schema": {
                   "type": "array",
                   "items": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1155,6 +1155,174 @@
         }
       }
     },
+    "/api/v1/albums/{aid}/media-imports/device": {
+      "post": {
+        "tags": [
+          "media-imports"
+        ],
+        "summary": "Import Device Media",
+        "operationId": "import_device_media",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_device_media"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportCompleted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/albums/{aid}/media-imports/google/session": {
+      "post": {
+        "tags": [
+          "media-imports"
+        ],
+        "summary": "Create Google Import Session",
+        "operationId": "create_google_import_session",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PickerSessionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/albums/{aid}/media-imports/google": {
+      "post": {
+        "tags": [
+          "media-imports"
+        ],
+        "summary": "Import Google Media",
+        "operationId": "import_google_media",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleImportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/ImportInProgress"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ImportCompleted"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ImportFailed"
+                      }
+                    ],
+                    "discriminator": {
+                      "propertyName": "type",
+                      "mapping": {
+                        "import_in_progress": "#/components/schemas/ImportInProgress",
+                        "import_completed": "#/components/schemas/ImportCompleted",
+                        "import_failed": "#/components/schemas/ImportFailed"
+                      }
+                    }
+                  },
+                  "title": "Response 200 Import Google Media"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/albums/{aid}/media/{name}": {
       "get": {
         "tags": [
@@ -2126,6 +2294,43 @@
         ],
         "title": "AuthState"
       },
+      "Body_import_device_media": {
+        "properties": {
+          "context": {
+            "type": "string",
+            "enum": [
+              "step",
+              "cover"
+            ],
+            "title": "Context"
+          },
+          "files": {
+            "items": {
+              "type": "string",
+              "contentMediaType": "application/octet-stream"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Step Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "context",
+          "files"
+        ],
+        "title": "Body_import_device_media"
+      },
       "Body_upload_data": {
         "properties": {
           "file": {
@@ -2302,6 +2507,38 @@
         ],
         "title": "ExportProgress"
       },
+      "GoogleImportRequest": {
+        "properties": {
+          "context": {
+            "type": "string",
+            "enum": [
+              "step",
+              "cover"
+            ],
+            "title": "Context"
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Step Id"
+          },
+          "session_id": {
+            "$ref": "#/components/schemas/PickerSessionId"
+          }
+        },
+        "type": "object",
+        "required": [
+          "context",
+          "session_id"
+        ],
+        "title": "GoogleImportRequest"
+      },
       "GoogleMediaId": {
         "type": "string",
         "maxLength": 256,
@@ -2342,6 +2579,77 @@
           "playwright"
         ],
         "title": "HealthStatus"
+      },
+      "ImportCompleted": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "import_completed",
+            "title": "Type",
+            "default": "import_completed"
+          },
+          "names": {
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|mp4)$"
+            },
+            "type": "array",
+            "title": "Names"
+          }
+        },
+        "type": "object",
+        "required": [
+          "names"
+        ],
+        "title": "ImportCompleted"
+      },
+      "ImportFailed": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "import_failed",
+            "title": "Type",
+            "default": "import_failed"
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "detail"
+        ],
+        "title": "ImportFailed"
+      },
+      "ImportInProgress": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "import_in_progress",
+            "title": "Type",
+            "default": "import_in_progress"
+          },
+          "phase": {
+            "type": "string",
+            "title": "Phase"
+          },
+          "done": {
+            "type": "integer",
+            "title": "Done"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phase",
+          "done",
+          "total"
+        ],
+        "title": "ImportInProgress"
       },
       "Location": {
         "properties": {

--- a/backend/tests/test_media_import.py
+++ b/backend/tests/test_media_import.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
+import inspect
 import io
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from httpx_oauth.oauth2 import OAuth2Token
 from PIL import Image
 from pydantic import TypeAdapter
 
 from app.api.v1.deps import _get_http_clients
+from app.api.v1.routes.media_imports import _download_google_items, import_google_media
 from app.core.config import get_settings
 from app.logic.layout.media import MediaName
 from app.logic.media_import import SavedInput
 from app.main import app
 from app.models.album import Album
+from app.models.google_photos import GoogleMediaFile, PickedMediaItem
 from app.models.step import Step
 
 from .conftest import _mock_http_clients
@@ -29,6 +33,7 @@ from .factories import (
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncEngine
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 _media_name_adapter = TypeAdapter(MediaName)
@@ -125,6 +130,14 @@ class TestDeviceMediaImport:
 
 
 class TestGoogleMediaImport:
+    @pytest.fixture(autouse=True)
+    def _pin_route_engine(self, engine: AsyncEngine) -> Iterator[None]:
+        with patch("app.api.v1.routes.media_imports.get_engine", return_value=engine):
+            yield
+
+    def test_google_import_stream_does_not_request_route_session(self) -> None:
+        assert "session" not in inspect.signature(import_google_media).parameters
+
     async def test_import_session_uses_fifty_item_picker_limit(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
@@ -175,9 +188,20 @@ class TestGoogleMediaImport:
             path.write_bytes(data)
             yield SavedInput(path=path, size=len(data))
 
-        with patch(
-            "app.api.v1.routes.media_imports._download_google_items",
-            fake_download,
+        with (
+            patch(
+                "app.api.v1.routes.media_imports._download_google_items",
+                fake_download,
+            ),
+            patch(
+                "app.api.v1.routes.media_imports._persist_google_import",
+                AsyncMock(
+                    return_value=[
+                        "11111111-1111-4111-8111-111111111111_"
+                        "22222222-2222-4222-8222-222222222222.jpg"
+                    ]
+                ),
+            ),
         ):
             resp = await client.post(
                 f"/api/v1/albums/{AID}/media-imports/google",
@@ -201,3 +225,47 @@ class TestGoogleMediaImport:
 
         assert resp.status_code == 400
         assert "text/event-stream" not in resp.headers.get("content-type", "")
+
+    async def test_google_video_import_downloads_video_variant(
+        self, tmp_path: Path
+    ) -> None:
+        http = _mock_http_clients()
+        item = PickedMediaItem(
+            id="video-1",
+            create_time="2024-01-01T00:00:00Z",
+            type="VIDEO",
+            media_file=GoogleMediaFile(
+                base_url="https://lh3.googleusercontent.com/video",
+                mime_type="video/mp4",
+                filename="video.mp4",
+            ),
+        )
+
+        async def fake_download(*args: object, **kwargs: object) -> None:
+            dest = args[3]
+            assert isinstance(dest, Path)
+            dest.write_bytes(b"video")
+
+        with (
+            patch(
+                "app.api.v1.routes.media_imports.get_media_items",
+                AsyncMock(return_value=[item]),
+            ),
+            patch(
+                "app.api.v1.routes.media_imports.download_media_to_file",
+                AsyncMock(side_effect=fake_download),
+            ) as download,
+        ):
+            access = "fresh-token"
+            saved = [
+                item
+                async for item in _download_google_items(
+                    http=http,
+                    access_token=access,
+                    session_id="session-abc",
+                    temp_dir=tmp_path,
+                )
+            ]
+
+        assert len(saved) == 1
+        assert download.await_args.kwargs["param"] == "=dv"

--- a/backend/tests/test_media_import.py
+++ b/backend/tests/test_media_import.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import io
 from collections.abc import AsyncIterator, Iterator
@@ -7,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import anyio
 import pytest
 from httpx_oauth.oauth2 import OAuth2Token
 from PIL import Image
@@ -15,12 +17,20 @@ from pydantic import TypeAdapter
 from app.api.v1.deps import _get_http_clients
 from app.api.v1.routes.media_imports import _download_google_items, import_google_media
 from app.core.config import get_settings
-from app.logic.layout.media import MediaName
-from app.logic.media_import import SavedInput
+from app.logic.layout.media import Media, MediaName
+from app.logic.media_import import (
+    ImportRequest,
+    SavedInput,
+    _import_one,
+    import_saved_media,
+    persist_imported_media,
+    process_saved_media,
+)
 from app.main import app
 from app.models.album import Album
 from app.models.google_photos import GoogleMediaFile, PickedMediaItem
 from app.models.step import Step
+from app.services.google_photos import DownloadTooLargeError
 
 from .conftest import _mock_http_clients
 from .factories import (
@@ -60,6 +70,11 @@ async def _signed_in_album(
     album_dir.mkdir(parents=True, exist_ok=True)
     await session.flush()
     return uid
+
+
+async def _no_saved_inputs(**_kwargs: object) -> AsyncIterator[SavedInput]:
+    for item in ():
+        yield item
 
 
 class TestDeviceMediaImport:
@@ -128,6 +143,25 @@ class TestDeviceMediaImport:
 
         assert resp.status_code == 413
 
+    async def test_rejects_missing_step_before_saving_uploads(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+
+        with patch(
+            "app.logic.media_import.save_uploads",
+            AsyncMock(),
+        ) as save_uploads:
+            resp = await client.post(
+                f"/api/v1/albums/{AID}/media-imports/device",
+                data={"context": "step", "step_id": "999"},
+                files={"files": ("holiday.jpg", _jpeg_bytes(), "image/jpeg")},
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Step not found"
+        save_uploads.assert_not_awaited()
+
 
 class TestGoogleMediaImport:
     @pytest.fixture(autouse=True)
@@ -190,6 +224,10 @@ class TestGoogleMediaImport:
 
         with (
             patch(
+                "app.api.v1.routes.media_imports._validate_google_import_target",
+                AsyncMock(),
+            ),
+            patch(
                 "app.api.v1.routes.media_imports._download_google_items",
                 fake_download,
             ),
@@ -212,6 +250,83 @@ class TestGoogleMediaImport:
         assert "import_in_progress" in resp.text
         assert "import_completed" in resp.text
         assert ".jpg" in resp.text
+
+    async def test_google_import_stream_reports_download_size_errors(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        users_dir = get_settings().USERS_FOLDER
+        uid = await _signed_in_album(client, session, users_dir)
+        await connect_google_photos(session, uid)
+
+        http = _mock_http_clients()
+        app.dependency_overrides[_get_http_clients] = lambda: http
+        http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
+            {"access_token": "fresh-token", "expires_in": 3600}
+        )
+
+        async def fail_download(**_kwargs: object) -> AsyncIterator[SavedInput]:
+            async for item in _no_saved_inputs():
+                yield item
+            raise DownloadTooLargeError("Download exceeds 200 MB limit")
+
+        with (
+            patch(
+                "app.api.v1.routes.media_imports._validate_google_import_target",
+                AsyncMock(),
+            ),
+            patch(
+                "app.api.v1.routes.media_imports._download_google_items",
+                fail_download,
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/albums/{AID}/media-imports/google",
+                json={"context": "cover", "session_id": "session-abc"},
+            )
+
+        assert resp.status_code == 200
+        assert "Download exceeds 200 MB limit" in resp.text
+        assert "Media import failed unexpectedly." not in resp.text
+
+    async def test_google_import_validates_step_before_download(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        users_dir = get_settings().USERS_FOLDER
+        uid = await _signed_in_album(client, session, users_dir)
+        await connect_google_photos(session, uid)
+
+        http = _mock_http_clients()
+        app.dependency_overrides[_get_http_clients] = lambda: http
+        http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
+            {"access_token": "fresh-token", "expires_in": 3600}
+        )
+        downloaded = False
+
+        async def fake_download(**_kwargs: object) -> AsyncIterator[SavedInput]:
+            nonlocal downloaded
+            downloaded = True
+            async for item in _no_saved_inputs():
+                yield item
+
+        with (
+            patch(
+                "app.api.v1.routes.media_imports._validate_google_import_target",
+                AsyncMock(side_effect=ValueError("Step not found")),
+            ),
+            patch(
+                "app.api.v1.routes.media_imports._download_google_items",
+                fake_download,
+            ),
+        ):
+            resp = await client.post(
+                f"/api/v1/albums/{AID}/media-imports/google",
+                json={"context": "step", "step_id": 999, "session_id": "session-abc"},
+            )
+
+        assert resp.status_code == 200
+        assert "Step not found" in resp.text
+        assert "Media import failed unexpectedly." not in resp.text
+        assert not downloaded
 
     async def test_google_import_validation_returns_http_error_before_stream(
         self, client: AsyncClient, session: AsyncSession
@@ -269,3 +384,179 @@ class TestGoogleMediaImport:
 
         assert len(saved) == 1
         assert download.await_args.kwargs["param"] == "=dv"
+
+
+class TestPersistImportedMedia:
+    async def test_import_one_cleans_current_video_on_cancellation(
+        self, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "imported.mp4"
+        poster = tmp_path / "imported.jpg"
+
+        def fake_generated_name(suffix: str) -> str:
+            return f"imported{suffix}"
+
+        async def cancel_video(_raw: Path, target: Path) -> None:
+            await anyio.Path(target).write_bytes(b"video")
+            await anyio.Path(poster).write_bytes(b"poster")
+            raise asyncio.CancelledError
+
+        with (
+            patch("app.logic.media_import._process_photo", side_effect=OSError),
+            patch("app.logic.media_import._generated_name", fake_generated_name),
+            patch("app.logic.media_import.process_video", cancel_video),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await _import_one(SavedInput(path=tmp_path / "raw", size=1), tmp_path)
+
+        assert not output.exists()
+        assert not poster.exists()
+
+    async def test_process_saved_media_cleans_written_file_on_cancellation(
+        self, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "imported.jpg"
+        output.write_bytes(b"imported")
+        media = Media(name="imported.jpg", width=640, height=480)
+
+        with (
+            patch(
+                "app.logic.media_import._import_one",
+                AsyncMock(
+                    side_effect=[
+                        (media, output),
+                        asyncio.CancelledError(),
+                    ],
+                ),
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await process_saved_media(
+                album_dir=tmp_path,
+                saved=[
+                    SavedInput(path=tmp_path / "raw-1", size=1),
+                    SavedInput(path=tmp_path / "raw-2", size=1),
+                ],
+            )
+
+        assert not output.exists()
+
+    async def test_import_saved_media_keeps_files_after_successful_persist(
+        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+    ) -> None:
+        uid = await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+        album = await session.get_one(Album, (uid, AID))
+        output = tmp_path / "imported.jpg"
+        output.write_bytes(b"imported")
+        media = Media(name="imported.jpg", width=640, height=480)
+
+        with (
+            patch(
+                "app.logic.media_import.process_saved_media",
+                AsyncMock(return_value=([media], [output])),
+            ),
+            patch(
+                "app.logic.media_import.persist_imported_media",
+                AsyncMock(return_value=["imported.jpg"]),
+            ),
+        ):
+            names = await import_saved_media(
+                session,
+                album=album,
+                album_dir=tmp_path,
+                request=ImportRequest(context="cover"),
+                saved=[SavedInput(path=tmp_path / "raw", size=1)],
+            )
+
+        assert names == ["imported.jpg"]
+        assert output.exists()
+
+    async def test_import_saved_media_cleans_processed_file_on_cancellation(
+        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+    ) -> None:
+        uid = await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+        album = await session.get_one(Album, (uid, AID))
+        output = tmp_path / "imported.jpg"
+        output.write_bytes(b"imported")
+        media = Media(name="imported.jpg", width=640, height=480)
+
+        with (
+            patch(
+                "app.logic.media_import.process_saved_media",
+                AsyncMock(return_value=([media], [output])),
+            ),
+            patch(
+                "app.logic.media_import.persist_imported_media",
+                AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await import_saved_media(
+                session,
+                album=album,
+                album_dir=tmp_path,
+                request=ImportRequest(context="cover"),
+                saved=[SavedInput(path=tmp_path / "raw", size=1)],
+            )
+
+        assert not output.exists()
+
+    async def test_refetches_album_before_appending_media(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        uid = await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+        stale_album = await session.get_one(Album, (uid, AID))
+
+        other = Media(name="other.jpg", width=640, height=480)
+        with session.no_autoflush:
+            fresh_album = await session.get_one(
+                Album,
+                (uid, AID),
+                populate_existing=True,
+            )
+            fresh_album.media = [*fresh_album.media, other]
+            session.add(fresh_album)
+            await session.flush()
+
+            imported = Media(name="imported.jpg", width=640, height=480)
+            await persist_imported_media(
+                session,
+                album=stale_album,
+                request=ImportRequest(context="cover"),
+                imported=[imported],
+            )
+
+        album = await session.get_one(Album, (uid, AID), populate_existing=True)
+        assert [m.name for m in album.media][-2:] == ["other.jpg", "imported.jpg"]
+
+    async def test_refetches_step_before_prepending_unused_media(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        uid = await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+        album = await session.get_one(Album, (uid, AID))
+
+        with session.no_autoflush:
+            stale_step = await session.get_one(Step, (uid, AID, 1))
+            stale_step.unused = ["stale.jpg"]
+            session.add(stale_step)
+            await session.flush()
+
+            fresh_step = await session.get_one(
+                Step,
+                (uid, AID, 1),
+                populate_existing=True,
+            )
+            fresh_step.unused = ["concurrent.jpg"]
+            session.add(fresh_step)
+            await session.flush()
+
+            imported = Media(name="imported.jpg", width=640, height=480)
+            await persist_imported_media(
+                session,
+                album=album,
+                request=ImportRequest(context="step", step_id=1),
+                imported=[imported],
+            )
+
+        step = await session.get_one(Step, (uid, AID, 1), populate_existing=True)
+        assert step.unused[:2] == ["imported.jpg", "concurrent.jpg"]

--- a/backend/tests/test_media_import.py
+++ b/backend/tests/test_media_import.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from httpx_oauth.oauth2 import OAuth2Token
+from PIL import Image
+from pydantic import TypeAdapter
+
+from app.api.v1.deps import _get_http_clients
+from app.core.config import get_settings
+from app.logic.layout.media import MediaName
+from app.main import app
+from app.models.album import Album
+from app.models.step import Step
+
+from .conftest import _mock_http_clients
+from .factories import (
+    AID,
+    connect_google_photos,
+    insert_album,
+    insert_step,
+    sign_in_and_upload,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import AsyncClient
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+_media_name_adapter = TypeAdapter(MediaName)
+
+
+def _jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color="red").save(buf, "JPEG")
+    return buf.getvalue()
+
+
+async def _signed_in_album(
+    client: AsyncClient,
+    session: AsyncSession,
+    users_dir: Path,
+) -> int:
+    user_data = await sign_in_and_upload(client, users_dir, provider="google")
+    uid = user_data["id"]
+    album = await insert_album(session, uid)
+    album.front_cover_photo = "photo1.jpg"
+    album.back_cover_photo = "photo1.jpg"
+    await insert_step(session, uid)
+    album_dir = users_dir / str(uid) / "trip" / AID
+    album_dir.mkdir(parents=True, exist_ok=True)
+    await session.flush()
+    return uid
+
+
+class TestDeviceMediaImport:
+    async def test_step_import_prepends_to_unused(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        uid = await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+
+        resp = await client.post(
+            f"/api/v1/albums/{AID}/media-imports/device",
+            data={"context": "step", "step_id": "1"},
+            files=[
+                ("files", ("holiday.jpg", _jpeg_bytes(640, 480), "image/jpeg")),
+                ("files", ("ignored-name.jpg", _jpeg_bytes(800, 600), "image/jpeg")),
+            ],
+        )
+
+        assert resp.status_code == 200
+        imported = resp.json()["names"]
+        assert len(imported) == 2
+        for name in imported:
+            _media_name_adapter.validate_python(name)
+
+        step = await session.get_one(Step, (uid, AID, 1))
+        assert step.unused[:2] == imported
+        assert step.unused[2:] == ["photo2.jpg"]
+
+        album = await session.get_one(Album, (uid, AID))
+        assert [m.name for m in album.media][-2:] == imported
+
+    async def test_cover_import_does_not_select_cover(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        uid = await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+
+        resp = await client.post(
+            f"/api/v1/albums/{AID}/media-imports/device",
+            data={"context": "cover"},
+            files={"files": ("cover.jpg", _jpeg_bytes(900, 600), "image/jpeg")},
+        )
+
+        assert resp.status_code == 200
+        imported = resp.json()["names"]
+        assert len(imported) == 1
+
+        album = await session.get_one(Album, (uid, AID))
+        assert album.front_cover_photo == "photo1.jpg"
+        assert album.back_cover_photo == "photo1.jpg"
+        assert album.media[-1].name == imported[0]
+
+        step = await session.get_one(Step, (uid, AID, 1))
+        assert step.unused == ["photo2.jpg"]
+
+    async def test_rejects_more_than_fifty_files(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+
+        resp = await client.post(
+            f"/api/v1/albums/{AID}/media-imports/device",
+            data={"context": "cover"},
+            files=[
+                ("files", (f"{i}.jpg", _jpeg_bytes(), "image/jpeg")) for i in range(51)
+            ],
+        )
+
+        assert resp.status_code == 413
+
+
+class TestGoogleMediaImport:
+    async def test_import_session_uses_fifty_item_picker_limit(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        users_dir = get_settings().USERS_FOLDER
+        uid = await _signed_in_album(client, session, users_dir)
+        await connect_google_photos(session, uid)
+
+        http = _mock_http_clients()
+        app.dependency_overrides[_get_http_clients] = lambda: http
+        http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
+            {"access_token": "fresh-token", "expires_in": 3600}
+        )
+        mock_picker = AsyncMock()
+        mock_picker.return_value.id = "session-abc"
+        mock_picker.return_value.picker_uri = "https://photos.google.com/picker/abc"
+
+        with patch(
+            "app.api.v1.routes.media_imports.create_picker_session",
+            mock_picker,
+        ):
+            resp = await client.post(
+                f"/api/v1/albums/{AID}/media-imports/google/session"
+            )
+
+        assert resp.status_code == 200
+        mock_picker.assert_awaited_once_with(
+            http.gphotos_picker,
+            "fresh-token",
+            max_item_count=50,
+        )

--- a/backend/tests/test_media_import.py
+++ b/backend/tests/test_media_import.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import io
+from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -11,6 +13,7 @@ from pydantic import TypeAdapter
 from app.api.v1.deps import _get_http_clients
 from app.core.config import get_settings
 from app.logic.layout.media import MediaName
+from app.logic.media_import import SavedInput
 from app.main import app
 from app.models.album import Album
 from app.models.step import Step
@@ -25,8 +28,6 @@ from .factories import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -154,3 +155,36 @@ class TestGoogleMediaImport:
             "fresh-token",
             max_item_count=50,
         )
+
+    async def test_google_import_stream_emits_completion(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        users_dir = get_settings().USERS_FOLDER
+        uid = await _signed_in_album(client, session, users_dir)
+        await connect_google_photos(session, uid)
+
+        http = _mock_http_clients()
+        app.dependency_overrides[_get_http_clients] = lambda: http
+        http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
+            {"access_token": "fresh-token", "expires_in": 3600}
+        )
+
+        async def fake_download(**kwargs: object) -> AsyncIterator[SavedInput]:
+            path = Path(kwargs["temp_dir"]) / "google-source"
+            data = _jpeg_bytes()
+            path.write_bytes(data)
+            yield SavedInput(path=path, size=len(data))
+
+        with patch(
+            "app.api.v1.routes.media_imports._download_google_items",
+            fake_download,
+        ):
+            resp = await client.post(
+                f"/api/v1/albums/{AID}/media-imports/google",
+                json={"context": "cover", "session_id": "session-abc"},
+            )
+
+        assert resp.status_code == 200
+        assert "import_in_progress" in resp.text
+        assert "import_completed" in resp.text
+        assert ".jpg" in resp.text

--- a/backend/tests/test_media_import.py
+++ b/backend/tests/test_media_import.py
@@ -188,3 +188,16 @@ class TestGoogleMediaImport:
         assert "import_in_progress" in resp.text
         assert "import_completed" in resp.text
         assert ".jpg" in resp.text
+
+    async def test_google_import_validation_returns_http_error_before_stream(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        await _signed_in_album(client, session, get_settings().USERS_FOLDER)
+
+        resp = await client.post(
+            f"/api/v1/albums/{AID}/media-imports/google",
+            json={"context": "cover", "session_id": "session-abc"},
+        )
+
+        assert resp.status_code == 400
+        assert "text/event-stream" not in resp.headers.get("content-type", "")

--- a/frontend/e2e/active-step-sync.test.ts
+++ b/frontend/e2e/active-step-sync.test.ts
@@ -12,6 +12,9 @@ test.describe("Active step sync", () => {
     const nav = page.getByRole("navigation");
     await nav.getByText("Argentina").click();
     await nav.locator('[data-nav-step="102"]').click();
+    await expect(
+      page.getByLabel("Inspector").getByText("Unused"),
+    ).toBeVisible();
 
     let importedStepId: string | null = null;
     await page.route(

--- a/frontend/e2e/active-step-sync.test.ts
+++ b/frontend/e2e/active-step-sync.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Active step sync", () => {
+  test("nav click keeps viewer, nav active state, and inspector target aligned", async ({
+    focusPage: page,
+  }) => {
+    await page.goto("/editor");
+    await expect(page.getByText("South America")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const nav = page.getByRole("navigation");
+    await nav.getByText("Argentina").click();
+    await nav.locator('[data-nav-step="102"]').click();
+
+    let importedStepId: string | null = null;
+    await page.route(
+      "**/api/v1/albums/*/media-imports/device",
+      async (route) => {
+        const headers = {
+          "access-control-allow-credentials": "true",
+          "access-control-allow-headers": "*",
+          "access-control-allow-methods": "POST, OPTIONS",
+          "access-control-allow-origin": new URL(page.url()).origin,
+        };
+        if (route.request().method() === "OPTIONS") {
+          await route.fulfill({ headers, status: 204 });
+          return;
+        }
+        const form = route.request().postDataBuffer();
+        importedStepId =
+          form.toString("utf8").match(/name="step_id"\r\n\r\n(\d+)/)?.[1] ??
+          null;
+        await route.fulfill({
+          headers: { ...headers, "content-type": "application/json" },
+          status: 200,
+          body: JSON.stringify({ type: "import_completed", names: [] }),
+        });
+      },
+    );
+
+    const fileChooser = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: "Add media" }).click();
+    await page.getByRole("menuitem", { name: "Device" }).click();
+    const chooser = await fileChooser;
+    await chooser.setFiles({
+      name: "import.jpg",
+      mimeType: "image/jpeg",
+      buffer: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+    });
+    await expect.poll(() => importedStepId).toBe("102");
+  });
+});

--- a/frontend/e2e/media-import.test.ts
+++ b/frontend/e2e/media-import.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "./fixtures";
-import { mockMedia, mockStep } from "../tests/fixtures/mocks";
+import {
+  mockAlbum,
+  mockMedia,
+  mockStep,
+  mockUser,
+} from "../tests/fixtures/mocks";
 
 const API = "**/api/v1";
 const IMPORTED =
@@ -54,7 +59,7 @@ test.describe("Media import", () => {
       timeout: 15_000,
     });
     await page.getByRole("button", { name: "Expand", exact: true }).click();
-    await page.getByText("Amsterdam").first().click();
+    await page.locator('[data-nav-step="1"]').click();
     await expect(
       unusedDrawer(page).getByText("0", { exact: true }),
     ).toBeVisible();
@@ -90,5 +95,102 @@ test.describe("Media import", () => {
         importedImage.evaluate((img) => (img as HTMLImageElement).naturalWidth),
       )
       .toBeGreaterThan(0);
+  });
+
+  test("step import overlay resets when changing albums", async ({
+    authedPage: page,
+  }) => {
+    let imported = false;
+
+    await page.route(`${API}/users`, (route) =>
+      route.fulfill({
+        json: { ...mockUser, album_ids: ["aid-1", "aid-2"] },
+      }),
+    );
+    await page.route(`${API}/albums/*`, (route) => {
+      const aid = new URL(route.request().url()).pathname
+        .split("/albums/")[1]
+        ?.split("/")[0];
+      return route.fulfill({
+        json: {
+          ...mockAlbum,
+          id: aid,
+          title: aid === "aid-2" ? "Second Album" : mockAlbum.title,
+        },
+      });
+    });
+    await page.route(`${API}/albums/*/steps`, (route) =>
+      route.fulfill({ json: [mockStep] }),
+    );
+    await page.route(`${API}/albums/*/media`, (route) => {
+      const aid = new URL(route.request().url()).pathname
+        .split("/albums/")[1]
+        ?.split("/")[0];
+      const media =
+        imported && aid === "aid-1"
+          ? [...mockMedia, { name: IMPORTED, width: 640, height: 480 }]
+          : mockMedia;
+      return route.fulfill({ json: media });
+    });
+    await page.route(`${API}/albums/*/media-imports/device`, async (route) => {
+      const headers = {
+        "access-control-allow-credentials": "true",
+        "access-control-allow-headers": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-origin": new URL(page.url()).origin,
+      };
+      if (route.request().method() === "OPTIONS") {
+        await route.fulfill({ headers, status: 204 });
+        return;
+      }
+      imported = true;
+      await route.fulfill({
+        headers: {
+          ...headers,
+          "content-type": "application/json",
+        },
+        status: 200,
+        body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
+      });
+    });
+
+    await page.goto("/editor");
+    await expect(page.getByText("South America")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByRole("button", { name: "Expand", exact: true }).click();
+    await page.locator('[data-nav-step="1"]').click();
+    await expect(
+      unusedDrawer(page).getByText("0", { exact: true }),
+    ).toBeVisible();
+
+    const fileChooser = page.waitForEvent("filechooser");
+    await page
+      .getByRole("button", { name: "Add media" })
+      .click({ force: true });
+    await expect(page.getByRole("menuitem", { name: "Device" })).toBeVisible();
+    await page.getByRole("menuitem", { name: "Device" }).click();
+    const chooser = await fileChooser;
+    await chooser.setFiles({
+      name: "import.jpg",
+      mimeType: "image/jpeg",
+      buffer: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+    });
+    await expect(
+      unusedDrawer(page).getByText("1", { exact: true }),
+    ).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByLabel("Select album").click();
+    await page.getByRole("option", { name: "Aid 2" }).click();
+    await page.getByRole("button", { name: "Expand", exact: true }).click();
+    await page.locator('[data-nav-step="1"]').click();
+
+    await expect(
+      unusedDrawer(page).getByText("0", { exact: true }),
+    ).toBeVisible({
+      timeout: 5_000,
+    });
   });
 });

--- a/frontend/e2e/media-import.test.ts
+++ b/frontend/e2e/media-import.test.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "./fixtures";
+import { mockMedia, mockStep } from "../tests/fixtures/mocks";
+
+const API = "**/api/v1";
+const IMPORTED =
+  "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg";
+
+function unusedDrawer(page: import("@playwright/test").Page) {
+  return page.getByLabel("Inspector").filter({ hasText: "Unused" });
+}
+
+test.describe("Media import", () => {
+  test("device import into a step appears in the unused tray", async ({
+    authedPage: page,
+  }) => {
+    let imported = false;
+
+    await page.route(`${API}/albums/*/media-imports/device`, async (route) => {
+      const headers = {
+        "access-control-allow-credentials": "true",
+        "access-control-allow-headers": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-origin": new URL(page.url()).origin,
+      };
+      if (route.request().method() === "OPTIONS") {
+        await route.fulfill({ headers, status: 204 });
+        return;
+      }
+      imported = true;
+      await route.fulfill({
+        headers: {
+          ...headers,
+          "content-type": "application/json",
+        },
+        status: 200,
+        body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
+      });
+    });
+    await page.route(`${API}/albums/*/steps`, async (route) => {
+      const steps = imported
+        ? [{ ...mockStep, unused: [IMPORTED, ...mockStep.unused] }]
+        : [mockStep];
+      await route.fulfill({ json: steps });
+    });
+    await page.route(`${API}/albums/*/media`, async (route) => {
+      const media = imported
+        ? [...mockMedia, { name: IMPORTED, width: 640, height: 480 }]
+        : mockMedia;
+      await route.fulfill({ json: media });
+    });
+
+    await page.goto("/editor");
+    await expect(page.getByText("South America")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByRole("button", { name: "Expand", exact: true }).click();
+    await page.getByText("Amsterdam").first().click();
+    await expect(
+      unusedDrawer(page).getByText("0", { exact: true }),
+    ).toBeVisible();
+
+    const fileChooser = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: "Add media" }).click();
+    await page.getByRole("menuitem", { name: "Device" }).click();
+    const importResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/v1/albums/") &&
+        res.url().endsWith("/media-imports/device") &&
+        res.request().method() === "POST",
+    );
+    const chooser = await fileChooser;
+    await chooser.setFiles({
+      name: "import.jpg",
+      mimeType: "image/jpeg",
+      buffer: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+    });
+    expect((await importResponse).ok()).toBeTruthy();
+    expect(imported).toBe(true);
+
+    await expect(
+      unusedDrawer(page).getByText("1", { exact: true }),
+    ).toBeVisible({
+      timeout: 5_000,
+    });
+    const importedImage = page.locator(`[data-media="${IMPORTED}"] img`);
+    await expect(importedImage).toBeVisible();
+    await expect(importedImage).toHaveAttribute("src", /11111111/);
+    await expect
+      .poll(() =>
+        importedImage.evaluate((img) => (img as HTMLImageElement).naturalWidth),
+      )
+      .toBeGreaterThan(0);
+  });
+});

--- a/frontend/public/google-photos.svg
+++ b/frontend/public/google-photos.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 350">
+  <defs>
+    <radialGradient id="g1" cx="173.161" cy="178.716" fx="239.836" fy="36.176" r="170.886" gradientTransform="translate(0 -7.272) scale(1 1.041)" gradientUnits="userSpaceOnUse">
+      <stop offset=".469" stop-color="#7acaff"/>
+      <stop offset=".828" stop-color="#00b054"/>
+    </radialGradient>
+    <radialGradient id="g2" cx="173.161" cy="178.716" fx="239.836" fy="36.176" r="170.886" gradientTransform="translate(357.272) rotate(90) scale(1 1.041)" gradientUnits="userSpaceOnUse">
+      <stop offset=".545" stop-color="#fded1c"/>
+      <stop offset=".828" stop-color="#feca01"/>
+    </radialGradient>
+    <radialGradient id="g3" cx="173.161" cy="178.716" fx="239.836" fy="36.176" r="170.886" gradientTransform="translate(350 357.272) rotate(-180) scale(1 1.041)" gradientUnits="userSpaceOnUse">
+      <stop offset=".469" stop-color="#ff81d0"/>
+      <stop offset=".828" stop-color="#ff4041"/>
+    </radialGradient>
+    <radialGradient id="g4" cx="173.161" cy="178.716" fx="239.836" fy="36.176" r="170.886" gradientTransform="translate(-7.272 350) rotate(-90) scale(1 1.041)" gradientUnits="userSpaceOnUse">
+      <stop offset=".469" stop-color="#aaa7ff"/>
+      <stop offset=".828" stop-color="#2f89ff"/>
+    </radialGradient>
+  </defs>
+  <path fill="url(#g1)" d="M79.6 262.5c0-48.3 39.2-87.5 87.5-87.5h7.9v167.1c0 4.4-3.6 7.9-7.9 7.9-48.3 0-87.5-39.2-87.5-87.5Z"/>
+  <path fill="url(#g2)" d="M87.5 79.6c48.3 0 87.5 39.2 87.5 87.5v7.9H7.9c-4.4 0-7.9-3.6-7.9-7.9 0-48.3 39.2-87.5 87.5-87.5Z"/>
+  <path fill="url(#g3)" d="M270.4 87.5c0 48.3-39.2 87.5-87.5 87.5H175V7.9c0-4.4 3.6-7.9 7.9-7.9 48.3 0 87.5 39.2 87.5 87.5Z"/>
+  <path fill="url(#g4)" d="M262.5 270.4c-48.3 0-87.5-39.2-87.5-87.5V175h167.1c4.4 0 7.9 3.6 7.9 7.9 0 48.3-39.2 87.5-87.5 87.5Z"/>
+</svg>

--- a/frontend/src/components/album/MediaItem.vue
+++ b/frontend/src/components/album/MediaItem.vue
@@ -35,12 +35,18 @@ const props = withDefaults(
     alt?: string;
     quality?: PhotoQuality | null;
     lazyRoot?: HTMLElement | null;
+    lazy?: boolean;
   }>(),
-  { focusable: true, alt: "" },
+  { focusable: true, alt: "", lazy: true },
 );
 
 const { albumId, mediaByName } = useAlbum();
 const printMode = usePrintMode();
+const supportsIntersectionObserver =
+  typeof window !== "undefined" && "IntersectionObserver" in window;
+const shouldLoadImmediately = computed(
+  () => printMode || !props.lazy || !supportsIntersectionObserver,
+);
 
 const programmaticScroll = inject(PROGRAMMATIC_SCROLL_KEY, ref(false));
 const rootRef = ref<HTMLElement | null>(null);
@@ -48,12 +54,14 @@ const visible = useElementVisibility(rootRef, {
   scrollTarget: computed(() => props.lazyRoot ?? null),
   rootMargin: "300px",
   once: true,
-  initialValue:
-    typeof window !== "undefined" && !("IntersectionObserver" in window),
+  initialValue: shouldLoadImmediately.value,
 });
-const loadImg = ref(printMode || !("IntersectionObserver" in window));
+const loadImg = ref(shouldLoadImmediately.value);
 watchEffect(() => {
-  if (printMode || (visible.value && !programmaticScroll.value)) {
+  if (
+    shouldLoadImmediately.value ||
+    (visible.value && !programmaticScroll.value)
+  ) {
     loadImg.value = true;
   }
 });
@@ -199,7 +207,7 @@ function onVideoKey(e: KeyboardEvent) {
         :sizes="imgSizes"
         :alt="alt"
         :class="['fit', fitCover ? 'fit-cover' : 'fit-contain']"
-        :loading="printMode ? 'eager' : 'lazy'"
+        :loading="shouldLoadImmediately ? 'eager' : 'lazy'"
         decoding="async"
       />
       <video
@@ -253,7 +261,7 @@ function onVideoKey(e: KeyboardEvent) {
         :srcset="loadImg ? imgSrcset : undefined"
         :sizes="imgSizes"
         :alt="alt"
-        :loading="printMode ? 'eager' : 'lazy'"
+        :loading="shouldLoadImmediately ? 'eager' : 'lazy'"
         :class="['fit', fitCover ? 'fit-cover' : 'fit-contain']"
         decoding="async"
       />

--- a/frontend/src/components/editor/AlbumNav.vue
+++ b/frontend/src/components/editor/AlbumNav.vue
@@ -54,6 +54,7 @@ const selectedAlbumId = defineModel<string | null>("albumId");
 const {
   activeStepId,
   activeSectionKey,
+  setActive,
   scrollTo,
   scrollToSection,
   scrollBehavior,
@@ -221,9 +222,24 @@ function mapDateChange(rangeIdx: number, range: DateRange) {
 }
 
 function scrollToMap(dateRange: DateRange) {
-  if (!scrollToSection(rangeSectionKey("map", dateRange))) {
-    scrollToSection(rangeSectionKey("hike", dateRange));
+  const mapKey = rangeSectionKey("map", dateRange);
+  if (scrollToSection(mapKey)) {
+    setActive(mapKey);
+    return;
   }
+  const hikeKey = rangeSectionKey("hike", dateRange);
+  if (scrollToSection(hikeKey)) {
+    setActive(hikeKey);
+  }
+}
+
+function scrollToStep(id: number) {
+  setActive(id);
+  scrollTo(id);
+}
+
+function scrollToHeader(key: HeaderKey) {
+  if (scrollToSection(key)) setActive(key);
 }
 
 // ── Header nav items ──────────────────────────────────────────────────
@@ -350,8 +366,8 @@ watch(activeSectionKey, (key) => {
               'nav-hidden': hiddenHeaderSet.has(item.key),
             },
           ]"
-          @click="scrollToSection(item.key)"
-          @keydown.enter="scrollToSection(item.key)"
+          @click="scrollToHeader(item.key)"
+          @keydown.enter="scrollToHeader(item.key)"
         >
           <q-icon :name="item.icon" size="var(--type-sm)" />
           <span>{{ item.label }}</span>
@@ -392,7 +408,7 @@ watch(activeSectionKey, (key) => {
         @toggle-open="
           openGroupKey = openGroupKey === group.key ? null : group.key
         "
-        @scroll-to-step="scrollTo"
+        @scroll-to-step="scrollToStep"
         @scroll-to-map="scrollToMap"
         @toggle-step="toggleStep"
         @toggle-country="toggleCountry(group)"

--- a/frontend/src/components/editor/InspectorDrawer.vue
+++ b/frontend/src/components/editor/InspectorDrawer.vue
@@ -5,11 +5,17 @@ import CoverCell from "./CoverCell.vue";
 import UnusedDrawer from "./UnusedDrawer.vue";
 import { useAlbumMutation } from "@/queries/useAlbumMutation";
 import { provideAlbum } from "@/composables/useAlbum";
+import { useMediaImport } from "@/composables/useMediaImport";
 import { mediaThumbUrl, isVideo, isPortrait } from "@/utils/media";
 import { DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET } from "@/utils/photoQuality";
 import { useI18n } from "vue-i18n";
 import { computed, ref } from "vue";
-import { matImage } from "@quasar/extras/material-icons";
+import {
+  matAddPhotoAlternate,
+  matComputer,
+  matImage,
+  matPhotoLibrary,
+} from "@quasar/extras/material-icons";
 
 const { t } = useI18n();
 
@@ -65,9 +71,46 @@ const landscapePhotos = computed(() =>
 );
 
 const coverGridRef = ref<HTMLElement | null>(null);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const pendingDeviceTarget = ref<{ context: "step" | "cover"; stepId?: number } | null>(
+  null,
+);
+const mediaImport = useMediaImport(() => props.album.id);
 
 function selectCoverPhoto(name: string) {
   albumMutation.mutate({ [coverField.value]: name });
+}
+
+const canImportMedia = computed(() => context.value === "step" || context.value === "cover");
+const importTarget = computed(() => {
+  if (context.value === "step" && props.step) {
+    return { context: "step" as const, stepId: props.step.id };
+  }
+  if (context.value === "cover") return { context: "cover" as const };
+  return null;
+});
+
+function pickDeviceFiles() {
+  const target = importTarget.value;
+  if (!target) return;
+  pendingDeviceTarget.value = target;
+  fileInputRef.value?.click();
+}
+
+function onDeviceFilesSelected(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const files = input.files;
+  const target = pendingDeviceTarget.value;
+  input.value = "";
+  pendingDeviceTarget.value = null;
+  if (!files?.length || !target) return;
+  void mediaImport.importDevice(files, target);
+}
+
+function importFromGoogle() {
+  const target = importTarget.value;
+  if (!target || mediaImport.googlePhotosState.value === "unavailable") return;
+  void mediaImport.importGoogle(target);
 }
 
 // ── Panel metadata ─────────────────────────────────────────────────────
@@ -75,20 +118,88 @@ const panelIcon = matImage;
 const panelLabel = computed(() =>
   isCoverBack.value ? t("album.backCover") : t("album.frontCover"),
 );
+
+const importProgressFraction = computed(() => {
+  const { done, total } = mediaImport.progress.value;
+  return total > 0 ? done / total : 0;
+});
+
+const importDialogTitle = computed(() => {
+  switch (mediaImport.phase.value) {
+    case "authorizing":
+      return t("mediaImport.authorizing");
+    case "picking":
+      return t("mediaImport.picking");
+    case "uploading":
+      return t("mediaImport.uploading");
+    case "processing":
+      return t("mediaImport.processing");
+    case "done":
+      return t(
+        "mediaImport.done",
+        { count: mediaImport.importedCount.value },
+        mediaImport.importedCount.value,
+      );
+    case "error":
+      return mediaImport.errorDetail.value ?? t("mediaImport.error");
+    default:
+      return "";
+  }
+});
 </script>
 
 <template>
   <div class="inspector-panel">
     <AlbumProperties :album="album" />
     <q-separator class="properties-separator" />
+    <input
+      ref="fileInputRef"
+      type="file"
+      class="hidden-input"
+      accept="image/*,video/*"
+      multiple
+      @change="onDeviceFilesSelected"
+    />
+
+    <div v-if="canImportMedia" class="import-bar">
+      <q-btn
+        dense
+        no-caps
+        unelevated
+        color="primary"
+        class="import-btn"
+        :disable="mediaImport.isBusy.value"
+        :icon="matAddPhotoAlternate"
+        :label="t('mediaImport.addMedia')"
+      >
+        <q-menu anchor="bottom start" self="top start">
+          <q-list dense class="import-menu">
+            <q-item v-close-popup clickable @click="pickDeviceFiles">
+              <q-item-section avatar>
+                <q-icon :name="matComputer" />
+              </q-item-section>
+              <q-item-section>{{ t("mediaImport.device") }}</q-item-section>
+            </q-item>
+            <q-item
+              v-close-popup
+              clickable
+              :disable="mediaImport.googlePhotosState.value === 'unavailable'"
+              @click="importFromGoogle"
+            >
+              <q-item-section avatar>
+                <q-icon :name="matPhotoLibrary" />
+              </q-item-section>
+              <q-item-section>{{ t("mediaImport.googlePhotos") }}</q-item-section>
+            </q-item>
+          </q-list>
+        </q-menu>
+      </q-btn>
+    </div>
 
     <!-- Step: unused photos tray -->
-    <UnusedDrawer
-      v-if="context === 'step'"
-      :step="step!"
-      :album-id="album.id"
-      class="context-section"
-    />
+    <div v-if="context === 'step'" class="context-section">
+      <UnusedDrawer :step="step!" :album-id="album.id" class="unused-section" />
+    </div>
 
     <!-- Cover: photo picker grid -->
     <div v-else-if="context === 'cover'" class="context-section">
@@ -116,6 +227,46 @@ const panelLabel = computed(() =>
       </div>
       <div v-else class="panel-hint">{{ t("album.noLandscapePhotos") }}</div>
     </div>
+
+    <q-dialog
+      :model-value="mediaImport.phase.value !== 'idle'"
+      persistent
+      @hide="mediaImport.cancel"
+    >
+      <q-card class="import-dialog">
+        <q-card-section class="row no-wrap items-center dialog-header">
+          <q-icon :name="matAddPhotoAlternate" size="1.5rem" />
+          <div class="text-subtitle1 text-weight-semibold">
+            {{ importDialogTitle }}
+          </div>
+        </q-card-section>
+        <q-card-section v-if="mediaImport.isBusy.value">
+          <q-linear-progress
+            :value="importProgressFraction"
+            :indeterminate="importProgressFraction === 0"
+            color="primary"
+            rounded
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn
+            v-if="mediaImport.isBusy.value"
+            flat
+            no-caps
+            :label="t('common.cancel')"
+            @click="mediaImport.cancel"
+          />
+          <q-btn
+            v-else-if="mediaImport.phase.value === 'error'"
+            flat
+            no-caps
+            color="primary"
+            :label="t('common.close')"
+            @click="mediaImport.cancel"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
   </div>
 </template>
 
@@ -132,12 +283,38 @@ const panelLabel = computed(() =>
   margin-inline: var(--gap-md);
 }
 
+.hidden-input {
+  position: absolute;
+  width: 0.0625rem;
+  height: 0.0625rem;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.import-bar {
+  padding: var(--gap-md) var(--gap-md) 0;
+}
+
+.import-btn {
+  width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.import-menu {
+  min-width: 13rem;
+}
+
 .context-section {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   padding: var(--gap-md);
+}
+
+.unused-section {
+  flex: 1;
+  min-height: 0;
 }
 
 .panel-header {
@@ -201,5 +378,14 @@ const panelLabel = computed(() =>
   .cover-cell {
     transition: none;
   }
+}
+
+.dialog-header {
+  gap: var(--gap-sm);
+}
+
+.import-dialog {
+  width: min(24rem, 90vw);
+  border-radius: var(--radius-sm);
 }
 </style>

--- a/frontend/src/components/editor/InspectorDrawer.vue
+++ b/frontend/src/components/editor/InspectorDrawer.vue
@@ -14,7 +14,6 @@ import {
   matAddPhotoAlternate,
   matComputer,
   matImage,
-  matPhotoLibrary,
 } from "@quasar/extras/material-icons";
 
 const { t } = useI18n();
@@ -24,6 +23,10 @@ const props = defineProps<{
   media: Media[];
   step?: Step;
   sectionKey?: string | null;
+}>();
+
+const emit = defineEmits<{
+  importedStepMedia: [payload: { stepId: number; names: string[] }];
 }>();
 
 // Provide album context so child components (MediaItem in UnusedDrawer)
@@ -72,16 +75,29 @@ const landscapePhotos = computed(() =>
 
 const coverGridRef = ref<HTMLElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
-const pendingDeviceTarget = ref<{ context: "step" | "cover"; stepId?: number } | null>(
-  null,
-);
+const showImportMenu = ref(false);
+const pendingDeviceTarget = ref<{
+  context: "step" | "cover";
+  stepId?: number;
+} | null>(null);
 const mediaImport = useMediaImport(() => props.album.id);
+const googlePhotosIcon = "img:/google-photos.svg";
+
+function applyVisibleImport(
+  result: { names: string[] } | undefined,
+  target: { context: "step" | "cover"; stepId?: number },
+) {
+  if (!result || target.context !== "step" || target.stepId == null) return;
+  emit("importedStepMedia", { stepId: target.stepId, names: result.names });
+}
 
 function selectCoverPhoto(name: string) {
   albumMutation.mutate({ [coverField.value]: name });
 }
 
-const canImportMedia = computed(() => context.value === "step" || context.value === "cover");
+const canImportMedia = computed(
+  () => context.value === "step" || context.value === "cover",
+);
 const importTarget = computed(() => {
   if (context.value === "step" && props.step) {
     return { context: "step" as const, stepId: props.step.id };
@@ -93,24 +109,31 @@ const importTarget = computed(() => {
 function pickDeviceFiles() {
   const target = importTarget.value;
   if (!target) return;
+  showImportMenu.value = false;
   pendingDeviceTarget.value = target;
   fileInputRef.value?.click();
 }
 
 function onDeviceFilesSelected(event: Event) {
   const input = event.target as HTMLInputElement;
-  const files = input.files;
+  const files = Array.from(input.files ?? []);
   const target = pendingDeviceTarget.value;
   input.value = "";
   pendingDeviceTarget.value = null;
-  if (!files?.length || !target) return;
-  void mediaImport.importDevice(files, target);
+  showImportMenu.value = false;
+  if (files.length === 0 || !target) return;
+  void mediaImport.importDevice(files, target, (result) =>
+    applyVisibleImport(result, target),
+  );
 }
 
 function importFromGoogle() {
   const target = importTarget.value;
   if (!target || mediaImport.googlePhotosState.value === "unavailable") return;
-  void mediaImport.importGoogle(target);
+  showImportMenu.value = false;
+  void mediaImport.importGoogle(target, (result) =>
+    applyVisibleImport(result, target),
+  );
 }
 
 // ── Panel metadata ─────────────────────────────────────────────────────
@@ -162,43 +185,47 @@ const importDialogTitle = computed(() => {
     />
 
     <div v-if="canImportMedia" class="import-bar">
-      <q-btn
-        dense
-        no-caps
-        unelevated
-        color="primary"
+      <button
+        type="button"
         class="import-btn"
-        :disable="mediaImport.isBusy.value"
-        :icon="matAddPhotoAlternate"
-        :label="t('mediaImport.addMedia')"
+        :disabled="mediaImport.isBusy.value"
+        aria-haspopup="menu"
+        @click="showImportMenu = true"
       >
-        <q-menu anchor="bottom start" self="top start">
-          <q-list dense class="import-menu">
-            <q-item v-close-popup clickable @click="pickDeviceFiles">
-              <q-item-section avatar>
-                <q-icon :name="matComputer" />
-              </q-item-section>
-              <q-item-section>{{ t("mediaImport.device") }}</q-item-section>
-            </q-item>
-            <q-item
-              v-close-popup
-              clickable
-              :disable="mediaImport.googlePhotosState.value === 'unavailable'"
-              @click="importFromGoogle"
-            >
-              <q-item-section avatar>
-                <q-icon :name="matPhotoLibrary" />
-              </q-item-section>
-              <q-item-section>{{ t("mediaImport.googlePhotos") }}</q-item-section>
-            </q-item>
-          </q-list>
-        </q-menu>
-      </q-btn>
+        <q-icon :name="matAddPhotoAlternate" size="var(--type-md)" />
+        <span>{{ t("mediaImport.addMedia") }}</span>
+      </button>
+      <div v-if="showImportMenu" class="import-menu" role="menu">
+        <button
+          type="button"
+          class="import-menu-item"
+          role="menuitem"
+          @click="pickDeviceFiles"
+        >
+          <q-icon :name="matComputer" size="var(--type-md)" />
+          <span>{{ t("mediaImport.device") }}</span>
+        </button>
+        <button
+          type="button"
+          class="import-menu-item"
+          role="menuitem"
+          :disabled="mediaImport.googlePhotosState.value === 'unavailable'"
+          @click="importFromGoogle"
+        >
+          <q-icon :name="googlePhotosIcon" size="var(--type-md)" />
+          <span>{{ t("mediaImport.googlePhotos") }}</span>
+        </button>
+      </div>
     </div>
 
     <!-- Step: unused photos tray -->
     <div v-if="context === 'step'" class="context-section">
-      <UnusedDrawer :step="step!" :album-id="album.id" class="unused-section" />
+      <UnusedDrawer
+        :key="step!.unused.join('|')"
+        :step="step!"
+        :album-id="album.id"
+        class="unused-section"
+      />
     </div>
 
     <!-- Cover: photo picker grid -->
@@ -292,16 +319,74 @@ const importDialogTitle = computed(() => {
 }
 
 .import-bar {
+  position: relative;
   padding: var(--gap-md) var(--gap-md) 0;
 }
 
 .import-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-sm);
   width: 100%;
+  min-height: 2.25rem;
+  border: 1px solid var(--q-primary);
   border-radius: var(--radius-sm);
+  background: var(--q-primary);
+  color: var(--bg);
+  font-family: var(--font-ui);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+
+  &:focus-visible {
+    outline: 0.125rem solid var(--q-primary);
+    outline-offset: 0.125rem;
+  }
 }
 
 .import-menu {
+  position: absolute;
+  z-index: 10;
+  inset-block-start: calc(100% + var(--gap-xs));
+  inset-inline: var(--gap-md);
+  padding: var(--gap-xs);
   min-width: 13rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  box-shadow: var(--shadow-md);
+}
+
+.import-menu-item {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 0 var(--gap-sm);
+  border-radius: var(--radius-xs);
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: var(--type-sm);
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    background: color-mix(in srgb, var(--q-primary) 10%, transparent);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
 }
 
 .context-section {

--- a/frontend/src/components/editor/UnusedDrawer.vue
+++ b/frontend/src/components/editor/UnusedDrawer.vue
@@ -69,6 +69,7 @@ useDraggable(trackRef, localUnused, {
         :key="photo"
         :media="photo"
         :lazy-root="trackRef"
+        :lazy="false"
       />
       <div v-if="localUnused.length === 0" class="drawer-empty">
         {{ t("album.dropPhotosHere") }}

--- a/frontend/src/components/editor/UpgradeMediaButton.vue
+++ b/frontend/src/components/editor/UpgradeMediaButton.vue
@@ -9,7 +9,6 @@ import {
   symOutlinedError,
   symOutlinedKeyboardArrowDown,
   symOutlinedLinkOff,
-  symOutlinedUpgrade,
 } from "@quasar/extras/material-symbols-outlined";
 import { useI18n } from "vue-i18n";
 import { computed, ref } from "vue";
@@ -21,6 +20,8 @@ const props = defineProps<{ albumId: string }>();
 const upgrade = useMediaUpgrade();
 const googlePhotos = useGooglePhotos();
 const showDisconnectConfirm = ref(false);
+const googlePhotosIcon = "img:/google-photos.svg";
+const googlePhotosButtonIconSize = "1rem";
 
 const isRunning = computed(() => {
   const p = upgrade.phase.value;
@@ -118,7 +119,8 @@ const { confirmUpgrade } = upgrade;
     <AsyncActionButton
       v-if="buttonState"
       :state="buttonState"
-      :idle-icon="symOutlinedUpgrade"
+      :idle-icon="googlePhotosIcon"
+      :idle-icon-size="googlePhotosButtonIconSize"
       :idle-label="t('upgrade.button')"
       :progress-fraction="progressFraction"
       :progress-message="progressMessage"
@@ -135,11 +137,7 @@ const { confirmUpgrade } = upgrade;
     >
       <q-icon :name="symOutlinedError" size="var(--type-lg)" />
       {{ errorMessage }}
-      <q-tooltip
-        transition-show="scale"
-        transition-hide="scale"
-        class="q-menu"
-      >
+      <q-tooltip transition-show="scale" transition-hide="scale" class="q-menu">
         {{ errorTooltip }}
       </q-tooltip>
     </button>
@@ -150,7 +148,7 @@ const { confirmUpgrade } = upgrade;
         :aria-label="t('upgrade.button')"
         @click="upgrade.start(props.albumId)"
       >
-        <q-icon :name="symOutlinedUpgrade" size="var(--type-lg)" />
+        <q-icon :name="googlePhotosIcon" :size="googlePhotosButtonIconSize" />
         {{ t("upgrade.button") }}
       </button>
       <button
@@ -172,7 +170,7 @@ const { confirmUpgrade } = upgrade;
 
     <PromptDialog
       :model-value="upgrade.phase.value === 'onboarding'"
-      :icon="symOutlinedUpgrade"
+      :icon="googlePhotosIcon"
       variant="primary"
       :title="t('upgrade.onboarding.title')"
       :body="t('upgrade.onboarding.body')"
@@ -292,5 +290,4 @@ const { confirmUpgrade } = upgrade;
     outline-offset: -1px;
   }
 }
-
 </style>

--- a/frontend/src/components/ui/AsyncActionButton.vue
+++ b/frontend/src/components/ui/AsyncActionButton.vue
@@ -5,14 +5,20 @@ import {
   symOutlinedCheck,
 } from "@quasar/extras/material-symbols-outlined";
 
-defineProps<{
-  state: "idle" | "running" | "done";
-  idleIcon: string;
-  idleLabel: string;
-  progressFraction: number;
-  progressMessage: string;
-  doneMessage: string;
-}>();
+withDefaults(
+  defineProps<{
+    state: "idle" | "running" | "done";
+    idleIcon: string;
+    idleIconSize?: string;
+    idleLabel: string;
+    progressFraction: number;
+    progressMessage: string;
+    doneMessage: string;
+  }>(),
+  {
+    idleIconSize: "var(--type-lg)",
+  },
+);
 
 defineEmits<{ start: []; cancel: [] }>();
 </script>
@@ -42,7 +48,9 @@ defineEmits<{ start: []; cancel: [] }>();
         size="var(--type-md)"
         class="cancel-icon"
       />
-      <span class="progress-text" aria-live="polite">{{ progressMessage }}</span>
+      <span class="progress-text" aria-live="polite">{{
+        progressMessage
+      }}</span>
     </div>
     <ProgressBar :progress="progressFraction" />
   </button>
@@ -53,7 +61,7 @@ defineEmits<{ start: []; cancel: [] }>();
     :aria-label="idleLabel"
     @click="$emit('start')"
   >
-    <q-icon :name="idleIcon" size="var(--type-lg)" />
+    <q-icon :name="idleIcon" :size="idleIconSize" />
     {{ idleLabel }}
   </button>
 </template>

--- a/frontend/src/composables/useActiveSection.ts
+++ b/frontend/src/composables/useActiveSection.ts
@@ -8,14 +8,14 @@ import { ref } from "vue";
 export function pickBestItem<T extends VirtualItem>(
   items: readonly T[],
   scrollY: number,
-  scrollMargin: number,
+  _scrollMargin: number,
   viewportCenter: number,
 ): T | null {
   let best: T | null = null;
   let bestDist = Infinity;
 
   for (const vi of items) {
-    const top = vi.start + scrollMargin - scrollY;
+    const top = vi.start - scrollY;
     const center = top + vi.size / 2;
     const dist = Math.abs(center - viewportCenter);
     if (dist < bestDist) {

--- a/frontend/src/composables/useMediaImport.ts
+++ b/frontend/src/composables/useMediaImport.ts
@@ -3,8 +3,9 @@ import { useGooglePhotos } from "@/composables/useGooglePhotos";
 import { t } from "@/i18n";
 import { queryKeys } from "@/queries/keys";
 import { sleep } from "@/utils/async";
+import type { Step } from "@/client";
 import { useQueryCache } from "@pinia/colada";
-import { computed, onScopeDispose, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 
 type ImportContext = "step" | "cover";
 type ImportPhase =
@@ -102,13 +103,35 @@ export function useMediaImport(albumId: () => string) {
     return popup;
   }
 
-  async function invalidateAlbumQueries() {
+  async function invalidateAlbumQueries(target: ImportTarget) {
     const aid = albumId();
-    await Promise.all([
+    const invalidations = [
       cache.invalidateQueries({ key: queryKeys.album(aid) }),
       cache.invalidateQueries({ key: queryKeys.media(aid) }),
-      cache.invalidateQueries({ key: queryKeys.steps(aid) }),
-    ]);
+    ];
+    if (target.context !== "step") {
+      invalidations.push(
+        cache.invalidateQueries({ key: queryKeys.steps(aid) }),
+      );
+    }
+    await Promise.all(invalidations);
+  }
+
+  function applyImportResult(result: ImportCompleted, target: ImportTarget) {
+    if (target.context !== "step" || target.stepId == null) return;
+    const key = queryKeys.steps(albumId());
+    const steps = cache.getQueryData<Step[]>(key);
+    if (!steps) return;
+    const imported = result.names.filter((name) =>
+      steps.every((step) => !step.unused.includes(name)),
+    );
+    if (imported.length === 0) return;
+    const next = steps.map((step) =>
+      step.id === target.stepId
+        ? { ...step, unused: [...imported, ...step.unused] }
+        : step,
+    );
+    cache.setQueryData(key, next);
   }
 
   function finish(count: number) {
@@ -124,10 +147,15 @@ export function useMediaImport(albumId: () => string) {
   function fail(err: unknown) {
     if (err instanceof DOMException && err.name === "AbortError") return;
     phase.value = "error";
-    errorDetail.value = err instanceof Error ? err.message : t("mediaImport.error");
+    errorDetail.value =
+      err instanceof Error ? err.message : t("mediaImport.error");
   }
 
-  async function importDevice(files: FileList | File[], target: ImportTarget) {
+  async function importDevice(
+    files: FileList | File[],
+    target: ImportTarget,
+    onCompleted?: (result: ImportCompleted) => void,
+  ): Promise<ImportCompleted | undefined> {
     const selected = Array.from(files);
     if (selected.length === 0) return;
     if (selected.length > MAX_ITEMS) {
@@ -143,10 +171,18 @@ export function useMediaImport(albumId: () => string) {
     controller = new AbortController();
 
     try {
-      const result = await uploadDeviceFiles(selected, target, controller.signal);
+      const result = await uploadDeviceFiles(
+        selected,
+        target,
+        controller.signal,
+      );
       phase.value = "processing";
-      await invalidateAlbumQueries();
+      onCompleted?.(result);
+      applyImportResult(result, target);
+      await nextTick();
+      await invalidateAlbumQueries(target);
       finish(result.names.length);
+      return result;
     } catch (err) {
       fail(err);
     }
@@ -162,40 +198,22 @@ export function useMediaImport(albumId: () => string) {
     if (target.stepId != null) form.set("step_id", String(target.stepId));
     for (const file of files) form.append("files", file);
 
-    return new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      const baseUrl = client.getConfig().baseUrl ?? "";
-      xhr.open("POST", `${baseUrl}/api/v1/albums/${albumId()}/media-imports/device`);
-      xhr.withCredentials = true;
-
-      const onAbort = () => {
-        xhr.abort();
-        reject(new DOMException("Aborted", "AbortError"));
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-
-      xhr.upload.onprogress = (event) => {
-        if (event.lengthComputable) {
-          progress.value = { done: event.loaded, total: event.total };
-        }
-      };
-      xhr.onload = () => {
-        signal.removeEventListener("abort", onAbort);
-        if (xhr.status >= 200 && xhr.status < 300) {
-          resolve(JSON.parse(xhr.responseText) as ImportCompleted);
-          return;
-        }
-        reject(new Error(statusMessage(xhr.status)));
-      };
-      xhr.onerror = () => {
-        signal.removeEventListener("abort", onAbort);
-        reject(new Error(t("mediaImport.errors.network")));
-      };
-      xhr.send(form);
+    const baseUrl = client.getConfig().baseUrl ?? "";
+    return fetch(`${baseUrl}/api/v1/albums/${albumId()}/media-imports/device`, {
+      method: "POST",
+      credentials: "include",
+      body: form,
+      signal,
+    }).then(async (res) => {
+      if (!res.ok) throw new Error(statusMessage(res.status));
+      return (await res.json()) as ImportCompleted;
     });
   }
 
-  async function importGoogle(target: ImportTarget) {
+  async function importGoogle(
+    target: ImportTarget,
+    onCompleted?: (result: ImportCompleted) => void,
+  ): Promise<ImportCompleted | undefined> {
     if (resetTimer !== null) clearTimeout(resetTimer);
     reset();
     controller = new AbortController();
@@ -214,10 +232,18 @@ export function useMediaImport(albumId: () => string) {
       await pollUntilReady(session.session_id, signal);
 
       phase.value = "processing";
-      const count = await runGoogleImportStream(session.session_id, target, signal);
+      const result = await runGoogleImportStream(
+        session.session_id,
+        target,
+        signal,
+      );
       googlePhotos.closeSession(session.session_id).catch(() => {});
-      await invalidateAlbumQueries();
-      finish(count);
+      onCompleted?.(result);
+      applyImportResult(result, target);
+      await nextTick();
+      await invalidateAlbumQueries(target);
+      finish(result.names.length);
+      return result;
     } catch (err) {
       fail(err);
     } finally {
@@ -261,7 +287,7 @@ export function useMediaImport(albumId: () => string) {
     sessionId: string,
     target: ImportTarget,
     signal: AbortSignal,
-  ): Promise<number> {
+  ): Promise<ImportCompleted> {
     const baseUrl = client.getConfig().baseUrl ?? "";
     const res = await fetch(
       `${baseUrl}/api/v1/albums/${albumId()}/media-imports/google`,
@@ -279,14 +305,14 @@ export function useMediaImport(albumId: () => string) {
     );
     if (!res.ok || !res.body) throw new Error(statusMessage(res.status));
 
-    let completed = 0;
+    let completed: ImportCompleted = { type: "import_completed", names: [] };
     for await (const event of parseSse(res.body)) {
       if (event.type === "import_in_progress") {
         progress.value = { done: event.done, total: event.total };
       } else if (event.type === "import_failed") {
         throw new Error(event.detail);
       } else {
-        completed = event.names.length;
+        completed = event;
       }
     }
     return completed;
@@ -319,8 +345,6 @@ export function useMediaImport(albumId: () => string) {
     phase.value = "idle";
     reset();
   }
-
-  onScopeDispose(cancel);
 
   return {
     phase,

--- a/frontend/src/composables/useMediaImport.ts
+++ b/frontend/src/composables/useMediaImport.ts
@@ -1,0 +1,343 @@
+import { client } from "@/client/client.gen";
+import { useGooglePhotos } from "@/composables/useGooglePhotos";
+import { t } from "@/i18n";
+import { queryKeys } from "@/queries/keys";
+import { sleep } from "@/utils/async";
+import { useQueryCache } from "@pinia/colada";
+import { computed, onScopeDispose, ref } from "vue";
+
+type ImportContext = "step" | "cover";
+type ImportPhase =
+  | "idle"
+  | "authorizing"
+  | "picking"
+  | "uploading"
+  | "processing"
+  | "done"
+  | "error";
+
+interface ImportTarget {
+  context: ImportContext;
+  stepId?: number;
+}
+
+interface ImportProgress {
+  done: number;
+  total: number;
+}
+
+interface ImportCompleted {
+  type: "import_completed";
+  names: string[];
+}
+
+interface ImportFailed {
+  type: "import_failed";
+  detail: string;
+}
+
+interface ImportInProgress {
+  type: "import_in_progress";
+  phase: string;
+  done: number;
+  total: number;
+}
+
+type ImportEvent = ImportCompleted | ImportFailed | ImportInProgress;
+
+const POLL_INTERVAL_MS = 2000;
+const PICKER_TIMEOUT_MS = 10 * 60 * 1000;
+const DONE_RESET_MS = 2500;
+const MAX_ITEMS = 50;
+
+export function useMediaImport(albumId: () => string) {
+  const cache = useQueryCache();
+  const googlePhotos = useGooglePhotos();
+  const phase = ref<ImportPhase>("idle");
+  const progress = ref<ImportProgress>({ done: 0, total: 0 });
+  const importedCount = ref(0);
+  const errorDetail = ref<string | null>(null);
+
+  let controller: AbortController | null = null;
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+  let activePopup: Window | null = null;
+
+  const isBusy = computed(() =>
+    ["authorizing", "picking", "uploading", "processing"].includes(phase.value),
+  );
+
+  function reset() {
+    controller?.abort();
+    controller = null;
+    progress.value = { done: 0, total: 0 };
+    importedCount.value = 0;
+    errorDetail.value = null;
+    try {
+      activePopup?.close();
+    } catch {
+      /* Cross-origin opener policy can block this. */
+    }
+    activePopup = null;
+  }
+
+  function openPopup(): Window {
+    const width = Math.min(screen.availWidth - 100, 1200);
+    const height = Math.min(screen.availHeight - 100, 900);
+    const left =
+      ((screen as { availLeft?: number }).availLeft ?? 0) +
+      (screen.availWidth - width) / 2;
+    const top =
+      ((screen as { availTop?: number }).availTop ?? 0) +
+      (screen.availHeight - height) / 2;
+    const popup = window.open(
+      "about:blank",
+      "google-photos",
+      `width=${width},height=${height},left=${left},top=${top}`,
+    );
+    if (!popup) throw new Error(t("mediaImport.errors.popupBlocked"));
+    popup.document.title = "Google Photos";
+    popup.document.body.style.cssText =
+      "font-family:system-ui;display:grid;place-items:center;height:100vh;margin:0;color:#666";
+    popup.document.body.textContent = t("mediaImport.authorizing");
+    return popup;
+  }
+
+  async function invalidateAlbumQueries() {
+    const aid = albumId();
+    await Promise.all([
+      cache.invalidateQueries({ key: queryKeys.album(aid) }),
+      cache.invalidateQueries({ key: queryKeys.media(aid) }),
+      cache.invalidateQueries({ key: queryKeys.steps(aid) }),
+    ]);
+  }
+
+  function finish(count: number) {
+    importedCount.value = count;
+    phase.value = "done";
+    resetTimer = setTimeout(() => {
+      phase.value = "idle";
+      reset();
+      resetTimer = null;
+    }, DONE_RESET_MS);
+  }
+
+  function fail(err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    phase.value = "error";
+    errorDetail.value = err instanceof Error ? err.message : t("mediaImport.error");
+  }
+
+  async function importDevice(files: FileList | File[], target: ImportTarget) {
+    const selected = Array.from(files);
+    if (selected.length === 0) return;
+    if (selected.length > MAX_ITEMS) {
+      phase.value = "error";
+      errorDetail.value = t("mediaImport.errors.tooMany");
+      return;
+    }
+
+    if (resetTimer !== null) clearTimeout(resetTimer);
+    reset();
+    phase.value = "uploading";
+    progress.value = { done: 0, total: 1 };
+    controller = new AbortController();
+
+    try {
+      const result = await uploadDeviceFiles(selected, target, controller.signal);
+      phase.value = "processing";
+      await invalidateAlbumQueries();
+      finish(result.names.length);
+    } catch (err) {
+      fail(err);
+    }
+  }
+
+  function uploadDeviceFiles(
+    files: File[],
+    target: ImportTarget,
+    signal: AbortSignal,
+  ): Promise<ImportCompleted> {
+    const form = new FormData();
+    form.set("context", target.context);
+    if (target.stepId != null) form.set("step_id", String(target.stepId));
+    for (const file of files) form.append("files", file);
+
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      const baseUrl = client.getConfig().baseUrl ?? "";
+      xhr.open("POST", `${baseUrl}/api/v1/albums/${albumId()}/media-imports/device`);
+      xhr.withCredentials = true;
+
+      const onAbort = () => {
+        xhr.abort();
+        reject(new DOMException("Aborted", "AbortError"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable) {
+          progress.value = { done: event.loaded, total: event.total };
+        }
+      };
+      xhr.onload = () => {
+        signal.removeEventListener("abort", onAbort);
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(JSON.parse(xhr.responseText) as ImportCompleted);
+          return;
+        }
+        reject(new Error(statusMessage(xhr.status)));
+      };
+      xhr.onerror = () => {
+        signal.removeEventListener("abort", onAbort);
+        reject(new Error(t("mediaImport.errors.network")));
+      };
+      xhr.send(form);
+    });
+  }
+
+  async function importGoogle(target: ImportTarget) {
+    if (resetTimer !== null) clearTimeout(resetTimer);
+    reset();
+    controller = new AbortController();
+    const signal = controller.signal;
+
+    try {
+      activePopup = openPopup();
+      if (!googlePhotos.isConnected.value) {
+        phase.value = "authorizing";
+        await googlePhotos.authorize(activePopup, signal);
+      }
+
+      phase.value = "picking";
+      const session = await createImportSession(signal);
+      activePopup.location.href = `${session.picker_uri}/autoclose`;
+      await pollUntilReady(session.session_id, signal);
+
+      phase.value = "processing";
+      const count = await runGoogleImportStream(session.session_id, target, signal);
+      googlePhotos.closeSession(session.session_id).catch(() => {});
+      await invalidateAlbumQueries();
+      finish(count);
+    } catch (err) {
+      fail(err);
+    } finally {
+      try {
+        activePopup?.close();
+      } catch {
+        /* Cross-origin opener policy can block this. */
+      }
+      activePopup = null;
+    }
+  }
+
+  async function createImportSession(signal: AbortSignal): Promise<{
+    session_id: string;
+    picker_uri: string;
+  }> {
+    const baseUrl = client.getConfig().baseUrl ?? "";
+    const res = await fetch(
+      `${baseUrl}/api/v1/albums/${albumId()}/media-imports/google/session`,
+      { method: "POST", credentials: "include", signal },
+    );
+    if (!res.ok) throw new Error(statusMessage(res.status));
+    return (await res.json()) as { session_id: string; picker_uri: string };
+  }
+
+  async function pollUntilReady(
+    sessionId: string,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const deadline = Date.now() + PICKER_TIMEOUT_MS;
+    while (!signal.aborted) {
+      if (Date.now() > deadline)
+        throw new Error(t("mediaImport.errors.selectionTimeout"));
+      const result = await googlePhotos.pollSession(sessionId);
+      if (result.ready) return;
+      await sleep(POLL_INTERVAL_MS, signal);
+    }
+  }
+
+  async function runGoogleImportStream(
+    sessionId: string,
+    target: ImportTarget,
+    signal: AbortSignal,
+  ): Promise<number> {
+    const baseUrl = client.getConfig().baseUrl ?? "";
+    const res = await fetch(
+      `${baseUrl}/api/v1/albums/${albumId()}/media-imports/google`,
+      {
+        method: "POST",
+        credentials: "include",
+        signal,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: target.context,
+          step_id: target.stepId,
+          session_id: sessionId,
+        }),
+      },
+    );
+    if (!res.ok || !res.body) throw new Error(statusMessage(res.status));
+
+    let completed = 0;
+    for await (const event of parseSse(res.body)) {
+      if (event.type === "import_in_progress") {
+        progress.value = { done: event.done, total: event.total };
+      } else if (event.type === "import_failed") {
+        throw new Error(event.detail);
+      } else {
+        completed = event.names.length;
+      }
+    }
+    return completed;
+  }
+
+  async function* parseSse(stream: ReadableStream<Uint8Array>) {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let split = buffer.indexOf("\n\n");
+      while (split !== -1) {
+        const frame = buffer.slice(0, split);
+        buffer = buffer.slice(split + 2);
+        const data = frame
+          .split("\n")
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trimStart())
+          .join("\n");
+        if (data) yield JSON.parse(data) as ImportEvent;
+        split = buffer.indexOf("\n\n");
+      }
+    }
+  }
+
+  function cancel() {
+    phase.value = "idle";
+    reset();
+  }
+
+  onScopeDispose(cancel);
+
+  return {
+    phase,
+    progress,
+    importedCount,
+    errorDetail,
+    isBusy,
+    googlePhotosState: googlePhotos.state,
+    importDevice,
+    importGoogle,
+    cancel,
+  };
+}
+
+function statusMessage(statusCode: number): string {
+  if (statusCode === 400) return t("mediaImport.errors.badFile");
+  if (statusCode === 403) return t("mediaImport.errors.googleUnavailable");
+  if (statusCode === 413) return t("mediaImport.errors.tooLarge");
+  return t("mediaImport.error");
+}

--- a/frontend/src/composables/useMediaImport.ts
+++ b/frontend/src/composables/useMediaImport.ts
@@ -218,6 +218,7 @@ export function useMediaImport(albumId: () => string) {
     reset();
     controller = new AbortController();
     const signal = controller.signal;
+    let sessionId: string | null = null;
 
     try {
       activePopup = openPopup();
@@ -228,16 +229,12 @@ export function useMediaImport(albumId: () => string) {
 
       phase.value = "picking";
       const session = await createImportSession(signal);
+      sessionId = session.session_id;
       activePopup.location.href = `${session.picker_uri}/autoclose`;
-      await pollUntilReady(session.session_id, signal);
+      await pollUntilReady(sessionId, signal);
 
       phase.value = "processing";
-      const result = await runGoogleImportStream(
-        session.session_id,
-        target,
-        signal,
-      );
-      googlePhotos.closeSession(session.session_id).catch(() => {});
+      const result = await runGoogleImportStream(sessionId, target, signal);
       onCompleted?.(result);
       applyImportResult(result, target);
       await nextTick();
@@ -253,6 +250,7 @@ export function useMediaImport(albumId: () => string) {
         /* Cross-origin opener policy can block this. */
       }
       activePopup = null;
+      if (sessionId) googlePhotos.closeSession(sessionId).catch(() => {});
     }
   }
 
@@ -278,6 +276,7 @@ export function useMediaImport(albumId: () => string) {
       if (Date.now() > deadline)
         throw new Error(t("mediaImport.errors.selectionTimeout"));
       const result = await googlePhotos.pollSession(sessionId);
+      signal.throwIfAborted();
       if (result.ready) return;
       await sleep(POLL_INTERVAL_MS, signal);
     }

--- a/frontend/src/composables/useMediaImport.ts
+++ b/frontend/src/composables/useMediaImport.ts
@@ -305,40 +305,9 @@ export function useMediaImport(albumId: () => string) {
     );
     if (!res.ok || !res.body) throw new Error(statusMessage(res.status));
 
-    let completed: ImportCompleted = { type: "import_completed", names: [] };
-    for await (const event of parseSse(res.body)) {
-      if (event.type === "import_in_progress") {
-        progress.value = { done: event.done, total: event.total };
-      } else if (event.type === "import_failed") {
-        throw new Error(event.detail);
-      } else {
-        completed = event;
-      }
-    }
-    return completed;
-  }
-
-  async function* parseSse(stream: ReadableStream<Uint8Array>) {
-    const reader = stream.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      let split = buffer.indexOf("\n\n");
-      while (split !== -1) {
-        const frame = buffer.slice(0, split);
-        buffer = buffer.slice(split + 2);
-        const data = frame
-          .split("\n")
-          .filter((line) => line.startsWith("data:"))
-          .map((line) => line.slice(5).trimStart())
-          .join("\n");
-        if (data) yield JSON.parse(data) as ImportEvent;
-        split = buffer.indexOf("\n\n");
-      }
-    }
+    return readImportStream(res.body, (event) => {
+      progress.value = { done: event.done, total: event.total };
+    });
   }
 
   function cancel() {
@@ -357,6 +326,47 @@ export function useMediaImport(albumId: () => string) {
     importGoogle,
     cancel,
   };
+}
+
+async function* parseSse(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let split = buffer.indexOf("\n\n");
+    while (split !== -1) {
+      const frame = buffer.slice(0, split);
+      buffer = buffer.slice(split + 2);
+      const data = frame
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trimStart())
+        .join("\n");
+      if (data) yield JSON.parse(data) as ImportEvent;
+      split = buffer.indexOf("\n\n");
+    }
+  }
+}
+
+export async function readImportStream(
+  stream: ReadableStream<Uint8Array>,
+  onProgress: (event: ImportInProgress) => void,
+): Promise<ImportCompleted> {
+  let completed: ImportCompleted | null = null;
+  for await (const event of parseSse(stream)) {
+    if (event.type === "import_in_progress") {
+      onProgress(event);
+    } else if (event.type === "import_failed") {
+      throw new Error(event.detail);
+    } else {
+      completed = event;
+    }
+  }
+  if (!completed) throw new Error(t("mediaImport.errors.incompleteStream"));
+  return completed;
 }
 
 function statusMessage(statusCode: number): string {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -4,7 +4,8 @@
   "common": {
     "loadingAlbum": "Loading album...",
     "retry": "Please try again.",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "close": "Close"
   },
   "units": {
     "km": "km",
@@ -162,6 +163,26 @@
   },
   "inspector": {
     "overview": "Overview"
+  },
+  "mediaImport": {
+    "addMedia": "Add media",
+    "device": "Device",
+    "googlePhotos": "Google Photos",
+    "authorizing": "Connecting to Google Photos...",
+    "picking": "Waiting for selection...",
+    "uploading": "Uploading media...",
+    "processing": "Processing media...",
+    "done": "Added 1 item | Added {count} items",
+    "error": "Media import failed. Try again.",
+    "errors": {
+      "badFile": "This file is not supported.",
+      "googleUnavailable": "Google Photos is not available for this account.",
+      "network": "Network error. @:common.retry",
+      "popupBlocked": "Popup blocked. Allow popups and try again.",
+      "selectionTimeout": "Selection timed out.",
+      "tooLarge": "Selected media is too large.",
+      "tooMany": "Select 50 items or fewer."
+    }
   },
   "export": {
     "preparing": "Preparing export...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -177,6 +177,7 @@
     "errors": {
       "badFile": "This file is not supported.",
       "googleUnavailable": "Google Photos is not available for this account.",
+      "incompleteStream": "Import connection closed before completion.",
       "network": "Network error. @:common.retry",
       "popupBlocked": "Popup blocked. Allow popups and try again.",
       "selectionTimeout": "Selection timed out.",

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -4,7 +4,8 @@
   "common": {
     "loadingAlbum": "טוען אלבום...",
     "retry": "נסו שוב.",
-    "cancel": "ביטול"
+    "cancel": "ביטול",
+    "close": "סגירה"
   },
   "units": {
     "km": "ק״מ",
@@ -162,6 +163,26 @@
   },
   "inspector": {
     "overview": "סיכום"
+  },
+  "mediaImport": {
+    "addMedia": "הוספת מדיה",
+    "device": "מכשיר",
+    "googlePhotos": "Google Photos",
+    "authorizing": "מתחבר ל-Google Photos...",
+    "picking": "ממתין לבחירה...",
+    "uploading": "מעלה מדיה...",
+    "processing": "מעבד מדיה...",
+    "done": "נוסף פריט אחד | נוספו {count} פריטים",
+    "error": "ייבוא המדיה נכשל. נסו שוב.",
+    "errors": {
+      "badFile": "הקובץ הזה לא נתמך.",
+      "googleUnavailable": "Google Photos לא זמין לחשבון הזה.",
+      "network": "שגיאת רשת. @:common.retry",
+      "popupBlocked": "חלון קופץ נחסם. אפשרו חלונות קופצים ונסו שוב.",
+      "selectionTimeout": "זמן הבחירה פג.",
+      "tooLarge": "המדיה שנבחרה גדולה מדי.",
+      "tooMany": "בחרו עד 50 פריטים."
+    }
   },
   "export": {
     "preparing": "מכין...",

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -177,6 +177,7 @@
     "errors": {
       "badFile": "הקובץ הזה לא נתמך.",
       "googleUnavailable": "Google Photos לא זמין לחשבון הזה.",
+      "incompleteStream": "חיבור הייבוא נסגר לפני שהסתיים.",
       "network": "שגיאת רשת. @:common.retry",
       "popupBlocked": "חלון קופץ נחסם. אפשרו חלונות קופצים ונסו שוב.",
       "selectionTimeout": "זמן הבחירה פג.",

--- a/frontend/src/pages/EditorView.vue
+++ b/frontend/src/pages/EditorView.vue
@@ -59,6 +59,7 @@ useEditorKeyboard();
 const undoStack = useUndoStack();
 const photoFocus = usePhotoFocus();
 watch(selectedAlbumId, () => {
+  importedUnusedByStep.value = {};
   undoStack.clear();
   photoFocus.blur();
   resetActiveSection();

--- a/frontend/src/pages/EditorView.vue
+++ b/frontend/src/pages/EditorView.vue
@@ -17,6 +17,7 @@ import { usePhotoFocus } from "@/composables/usePhotoFocus";
 import { useUndoStack } from "@/composables/useUndoStack";
 import { useActiveSection } from "@/composables/useActiveSection";
 import { useLocalStorage } from "@vueuse/core";
+import { mergeImportedUnused } from "@/utils/stepImportedUnused";
 import { useMeta } from "quasar";
 import { useI18n } from "vue-i18n";
 import { computed, watch, nextTick, onBeforeUnmount, ref } from "vue";
@@ -70,12 +71,7 @@ const { activeStepId, activeSectionKey, resetActiveSection } =
 onBeforeUnmount(resetActiveSection);
 const displayedSteps = computed(() =>
   steps.value?.map((step) => {
-    const imported = (importedUnusedByStep.value[step.id] ?? []).filter(
-      (name) => !step.unused.includes(name),
-    );
-    return imported.length
-      ? { ...step, unused: [...imported, ...step.unused] }
-      : step;
+    return mergeImportedUnused(step, importedUnusedByStep.value[step.id] ?? []);
   }),
 );
 const activeStep = computed(() =>

--- a/frontend/src/pages/EditorView.vue
+++ b/frontend/src/pages/EditorView.vue
@@ -19,7 +19,7 @@ import { useActiveSection } from "@/composables/useActiveSection";
 import { useLocalStorage } from "@vueuse/core";
 import { useMeta } from "quasar";
 import { useI18n } from "vue-i18n";
-import { computed, watch, nextTick, onBeforeUnmount } from "vue";
+import { computed, watch, nextTick, onBeforeUnmount, ref } from "vue";
 
 const { t } = useI18n();
 
@@ -51,6 +51,7 @@ const { data: album } = useAlbumQuery(selectedAlbumId);
 const { data: media } = useMediaQuery(selectedAlbumId);
 const { data: steps } = useStepsQuery(selectedAlbumId);
 const { data: segmentOutlines } = useSegmentsQuery(selectedAlbumId);
+const importedUnusedByStep = ref<Record<number, string[]>>({});
 
 useLocale(locale);
 
@@ -66,11 +67,35 @@ watch(selectedAlbumId, () => {
 const { activeStepId, activeSectionKey, resetActiveSection } =
   useActiveSection();
 onBeforeUnmount(resetActiveSection);
+const displayedSteps = computed(() =>
+  steps.value?.map((step) => {
+    const imported = (importedUnusedByStep.value[step.id] ?? []).filter(
+      (name) => !step.unused.includes(name),
+    );
+    return imported.length
+      ? { ...step, unused: [...imported, ...step.unused] }
+      : step;
+  }),
+);
 const activeStep = computed(() =>
   activeStepId.value != null
-    ? steps.value?.find((s) => s.id === activeStepId.value)
+    ? displayedSteps.value?.find((s) => s.id === activeStepId.value)
     : undefined,
 );
+
+function onImportedStepMedia({
+  stepId,
+  names,
+}: {
+  stepId: number;
+  names: string[];
+}) {
+  const current = importedUnusedByStep.value[stepId] ?? [];
+  importedUnusedByStep.value = {
+    ...importedUnusedByStep.value,
+    [stepId]: [...names, ...current.filter((name) => !names.includes(name))],
+  };
+}
 </script>
 
 <template>
@@ -101,10 +126,10 @@ const activeStep = computed(() =>
     class="print-hide"
   >
     <AlbumNav
-      v-if="album && steps"
+      v-if="album && displayedSteps"
       v-model:album-id="selectedAlbumId"
       :album-ids="albumIds ?? undefined"
-      :steps="steps"
+      :steps="displayedSteps"
       :hidden-steps="album.hidden_steps ?? undefined"
       :hidden-headers="album.hidden_headers ?? undefined"
       :colors="album.colors ?? undefined"
@@ -135,15 +160,16 @@ const activeStep = computed(() =>
       :media="media"
       :step="activeStep"
       :section-key="activeSectionKey"
+      @imported-step-media="onImportedStepMedia"
     />
   </q-drawer>
 
   <q-page class="editor-page">
     <AlbumViewer
-      v-if="album && steps && media && segmentOutlines"
+      v-if="album && displayedSteps && media && segmentOutlines"
       :album="album"
       :media="media"
-      :steps="steps"
+      :steps="displayedSteps"
       :segment-outlines="segmentOutlines"
     />
   </q-page>

--- a/frontend/src/utils/stepImportedUnused.ts
+++ b/frontend/src/utils/stepImportedUnused.ts
@@ -1,0 +1,16 @@
+import type { Step } from "@/client";
+
+export function mergeImportedUnused(
+  step: Step,
+  names: readonly string[],
+): Step {
+  const alreadyPlaced = new Set([
+    ...step.unused,
+    ...step.pages.flat(),
+    ...(step.cover ? [step.cover] : []),
+  ]);
+  const imported = names.filter((name) => !alreadyPlaced.has(name));
+  return imported.length
+    ? { ...step, unused: [...imported, ...step.unused] }
+    : step;
+}

--- a/frontend/tests/composables/useActiveSection.test.ts
+++ b/frontend/tests/composables/useActiveSection.test.ts
@@ -1,6 +1,10 @@
 import { useActiveSection, pickBestItem } from "@/composables/useActiveSection";
 import type { VirtualItem } from "@tanstack/vue-virtual";
-import { activeSectionId, HEADER_KEYS, type Section } from "@/components/album/albumSections";
+import {
+  activeSectionId,
+  HEADER_KEYS,
+  type Section,
+} from "@/components/album/albumSections";
 import { makeStep } from "../helpers";
 import type { DateRange } from "@/client";
 
@@ -28,7 +32,12 @@ describe("active section highlighting", () => {
     return { index, start, size };
   }
   const PAGE = 800;
-  const headers = [item(0, 0), item(1, PAGE), item(2, PAGE * 2), item(3, PAGE * 3)];
+  const headers = [
+    item(0, 0),
+    item(1, PAGE),
+    item(2, PAGE * 2),
+    item(3, PAGE * 3),
+  ];
   const sectionStart = PAGE * 4; // where content sections begin
 
   const stepSection = (id: number): Section => ({
@@ -52,7 +61,8 @@ describe("active section highlighting", () => {
     scrollY: number,
     viewportHeight = 800,
   ) {
-    const { setActive, activeStepId, activeSectionKey, resetActiveSection } = useActiveSection();
+    const { setActive, activeStepId, activeSectionKey, resetActiveSection } =
+      useActiveSection();
     const best = pickBestItem(vItems, scrollY, 0, viewportHeight / 2);
     let id: number | string | null = null;
     if (best) {
@@ -60,7 +70,10 @@ describe("active section highlighting", () => {
       else id = activeSectionId(sections, best.index - HEADER_COUNT) ?? null;
     }
     setActive(id);
-    const result = { stepId: activeStepId.value, sectionKey: activeSectionKey.value };
+    const result = {
+      stepId: activeStepId.value,
+      sectionKey: activeSectionKey.value,
+    };
     resetActiveSection();
     return result;
   }
@@ -69,6 +82,12 @@ describe("active section highlighting", () => {
     const vItems = [...headers, item(4, sectionStart)];
     const result = activeAt(vItems, [stepSection(42)], sectionStart - 100);
     expect(result.stepId).toBe(42);
+  });
+
+  it("does not double-count window virtualizer scrollMargin", () => {
+    const vItems = [item(0, 100), item(1, 900)];
+    const best = pickBestItem(vItems, 550, 100, 400);
+    expect(best?.index).toBe(1);
   });
 
   it("section barely visible at top does not steal highlight from section filling the viewport", () => {
@@ -101,7 +120,9 @@ describe("active section highlighting", () => {
     const sections = [stepSection(55)];
 
     expect(activeAt(vItems, sections, 0).sectionKey).toBe("cover-front");
-    expect(activeAt(vItems, sections, PAGE * 2 + 100).sectionKey).toBe("overview");
+    expect(activeAt(vItems, sections, PAGE * 2 + 100).sectionKey).toBe(
+      "overview",
+    );
     expect(activeAt(vItems, sections, sectionStart - 100).stepId).toBe(55);
   });
 });

--- a/frontend/tests/composables/useMediaImport.test.ts
+++ b/frontend/tests/composables/useMediaImport.test.ts
@@ -1,0 +1,40 @@
+import { readImportStream } from "@/composables/useMediaImport";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+function sseBody(events: object[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+describe("readImportStream", () => {
+  it("rejects EOF before import_completed", async () => {
+    const onProgress = vi.fn();
+    const stream = streamFromText(
+      sseBody([
+        {
+          type: "import_in_progress",
+          phase: "downloading",
+          done: 1,
+          total: 0,
+        },
+      ]),
+    );
+
+    await expect(readImportStream(stream, onProgress)).rejects.toThrow(
+      "Import connection closed before completion.",
+    );
+    expect(onProgress).toHaveBeenCalledWith({
+      type: "import_in_progress",
+      phase: "downloading",
+      done: 1,
+      total: 0,
+    });
+  });
+});

--- a/frontend/tests/composables/useMediaImport.test.ts
+++ b/frontend/tests/composables/useMediaImport.test.ts
@@ -1,4 +1,37 @@
-import { readImportStream } from "@/composables/useMediaImport";
+import { ref } from "vue";
+import { readImportStream, useMediaImport } from "@/composables/useMediaImport";
+
+const mocks = vi.hoisted(() => ({
+  closeSession: vi.fn(),
+  pollSession: vi.fn(),
+  authorize: vi.fn(),
+  invalidateQueries: vi.fn(),
+  getQueryData: vi.fn(),
+  setQueryData: vi.fn(),
+  getConfig: vi.fn(() => ({ baseUrl: "" })),
+}));
+
+vi.mock("@/client/client.gen", () => ({
+  client: { getConfig: mocks.getConfig },
+}));
+
+vi.mock("@pinia/colada", () => ({
+  useQueryCache: () => ({
+    invalidateQueries: mocks.invalidateQueries,
+    getQueryData: mocks.getQueryData,
+    setQueryData: mocks.setQueryData,
+  }),
+}));
+
+vi.mock("@/composables/useGooglePhotos", () => ({
+  useGooglePhotos: () => ({
+    state: ref("connected"),
+    isConnected: ref(true),
+    authorize: mocks.authorize,
+    pollSession: mocks.pollSession,
+    closeSession: mocks.closeSession,
+  }),
+}));
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -36,5 +69,85 @@ describe("readImportStream", () => {
       done: 1,
       total: 0,
     });
+  });
+});
+
+describe("useMediaImport", () => {
+  function mockPopup(): Window {
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: { href: "" },
+      document: {
+        title: "",
+        body: { style: { cssText: "" }, textContent: "" },
+      },
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+    return popup;
+  }
+
+  function mockImportSessionFetch() {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          session_id: "session-abc",
+          picker_uri: "https://photos.google.com/picker/abc",
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    mocks.closeSession.mockReset();
+    mocks.pollSession.mockReset();
+    mocks.authorize.mockReset();
+    mocks.invalidateQueries.mockReset();
+    mocks.getQueryData.mockReset();
+    mocks.setQueryData.mockReset();
+    mocks.getConfig.mockReturnValue({ baseUrl: "" });
+    mocks.closeSession.mockResolvedValue(undefined);
+  });
+
+  it("closes a Google Picker session when import fails after session creation", async () => {
+    mockPopup();
+    mockImportSessionFetch();
+    mocks.pollSession.mockRejectedValue(new Error("selection failed"));
+
+    const mediaImport = useMediaImport(() => "aid-1");
+    await mediaImport.importGoogle({ context: "cover" });
+
+    expect(mocks.closeSession).toHaveBeenCalledWith("session-abc");
+    expect(mediaImport.phase.value).toBe("error");
+    expect(mediaImport.errorDetail.value).toBe("selection failed");
+  });
+
+  it("stays canceled when Google Picker polling resolves after cancel", async () => {
+    mockPopup();
+    const fetchMock = mockImportSessionFetch();
+    let resolvePoll!: (result: { ready: boolean }) => void;
+    mocks.pollSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePoll = resolve;
+      }),
+    );
+
+    const mediaImport = useMediaImport(() => "aid-1");
+    const importPromise = mediaImport.importGoogle({ context: "cover" });
+    await vi.waitFor(() =>
+      expect(mocks.pollSession).toHaveBeenCalledWith("session-abc"),
+    );
+
+    mediaImport.cancel();
+    resolvePoll({ ready: true });
+    await importPromise;
+
+    expect(mediaImport.phase.value).toBe("idle");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mocks.closeSession).toHaveBeenCalledWith("session-abc");
   });
 });

--- a/frontend/tests/utils/stepImportedUnused.test.ts
+++ b/frontend/tests/utils/stepImportedUnused.test.ts
@@ -1,0 +1,31 @@
+import { mergeImportedUnused } from "@/utils/stepImportedUnused";
+import { makeStep } from "../helpers";
+
+describe("mergeImportedUnused", () => {
+  it("does not re-add imported media that was placed on a page", () => {
+    const step = makeStep({
+      pages: [["imported.jpg"]],
+      unused: [],
+    });
+
+    expect(mergeImportedUnused(step, ["imported.jpg"]).unused).toEqual([]);
+  });
+
+  it("does not re-add imported media that was placed as step cover", () => {
+    const step = makeStep({
+      cover: "imported.jpg",
+      unused: [],
+    });
+
+    expect(mergeImportedUnused(step, ["imported.jpg"]).unused).toEqual([]);
+  });
+
+  it("prepends imports that are not in base step state yet", () => {
+    const step = makeStep({ unused: ["old.jpg"] });
+
+    expect(mergeImportedUnused(step, ["new.jpg"]).unused).toEqual([
+      "new.jpg",
+      "old.jpg",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #31
- add contextual device and Google Photos media import from the editor inspector
- import step media into unused trays and cover media into album media
- harden import persistence, cancellation cleanup, Google Picker session cleanup, and stale overlay handling
