### PR TITLE
test: overhaul test helpers

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -8,14 +8,18 @@ percentage.
 ## Layer Choice
 
 - Unit tests are for pure computation, edge-heavy transformations, parsing,
-  formatting, and payload builders.
-- Integration tests are the default for API and data-flow boundaries.
-- E2E tests are for user interaction, async timing, DOM behavior, scrolling,
-  keyboard handling, and multi-system flows.
+  formatting, payload builders, layout math, and small deterministic helpers.
+- Backend integration tests are the default for API, database, filesystem,
+  transaction, and data-flow boundaries.
+- Frontend integration tests are for composables, Pinia Colada cache behavior,
+  component interactions, and API hooks with MSW.
+- E2E tests are for user interaction, async timing, DOM focus, scrolling,
+  keyboard handling, file picker or popup behavior, and multi-component
+  workflows that cannot be covered cheaply below.
 
-Avoid tests that only prove wiring, initial state, library behavior, or mock
-behavior. If a test needs more mocks than assertions, it is probably at the
-wrong layer.
+Avoid tests that only prove wiring, initial state, library behavior, generated
+client behavior, mock behavior, or log output. If a test needs more mocks than
+assertions, it is probably at the wrong layer.
 
 ## Conventions
 
@@ -25,6 +29,26 @@ wrong layer.
 - E2E: Playwright route handlers for mocked API. Assert user-observable behavior,
   not implementation details.
 - Snapshot tests are only for serialized contract boundaries. Never snapshot DOM.
+
+## Helper Libraries
+
+Use plain fixtures and typed builders first.
+
+- Do not add `factory_boy`, `pytest-factoryboy`, `polyfactory`, or `Faker`
+  unless model creation remains noisy after local builders are split.
+- Do not add `@pinia/testing` unless a store-heavy component test needs action
+  stubbing that the current Pinia setup cannot express cleanly.
+- Do not add Testing Library or `user-event` unless Vue Test Utils tests keep
+  asserting implementation details that Playwright cannot cover more cheaply.
+
+## Structure
+
+- Keep shared setup in `support/` modules or focused fixtures.
+- Let fixtures do setup and teardown. Use plain builder functions for data.
+- Prefer one state-changing action per helper.
+- Move repeated E2E route stubs into Playwright support files.
+- Move files into `unit/` and `integration/` directories only after helper
+  boundaries are stable enough to avoid churn.
 
 After bugfixes, write a regression test that fails without the fix and passes
 with it. Choose the layer that would have caught the original bug.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -96,6 +96,13 @@ async def client(
     app.dependency_overrides.clear()
 
 
+@pytest.fixture
+def users_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "users"
+    path.mkdir(exist_ok=True)
+    return path
+
+
 @pytest.fixture(scope="module")
 def sa_trip_dir() -> Path:
     trip_dir = TRIPS_DIR / "south-america-2024-2025"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,13 @@ from app.services.google_photos import GooglePhotosOAuth2
 
 from .factories import TRIPS_DIR
 
+pytest_plugins = (
+    "tests.helpers.album_fixtures",
+    "tests.helpers.external_media_fixtures",
+    "tests.helpers.google_photos_fixtures",
+    "tests.helpers.user_fixtures",
+)
+
 
 def _mock_http_clients() -> HttpClients:
     """Provide an HttpClients with AsyncMock clients for tests.

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -203,15 +203,26 @@ def make_user(
     *,
     album_ids: list[str] | None = None,
     google_sub: str | None = None,
+    first_name: str = "Test",
+    locale: str = "en-US",
+    unit_is_km: bool = True,
+    temperature_is_celsius: bool = True,
+    is_demo: bool = False,
+    last_active_at: datetime | None = None,
 ) -> User:
+    resolved_google_sub = google_sub
+    if resolved_google_sub is None and not is_demo:
+        resolved_google_sub = f"google-{uid}"
     user = User(
         id=uid,
-        google_sub=google_sub if google_sub is not None else f"google-{uid}",
-        first_name="Test",
-        locale="en-US",
-        unit_is_km=True,
-        temperature_is_celsius=True,
+        google_sub=resolved_google_sub,
+        first_name=first_name,
+        locale=locale,
+        unit_is_km=unit_is_km,
+        temperature_is_celsius=temperature_is_celsius,
         album_ids=album_ids if album_ids is not None else [AID],
+        is_demo=is_demo,
+        last_active_at=last_active_at or datetime.now(UTC),
     )
     user.folder.mkdir(parents=True, exist_ok=True)
     return user
@@ -270,25 +281,128 @@ def make_points(times: list[float]) -> list[Point]:
     ]
 
 
+def make_weather(
+    temp: float = 20.0,
+    feels_like: float = 18.0,
+    icon: str = "sun",
+) -> Weather:
+    return Weather(
+        day=WeatherData(temp=temp, feels_like=feels_like, icon=icon),
+        night=None,
+    )
+
+
+def make_album(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    title: str = "Test Album",
+    subtitle: str = "A subtitle",
+    front_cover_photo: str = "photo1.jpg",
+    back_cover_photo: str = "photo2.jpg",
+    colors: dict[str, str] | None = None,
+    font: str | None = "Assistant",
+    body_font: str = "Frank Ruhl Libre",
+) -> Album:
+    values: dict[str, object] = {
+        "uid": uid,
+        "id": aid,
+        "title": title,
+        "subtitle": subtitle,
+        "hidden_steps": [],
+        "hidden_headers": [],
+        "maps_ranges": [],
+        "front_cover_photo": front_cover_photo,
+        "back_cover_photo": back_cover_photo,
+        "colors": colors if colors is not None else {"nl": "#0000ff"},
+        "body_font": body_font,
+    }
+    if font is not None:
+        values["font"] = font
+    return Album(**values)
+
+
+def make_album_media(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    name: str = DEFAULT_MEDIA_NAME,
+    width: int = 1920,
+    height: int = 1080,
+    kind: str | None = None,
+    byte_size: int = 1234,
+    upgrade_candidate: bool = True,
+) -> AlbumMedia:
+    return AlbumMedia(
+        uid=uid,
+        aid=aid,
+        name=name,
+        kind=kind or ("video" if name.endswith(".mp4") else "photo"),
+        width=width,
+        height=height,
+        byte_size=byte_size,
+        upgrade_candidate=upgrade_candidate,
+    )
+
+
+def make_step(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    step_id: int = 1,
+    name: str = "Test Step",
+    description: str = "A test step.",
+    timestamp: float = 1_700_000_000.0,
+    timezone_id: str = "Europe/Amsterdam",
+    location: Location | None = LOCATION,
+    elevation: int = 0,
+    weather: Weather | None = None,
+    cover_media_name: str | None = None,
+) -> Step:
+    return Step(
+        uid=uid,
+        aid=aid,
+        id=step_id,
+        name=name,
+        description=description,
+        timestamp=timestamp,
+        timezone_id=timezone_id,
+        location=location,
+        elevation=elevation,
+        weather=weather or WEATHER,
+        cover_media_name=cover_media_name,
+    )
+
+
+def make_segment(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    start_time: float = 1_700_000_000.0,
+    end_time: float = 1_700_003_600.0,
+    kind: SegmentKind = SegmentKind.driving,
+    points: list[Point] | None = None,
+    timezone_id: str = "UTC",
+) -> Segment:
+    return Segment(
+        uid=uid,
+        aid=aid,
+        start_time=start_time,
+        end_time=end_time,
+        kind=kind,
+        timezone_id=timezone_id,
+        points=points
+        if points is not None
+        else make_points([start_time, (start_time + end_time) / 2, end_time]),
+    )
+
+
 async def insert_album(
     session: AsyncSession,
     uid: int,
     aid: str = AID,
 ) -> Album:
-    album = Album(
-        uid=uid,
-        id=aid,
-        title="Test Album",
-        subtitle="A subtitle",
-        hidden_steps=[],
-        hidden_headers=[],
-        maps_ranges=[],
-        front_cover_photo="photo1.jpg",
-        back_cover_photo="photo2.jpg",
-        colors={"nl": "#0000ff"},
-        font="Assistant",
-        body_font="Frank Ruhl Libre",
-    )
+    album = make_album(uid, aid)
     session.add(album)
     await session.flush()
     return album
@@ -302,15 +416,12 @@ async def insert_album_media(
     width: int = 1920,
     height: int = 1080,
 ) -> AlbumMedia:
-    media = AlbumMedia(
+    media = make_album_media(
         uid=uid,
         aid=aid,
         name=name,
-        kind="video" if name.endswith(".mp4") else "photo",
         width=width,
         height=height,
-        byte_size=1234,
-        upgrade_candidate=True,
     )
     session.add(media)
     await session.flush()
@@ -332,17 +443,11 @@ async def insert_step(
             continue
         if await session.get(AlbumMedia, (uid, aid, name)) is None:
             await insert_album_media(session, uid, aid=aid, name=name)
-    step = Step(
-        uid=uid,
-        aid=aid,
-        id=step_id,
-        name="Test Step",
-        description="A test step.",
+    step = make_step(
+        uid,
+        aid,
+        step_id=step_id,
         timestamp=timestamp,
-        timezone_id="Europe/Amsterdam",
-        location=LOCATION,
-        elevation=0,
-        weather=WEATHER,
         cover_media_name=cover_media_name,
     )
     session.add(step)
@@ -425,15 +530,13 @@ async def insert_segment(
     kind: SegmentKind = SegmentKind.driving,
     points: list[Point] | None = None,
 ) -> Segment:
-    pts = points or make_points([start_time, (start_time + end_time) / 2, end_time])
-    segment = Segment(
+    segment = make_segment(
         uid=uid,
         aid=aid,
         start_time=start_time,
         end_time=end_time,
         kind=kind,
-        timezone_id="UTC",
-        points=pts,
+        points=points,
     )
     session.add(segment)
     await session.flush()

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -7,7 +7,7 @@ import tempfile
 from collections.abc import AsyncIterator, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,7 +18,12 @@ from PIL import Image
 from app.core.config import get_settings
 from app.logic.upload import TripMeta
 from app.models.album import Album
-from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
+from app.models.album_media import (
+    AlbumMedia,
+    AlbumMediaUndoSnapshot,
+    StepPageMedia,
+    StepUnusedMedia,
+)
 from app.models.polarsteps import Location, Point, PSStep
 from app.models.segment import Segment, SegmentKind
 from app.models.step import Step, StepRead
@@ -368,6 +373,62 @@ def make_album_media(
         height=height,
         byte_size=byte_size,
         upgrade_candidate=upgrade_candidate,
+    )
+
+
+def make_step_page_media(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    step_id: int = 1,
+    media_name: str = DEFAULT_MEDIA_NAME,
+    page_index: int = 0,
+    position_index: int = 0,
+) -> StepPageMedia:
+    return StepPageMedia(
+        uid=uid,
+        aid=aid,
+        step_id=step_id,
+        media_name=media_name,
+        page_index=page_index,
+        position_index=position_index,
+    )
+
+
+def make_step_unused_media(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    step_id: int = 1,
+    media_name: str = DEFAULT_MEDIA_NAME,
+    position_index: int = 0,
+) -> StepUnusedMedia:
+    return StepUnusedMedia(
+        uid=uid,
+        aid=aid,
+        step_id=step_id,
+        media_name=media_name,
+        position_index=position_index,
+    )
+
+
+def make_undo_snapshot(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    media_name: str = DEFAULT_MEDIA_NAME,
+    created_at: datetime | None = None,
+    expires_at: datetime | None = None,
+) -> AlbumMediaUndoSnapshot:
+    now = created_at or datetime.now(UTC)
+    return AlbumMediaUndoSnapshot(
+        uid=uid,
+        aid=aid,
+        media_name=media_name,
+        snapshot_path=str(Path(".undo") / media_name),
+        upgrade_candidate=True,
+        created_at=now,
+        expires_at=expires_at or now + timedelta(minutes=5),
     )
 
 

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -19,7 +19,7 @@ from app.core.config import get_settings
 from app.logic.upload import TripMeta
 from app.models.album import Album
 from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
-from app.models.polarsteps import Location, Point
+from app.models.polarsteps import Location, Point, PSStep
 from app.models.segment import Segment, SegmentKind
 from app.models.step import Step, StepRead
 from app.models.user import PSUser, User
@@ -279,6 +279,28 @@ def make_points(times: list[float]) -> list[Point]:
         Point(lat=52.0 + i * 0.01, lon=4.0 + i * 0.01, time=t)
         for i, t in enumerate(times)
     ]
+
+
+def make_ps_step(
+    step_id: int = 1,
+    *,
+    name: str | None = None,
+    slug: str | None = None,
+    description: str | None = None,
+    timestamp: float = 1_700_000_000.0,
+    timezone_id: str = "UTC",
+    location: Location = LOCATION,
+) -> PSStep:
+    resolved_name = name or f"Step {step_id}"
+    return PSStep(
+        id=step_id,
+        name=resolved_name,
+        slug=slug or resolved_name.lower().replace(" ", "-"),
+        description=description if description is not None else f"Desc {step_id}",
+        timestamp=timestamp,
+        timezone_id=timezone_id,
+        location=location,
+    )
 
 
 def make_weather(

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -198,6 +198,25 @@ async def sign_in_uploaded_user(
 GOOGLE_REFRESH_TOKEN = "1//0fake-refresh-token-for-tests"  # noqa: S105
 
 
+def make_user(
+    uid: int = 1,
+    *,
+    album_ids: list[str] | None = None,
+    google_sub: str | None = None,
+) -> User:
+    user = User(
+        id=uid,
+        google_sub=google_sub if google_sub is not None else f"google-{uid}",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=album_ids if album_ids is not None else [AID],
+    )
+    user.folder.mkdir(parents=True, exist_ok=True)
+    return user
+
+
 async def connect_google_photos(session: AsyncSession, uid: int) -> None:
     """Mark user as Google Photos connected with a refresh token."""
     user = await session.get(User, uid)
@@ -304,8 +323,13 @@ async def insert_step(
     aid: str = AID,
     step_id: int = 1,
     timestamp: float = 1_700_000_000.0,
+    cover_media_name: str | None = None,
+    page_media_name: str | None = "photo1.jpg",
+    unused_media_name: str | None = "photo2.jpg",
 ) -> Step:
-    for name in ("photo1.jpg", "photo2.jpg"):
+    for name in {cover_media_name, page_media_name, unused_media_name}:
+        if name is None:
+            continue
         if await session.get(AlbumMedia, (uid, aid, name)) is None:
             await insert_album_media(session, uid, aid=aid, name=name)
     step = Step(
@@ -319,29 +343,31 @@ async def insert_step(
         location=LOCATION,
         elevation=0,
         weather=WEATHER,
-        cover_media_name=None,
+        cover_media_name=cover_media_name,
     )
     session.add(step)
     await session.flush()
-    session.add(
-        StepPageMedia(
-            uid=uid,
-            aid=aid,
-            step_id=step_id,
-            page_index=0,
-            position_index=0,
-            media_name="photo1.jpg",
+    if page_media_name is not None:
+        session.add(
+            StepPageMedia(
+                uid=uid,
+                aid=aid,
+                step_id=step_id,
+                page_index=0,
+                position_index=0,
+                media_name=page_media_name,
+            )
         )
-    )
-    session.add(
-        StepUnusedMedia(
-            uid=uid,
-            aid=aid,
-            step_id=step_id,
-            position_index=0,
-            media_name="photo2.jpg",
+    if unused_media_name is not None:
+        session.add(
+            StepUnusedMedia(
+                uid=uid,
+                aid=aid,
+                step_id=step_id,
+                position_index=0,
+                media_name=unused_media_name,
+            )
         )
-    )
     await session.flush()
     return step
 

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -6,6 +6,7 @@ import io
 import tempfile
 from collections.abc import AsyncIterator, Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -201,6 +202,19 @@ LOCATION = Location(
 )
 WEATHER = Weather(day=WeatherData(temp=20.0, feels_like=18.0, icon="sun"), night=None)
 AID = "trip-1"
+DEFAULT_MEDIA_NAME = (
+    "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+)
+MISSING_MEDIA_NAME = (
+    "33333333-3333-4333-8333-333333333333_44444444-4444-4444-8444-444444444444.jpg"
+)
+
+
+@dataclass(frozen=True)
+class AlbumMediaScenario:
+    uid: int
+    album_dir: Path
+    media_name: str = DEFAULT_MEDIA_NAME
 
 
 def make_points(times: list[float]) -> list[Point]:
@@ -238,9 +252,7 @@ async def insert_album_media(
     session: AsyncSession,
     uid: int,
     aid: str = AID,
-    name: str = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
-    ),
+    name: str = DEFAULT_MEDIA_NAME,
     width: int = 1920,
     height: int = 1080,
 ) -> AlbumMedia:
@@ -305,6 +317,33 @@ async def insert_step(
     )
     await session.flush()
     return step
+
+
+async def sign_in_with_album_media(
+    client: AsyncClient,
+    session: AsyncSession,
+    *,
+    provider: str = "google",
+    media_name: str = DEFAULT_MEDIA_NAME,
+    width: int = 640,
+    height: int = 480,
+    write_media: bool = False,
+) -> AlbumMediaScenario:
+    user_data = await sign_in_and_upload(
+        client,
+        get_settings().USERS_FOLDER,
+        provider=provider,
+    )
+    uid = user_data["id"]
+    await insert_album(session, uid)
+    await insert_album_media(session, uid, name=media_name, width=width, height=height)
+    await insert_step(session, uid)
+    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
+    album_dir.mkdir(parents=True, exist_ok=True)
+    if write_media:
+        create_test_jpeg(album_dir / media_name, width, height)
+    await session.commit()
+    return AlbumMediaScenario(uid=uid, album_dir=album_dir, media_name=media_name)
 
 
 async def insert_segment(

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -211,6 +211,12 @@ MISSING_MEDIA_NAME = (
 
 
 @dataclass(frozen=True)
+class AlbumScenario:
+    uid: int
+    aid: str = AID
+
+
+@dataclass(frozen=True)
 class AlbumMediaScenario:
     uid: int
     album_dir: Path
@@ -317,6 +323,23 @@ async def insert_step(
     )
     await session.flush()
     return step
+
+
+async def sign_in_with_album(
+    client: AsyncClient,
+    session: AsyncSession,
+    *,
+    provider: str = "google",
+    aid: str = AID,
+) -> AlbumScenario:
+    user_data = await sign_in_and_upload(
+        client,
+        get_settings().USERS_FOLDER,
+        provider=provider,
+    )
+    uid = user_data["id"]
+    await insert_album(session, uid, aid=aid)
+    return AlbumScenario(uid=uid, aid=aid)
 
 
 async def sign_in_with_album_media(

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -180,6 +180,17 @@ async def sign_in_and_upload(
     return resp.json()["user"]
 
 
+async def sign_in_uploaded_user(
+    client: AsyncClient,
+    *,
+    provider: str = "google",
+    payload: dict | None = None,
+) -> dict:
+    users_dir = get_settings().USERS_FOLDER
+    users_dir.mkdir(parents=True, exist_ok=True)
+    return await sign_in_and_upload(client, users_dir, provider, payload)
+
+
 # ---------------------------------------------------------------------------
 # DB insert helpers
 # ---------------------------------------------------------------------------
@@ -195,6 +206,16 @@ async def connect_google_photos(session: AsyncSession, uid: int) -> None:
     user.google_photos_connected_at = datetime.now(UTC)
     session.add(user)
     await session.flush()
+
+
+async def sign_in_connected_google_photos(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> int:
+    user_data = await sign_in_uploaded_user(client, provider="google")
+    uid = user_data["id"]
+    await connect_google_photos(session, uid)
+    return uid
 
 
 LOCATION = Location(

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -281,6 +281,10 @@ def make_points(times: list[float]) -> list[Point]:
     ]
 
 
+def make_points_from_tuples(points: list[tuple[float, float, float]]) -> list[Point]:
+    return [Point(lat=lat, lon=lon, time=time) for lat, lon, time in points]
+
+
 def make_ps_step(
     step_id: int = 1,
     *,

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -21,7 +21,7 @@ from app.models.album import Album
 from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
 from app.models.polarsteps import Location, Point
 from app.models.segment import Segment, SegmentKind
-from app.models.step import Step
+from app.models.step import Step, StepRead
 from app.models.user import PSUser, User
 from app.models.weather import Weather, WeatherData
 
@@ -371,6 +371,39 @@ def make_step(
         elevation=elevation,
         weather=weather or WEATHER,
         cover_media_name=cover_media_name,
+    )
+
+
+def make_step_read(
+    uid: int = 1,
+    aid: str = AID,
+    *,
+    step_id: int = 1,
+    name: str = "Test Step",
+    description: str = "A test step.",
+    timestamp: float = 1_700_000_000.0,
+    timezone_id: str = "Europe/Amsterdam",
+    location: Location | None = LOCATION,
+    elevation: int = 0,
+    weather: Weather | None = None,
+    cover: str | None = None,
+    pages: list[list[str]] | None = None,
+    unused: list[str] | None = None,
+) -> StepRead:
+    return StepRead(
+        uid=uid,
+        aid=aid,
+        id=step_id,
+        name=name,
+        description=description,
+        timestamp=timestamp,
+        timezone_id=timezone_id,
+        location=location,
+        elevation=elevation,
+        weather=weather or WEATHER,
+        cover=cover,
+        pages=pages or [],
+        unused=unused or [],
     )
 
 

--- a/backend/tests/helpers/__init__.py
+++ b/backend/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Domain-scoped helpers for backend tests."""

--- a/backend/tests/helpers/album_fixtures.py
+++ b/backend/tests/helpers/album_fixtures.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.factories import AlbumScenario, sign_in_with_album
+from tests.helpers.albums import AlbumRoutes
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+def album_routes(client: AsyncClient) -> AlbumRoutes:
+    return AlbumRoutes(client)
+
+
+@pytest.fixture
+async def signed_album(client: AsyncClient, session: AsyncSession) -> AlbumScenario:
+    return await sign_in_with_album(client, session)

--- a/backend/tests/helpers/albums.py
+++ b/backend/tests/helpers/albums.py
@@ -41,6 +41,11 @@ class AlbumRoutes:
     async def get_media(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/media")
 
+    async def get_media_ok(self, aid: str = AID) -> list:
+        resp = await self.get_media(aid)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def get_segment_points(
         self,
         *,
@@ -163,3 +168,8 @@ class AlbumRoutes:
 
     async def download_pdf(self, token: str) -> Response:
         return await self.client.get(f"/api/v1/albums/pdf/download/{token}")
+
+    async def download_pdf_ok(self, token: str) -> Response:
+        resp = await self.download_pdf(token)
+        assert resp.status_code == 200
+        return resp

--- a/backend/tests/helpers/albums.py
+++ b/backend/tests/helpers/albums.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from tests.factories import AID
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient, Response
+
+
+@dataclass(frozen=True)
+class AlbumRoutes:
+    client: AsyncClient
+
+    async def get_album(self, aid: str = AID) -> Response:
+        return await self.client.get(f"/api/v1/albums/{aid}")
+
+    async def get_segments(self, aid: str = AID) -> Response:
+        return await self.client.get(f"/api/v1/albums/{aid}/segments")
+
+    async def get_steps(self, aid: str = AID) -> Response:
+        return await self.client.get(f"/api/v1/albums/{aid}/steps")
+
+    async def get_media(self, aid: str = AID) -> Response:
+        return await self.client.get(f"/api/v1/albums/{aid}/media")
+
+    async def get_segment_points(
+        self,
+        *,
+        from_time: float = 0.0,
+        to_time: float = 1000.0,
+    ) -> tuple[Response, MagicMock]:
+        with patch(
+            "app.api.v1.routes.albums.enqueue_album_route_enrichment",
+        ) as mock_enqueue:
+            resp = await self.client.get(
+                f"/api/v1/albums/{AID}/segments/points",
+                params={"from_time": from_time, "to_time": to_time},
+            )
+        return resp, mock_enqueue
+
+    async def update_album(self, **payload: object) -> Response:
+        return await self.client.patch(f"/api/v1/albums/{AID}", json=payload)
+
+    async def update_step(self, step_id: int = 1, **payload: object) -> Response:
+        return await self.client.patch(
+            f"/api/v1/albums/{AID}/steps/{step_id}",
+            json=payload,
+        )
+
+    async def update_media_layout(
+        self,
+        *,
+        step_id: int = 1,
+        cover: str | None,
+        pages: list[list[str]],
+        unused: list[str],
+    ) -> Response:
+        return await self.client.put(
+            f"/api/v1/albums/{AID}/steps/{step_id}/media-layout",
+            json={"cover": cover, "pages": pages, "unused": unused},
+        )
+
+    async def adjust_boundary(
+        self,
+        *,
+        start_time: float = 100.0,
+        end_time: float = 300.0,
+        new_boundary_time: float = 200.0,
+        handle: str = "end",
+    ) -> Response:
+        return await self.client.patch(
+            f"/api/v1/albums/{AID}/segments/adjust-boundary",
+            json={
+                "start_time": start_time,
+                "end_time": end_time,
+                "new_boundary_time": new_boundary_time,
+                "handle": handle,
+            },
+        )
+
+    async def print_bundle(self) -> Response:
+        return await self.client.get(f"/api/v1/albums/{AID}/print-bundle")
+
+    async def download_pdf(self, token: str) -> Response:
+        return await self.client.get(f"/api/v1/albums/pdf/download/{token}")

--- a/backend/tests/helpers/albums.py
+++ b/backend/tests/helpers/albums.py
@@ -17,34 +17,14 @@ class AlbumRoutes:
     async def get_album(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}")
 
-    async def get_album_ok(self, aid: str = AID) -> dict:
-        resp = await self.get_album(aid)
-        assert resp.status_code == 200
-        return resp.json()
-
     async def get_segments(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/segments")
-
-    async def get_segments_ok(self, aid: str = AID) -> list:
-        resp = await self.get_segments(aid)
-        assert resp.status_code == 200
-        return resp.json()
 
     async def get_steps(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/steps")
 
-    async def get_steps_ok(self, aid: str = AID) -> list:
-        resp = await self.get_steps(aid)
-        assert resp.status_code == 200
-        return resp.json()
-
     async def get_media(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/media")
-
-    async def get_media_ok(self, aid: str = AID) -> list:
-        resp = await self.get_media(aid)
-        assert resp.status_code == 200
-        return resp.json()
 
     async def get_segment_points(
         self,
@@ -88,11 +68,6 @@ class AlbumRoutes:
             json=payload,
         )
 
-    async def update_step_ok(self, step_id: int = 1, **payload: object) -> dict:
-        resp = await self.update_step(step_id, **payload)
-        assert resp.status_code == 200
-        return resp.json()
-
     async def update_media_layout(
         self,
         *,
@@ -105,23 +80,6 @@ class AlbumRoutes:
             f"/api/v1/albums/{AID}/steps/{step_id}/media-layout",
             json={"cover": cover, "pages": pages, "unused": unused},
         )
-
-    async def update_media_layout_ok(
-        self,
-        *,
-        step_id: int = 1,
-        cover: str | None,
-        pages: list[list[str]],
-        unused: list[str],
-    ) -> dict:
-        resp = await self.update_media_layout(
-            step_id=step_id,
-            cover=cover,
-            pages=pages,
-            unused=unused,
-        )
-        assert resp.status_code == 200
-        return resp.json()
 
     async def adjust_boundary(
         self,
@@ -161,15 +119,5 @@ class AlbumRoutes:
     async def print_bundle(self) -> Response:
         return await self.client.get(f"/api/v1/albums/{AID}/print-bundle")
 
-    async def print_bundle_ok(self) -> dict:
-        resp = await self.print_bundle()
-        assert resp.status_code == 200
-        return resp.json()
-
     async def download_pdf(self, token: str) -> Response:
         return await self.client.get(f"/api/v1/albums/pdf/download/{token}")
-
-    async def download_pdf_ok(self, token: str) -> Response:
-        resp = await self.download_pdf(token)
-        assert resp.status_code == 200
-        return resp

--- a/backend/tests/helpers/albums.py
+++ b/backend/tests/helpers/albums.py
@@ -17,11 +17,26 @@ class AlbumRoutes:
     async def get_album(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}")
 
+    async def get_album_ok(self, aid: str = AID) -> dict:
+        resp = await self.get_album(aid)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def get_segments(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/segments")
 
+    async def get_segments_ok(self, aid: str = AID) -> list:
+        resp = await self.get_segments(aid)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def get_steps(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/steps")
+
+    async def get_steps_ok(self, aid: str = AID) -> list:
+        resp = await self.get_steps(aid)
+        assert resp.status_code == 200
+        return resp.json()
 
     async def get_media(self, aid: str = AID) -> Response:
         return await self.client.get(f"/api/v1/albums/{aid}/media")
@@ -41,14 +56,37 @@ class AlbumRoutes:
             )
         return resp, mock_enqueue
 
+    async def get_segment_points_ok(
+        self,
+        *,
+        from_time: float = 0.0,
+        to_time: float = 1000.0,
+    ) -> tuple[list, MagicMock]:
+        resp, mock_enqueue = await self.get_segment_points(
+            from_time=from_time,
+            to_time=to_time,
+        )
+        assert resp.status_code == 200
+        return resp.json(), mock_enqueue
+
     async def update_album(self, **payload: object) -> Response:
         return await self.client.patch(f"/api/v1/albums/{AID}", json=payload)
+
+    async def update_album_ok(self, **payload: object) -> dict:
+        resp = await self.update_album(**payload)
+        assert resp.status_code == 200
+        return resp.json()
 
     async def update_step(self, step_id: int = 1, **payload: object) -> Response:
         return await self.client.patch(
             f"/api/v1/albums/{AID}/steps/{step_id}",
             json=payload,
         )
+
+    async def update_step_ok(self, step_id: int = 1, **payload: object) -> dict:
+        resp = await self.update_step(step_id, **payload)
+        assert resp.status_code == 200
+        return resp.json()
 
     async def update_media_layout(
         self,
@@ -62,6 +100,23 @@ class AlbumRoutes:
             f"/api/v1/albums/{AID}/steps/{step_id}/media-layout",
             json={"cover": cover, "pages": pages, "unused": unused},
         )
+
+    async def update_media_layout_ok(
+        self,
+        *,
+        step_id: int = 1,
+        cover: str | None,
+        pages: list[list[str]],
+        unused: list[str],
+    ) -> dict:
+        resp = await self.update_media_layout(
+            step_id=step_id,
+            cover=cover,
+            pages=pages,
+            unused=unused,
+        )
+        assert resp.status_code == 200
+        return resp.json()
 
     async def adjust_boundary(
         self,
@@ -81,8 +136,30 @@ class AlbumRoutes:
             },
         )
 
+    async def adjust_boundary_ok(
+        self,
+        *,
+        start_time: float = 100.0,
+        end_time: float = 300.0,
+        new_boundary_time: float = 200.0,
+        handle: str = "end",
+    ) -> list:
+        resp = await self.adjust_boundary(
+            start_time=start_time,
+            end_time=end_time,
+            new_boundary_time=new_boundary_time,
+            handle=handle,
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
     async def print_bundle(self) -> Response:
         return await self.client.get(f"/api/v1/albums/{AID}/print-bundle")
+
+    async def print_bundle_ok(self) -> dict:
+        resp = await self.print_bundle()
+        assert resp.status_code == 200
+        return resp.json()
 
     async def download_pdf(self, token: str) -> Response:
         return await self.client.get(f"/api/v1/albums/pdf/download/{token}")

--- a/backend/tests/helpers/external_media.py
+++ b/backend/tests/helpers/external_media.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from PIL import Image
+
+from tests.factories import AID, DEFAULT_MEDIA_NAME, AlbumMediaScenario
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient, Response
+
+AlbumMediaFactory = Callable[..., Awaitable[AlbumMediaScenario]]
+
+
+def jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color="red").save(buf, "JPEG")
+    return buf.getvalue()
+
+
+def download_guard() -> tuple[Callable[..., AsyncIterator[object]], Callable[[], bool]]:
+    downloaded = False
+
+    async def fail_if_downloaded(**_kwargs: object) -> AsyncIterator[object]:
+        nonlocal downloaded
+        downloaded = True
+        for item in ():
+            yield item
+
+    return fail_if_downloaded, lambda: downloaded
+
+
+@dataclass(frozen=True)
+class ExternalMediaRoutes:
+    client: AsyncClient
+
+    async def add_device(
+        self,
+        *,
+        context: str,
+        filename: str = "holiday.jpg",
+        step_id: int | None = None,
+        width: int = 640,
+        height: int = 480,
+    ) -> Response:
+        data: dict[str, str] = {"context": context}
+        if step_id is not None:
+            data["step_id"] = str(step_id)
+        return await self.client.post(
+            f"/api/v1/albums/{AID}/external-media/add/device",
+            data=data,
+            files=[("files", (filename, jpeg_bytes(width, height), "image/jpeg"))],
+        )
+
+    async def replace_device(
+        self,
+        media_name: str,
+        *,
+        width: int = 1200,
+        height: int = 800,
+        content: bytes | None = None,
+    ) -> Response:
+        body = content if content is not None else jpeg_bytes(width, height)
+        return await self.client.post(
+            f"/api/v1/albums/{AID}/external-media/replace/device",
+            data={"media_name": media_name},
+            files={"file": ("replacement.jpg", body, "image/jpeg")},
+        )
+
+    async def undo_replacement(self, media_name: str) -> Response:
+        return await self.client.post(
+            f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
+        )
+
+    async def replace_google(
+        self,
+        *,
+        media_name: str = DEFAULT_MEDIA_NAME,
+        session_id: str = "session-abc",
+    ) -> Response:
+        return await self.client.post(
+            f"/api/v1/albums/{AID}/external-media/replace/google",
+            json={"media_name": media_name, "session_id": session_id},
+        )
+
+    async def add_google(
+        self,
+        **payload: str | int,
+    ) -> Response:
+        return await self.client.post(
+            f"/api/v1/albums/{AID}/external-media/add/google",
+            json={"session_id": "session-abc", **payload},
+        )

--- a/backend/tests/helpers/external_media.py
+++ b/backend/tests/helpers/external_media.py
@@ -127,16 +127,6 @@ class ExternalMediaRoutes:
             json={"media_name": media_name, "session_id": session_id},
         )
 
-    async def replace_google_ok(
-        self,
-        *,
-        media_name: str = DEFAULT_MEDIA_NAME,
-        session_id: str = "session-abc",
-    ) -> dict:
-        resp = await self.replace_google(media_name=media_name, session_id=session_id)
-        assert resp.status_code == 200
-        return resp.json()
-
     async def add_google(
         self,
         **payload: str | int,
@@ -145,8 +135,3 @@ class ExternalMediaRoutes:
             f"/api/v1/albums/{AID}/external-media/add/google",
             json={"session_id": "session-abc", **payload},
         )
-
-    async def add_google_ok(self, **payload: str | int) -> str:
-        resp = await self.add_google(**payload)
-        assert resp.status_code == 200
-        return resp.text

--- a/backend/tests/helpers/external_media.py
+++ b/backend/tests/helpers/external_media.py
@@ -55,6 +55,25 @@ class ExternalMediaRoutes:
             files=[("files", (filename, jpeg_bytes(width, height), "image/jpeg"))],
         )
 
+    async def add_device_ok(
+        self,
+        *,
+        context: str,
+        filename: str = "holiday.jpg",
+        step_id: int | None = None,
+        width: int = 640,
+        height: int = 480,
+    ) -> dict:
+        resp = await self.add_device(
+            context=context,
+            filename=filename,
+            step_id=step_id,
+            width=width,
+            height=height,
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
     async def replace_device(
         self,
         media_name: str,
@@ -70,10 +89,32 @@ class ExternalMediaRoutes:
             files={"file": ("replacement.jpg", body, "image/jpeg")},
         )
 
+    async def replace_device_ok(
+        self,
+        media_name: str,
+        *,
+        width: int = 1200,
+        height: int = 800,
+        content: bytes | None = None,
+    ) -> dict:
+        resp = await self.replace_device(
+            media_name,
+            width=width,
+            height=height,
+            content=content,
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
     async def undo_replacement(self, media_name: str) -> Response:
         return await self.client.post(
             f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
         )
+
+    async def undo_replacement_ok(self, media_name: str) -> dict:
+        resp = await self.undo_replacement(media_name)
+        assert resp.status_code == 200
+        return resp.json()
 
     async def replace_google(
         self,
@@ -86,6 +127,16 @@ class ExternalMediaRoutes:
             json={"media_name": media_name, "session_id": session_id},
         )
 
+    async def replace_google_ok(
+        self,
+        *,
+        media_name: str = DEFAULT_MEDIA_NAME,
+        session_id: str = "session-abc",
+    ) -> dict:
+        resp = await self.replace_google(media_name=media_name, session_id=session_id)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def add_google(
         self,
         **payload: str | int,
@@ -94,3 +145,8 @@ class ExternalMediaRoutes:
             f"/api/v1/albums/{AID}/external-media/add/google",
             json={"session_id": "session-abc", **payload},
         )
+
+    async def add_google_ok(self, **payload: str | int) -> str:
+        resp = await self.add_google(**payload)
+        assert resp.status_code == 200
+        return resp.text

--- a/backend/tests/helpers/external_media_fixtures.py
+++ b/backend/tests/helpers/external_media_fixtures.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tests.factories import AlbumMediaScenario, sign_in_with_album_media
+from tests.helpers.external_media import AlbumMediaFactory, ExternalMediaRoutes
+from tests.helpers.google_photos import google_connected_album_media
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+def external_media(client: AsyncClient) -> ExternalMediaRoutes:
+    return ExternalMediaRoutes(client)
+
+
+@pytest.fixture
+def album_media_scenario(
+    client: AsyncClient, session: AsyncSession
+) -> AlbumMediaFactory:
+    async def factory(**kwargs: Any) -> AlbumMediaScenario:
+        return await sign_in_with_album_media(client, session, **kwargs)
+
+    return factory
+
+
+@pytest.fixture
+def google_album_media_scenario(
+    client: AsyncClient, session: AsyncSession
+) -> AlbumMediaFactory:
+    async def factory(**kwargs: Any) -> AlbumMediaScenario:
+        return await google_connected_album_media(client, session, **kwargs)
+
+    return factory

--- a/backend/tests/helpers/google_photos.py
+++ b/backend/tests/helpers/google_photos.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from httpx_oauth.oauth2 import OAuth2Token
+from itsdangerous import URLSafeTimedSerializer
+
+from app.api.v1.deps import _get_http_clients
+from app.core.config import get_settings
+from app.core.http_clients import HttpClients
+from app.main import app
+from app.models.google_photos import GoogleMediaFile, PickedMediaItem
+from tests.conftest import _mock_http_clients
+from tests.factories import (
+    AlbumMediaScenario,
+    connect_google_photos,
+    sign_in_connected_google_photos,
+    sign_in_with_album_media,
+)
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient, Response
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+def fresh_oauth_token() -> OAuth2Token:
+    return OAuth2Token({"access_token": "fresh-token", "expires_in": 3600})
+
+
+def pin_http_clients() -> HttpClients:
+    http = _mock_http_clients()
+    app.dependency_overrides[_get_http_clients] = lambda: http
+    return http
+
+
+async def connected_google_photos_http(
+    client: AsyncClient, session: AsyncSession
+) -> HttpClients:
+    await sign_in_connected_google_photos(client, session)
+    http = pin_http_clients()
+    http.gphotos_oauth.refresh_token.return_value = fresh_oauth_token()
+    return http
+
+
+async def google_connected_album_media(
+    client: AsyncClient,
+    session: AsyncSession,
+    *,
+    write_media: bool = False,
+) -> AlbumMediaScenario:
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=write_media,
+    )
+    await connect_google_photos(session, scenario.uid)
+    http = pin_http_clients()
+    http.gphotos_oauth.refresh_token.return_value = fresh_oauth_token()
+    return scenario
+
+
+def picker_mock() -> AsyncMock:
+    mock_picker = AsyncMock()
+    mock_picker.return_value.id = "session-abc"
+    mock_picker.return_value.picker_uri = "https://photos.google.com/picker/abc"
+    return mock_picker
+
+
+def picked_item(
+    item_id: str = "google-1",
+    *,
+    filename: str = "picked.jpg",
+    base_url: str = "https://lh3.googleusercontent.com/test",
+    width: int = 1200,
+    height: int = 800,
+) -> PickedMediaItem:
+    return PickedMediaItem(
+        id=item_id,
+        create_time="2024-01-01T00:00:00Z",
+        type="PHOTO",
+        media_file=GoogleMediaFile(
+            base_url=base_url,
+            mime_type="image/jpeg",
+            filename=filename,
+            width=width,
+            height=height,
+        ),
+    )
+
+
+def build_callback_state(
+    csrf: str = "test-csrf-value",
+    nonce: str = "n-8chars",
+    redirect_uri: str = "http://test/api/v1/google-photos/callback",
+) -> str:
+    return URLSafeTimedSerializer(
+        get_settings().SECRET_KEY, salt="gphotos-oauth-state"
+    ).dumps({"csrf": csrf, "nonce": nonce, "redirect_uri": redirect_uri})
+
+
+def build_oauth_cookie(
+    csrf: str = "test-csrf-value",
+    verifier: str = "test-verifier-value",
+) -> str:
+    return URLSafeTimedSerializer(
+        get_settings().SECRET_KEY, salt="gphotos-oauth-cookie"
+    ).dumps({"csrf": csrf, "verifier": verifier})
+
+
+async def oauth_callback(
+    client: AsyncClient,
+    *,
+    csrf: str = "test-csrf-value",
+    cookie_csrf: str | None = "test-csrf-value",
+    verifier: str = "test-verifier-value",
+) -> Response:
+    state = build_callback_state(csrf=csrf)
+    if cookie_csrf is not None:
+        client.cookies.set(
+            "gphotos_oauth",
+            build_oauth_cookie(csrf=cookie_csrf, verifier=verifier),
+        )
+    return await client.get(
+        "/api/v1/google-photos/callback",
+        params={"code": "auth-code", "state": state},
+        follow_redirects=False,
+    )
+
+
+def assert_error_redirect(resp: Response) -> None:
+    assert resp.status_code == 303
+    assert "?error" in resp.headers["location"]

--- a/backend/tests/helpers/google_photos.py
+++ b/backend/tests/helpers/google_photos.py
@@ -37,6 +37,11 @@ class GooglePhotosRoutes:
             else None,
         )
 
+    async def create_session_ok(self, max_item_count: int | None = None) -> dict:
+        resp = await self.create_session(max_item_count=max_item_count)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def disconnect(self) -> Response:
         return await self.client.delete("/api/v1/google-photos/connection")
 

--- a/backend/tests/helpers/google_photos.py
+++ b/backend/tests/helpers/google_photos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
@@ -22,6 +23,22 @@ from tests.factories import (
 if TYPE_CHECKING:
     from httpx import AsyncClient, Response
     from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@dataclass(frozen=True)
+class GooglePhotosRoutes:
+    client: AsyncClient
+
+    async def create_session(self, max_item_count: int | None = None) -> Response:
+        return await self.client.post(
+            "/api/v1/google-photos/sessions",
+            params={"max_item_count": max_item_count}
+            if max_item_count is not None
+            else None,
+        )
+
+    async def disconnect(self) -> Response:
+        return await self.client.delete("/api/v1/google-photos/connection")
 
 
 def fresh_oauth_token() -> OAuth2Token:

--- a/backend/tests/helpers/google_photos_fixtures.py
+++ b/backend/tests/helpers/google_photos_fixtures.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers.google_photos import GooglePhotosRoutes
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+@pytest.fixture
+def google_photos_routes(client: AsyncClient) -> GooglePhotosRoutes:
+    return GooglePhotosRoutes(client)

--- a/backend/tests/helpers/http.py
+++ b/backend/tests/helpers/http.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+_DUMMY_REQUEST = httpx.Request("GET", "http://test")
+
+
+def json_response(data: object, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code, content=json.dumps(data).encode(), request=_DUMMY_REQUEST
+    )
+
+
+def mock_response(content: bytes, status_code: int = 200) -> MagicMock:
+    resp = MagicMock(status_code=status_code)
+    resp.content = content
+    return resp
+
+
+def error_response(status: int = 500) -> MagicMock:
+    resp = MagicMock(status_code=status)
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status}", request=MagicMock(), response=resp
+    )
+    return resp
+
+
+def async_client(**methods: object) -> AsyncMock:
+    client = AsyncMock()
+    for method, response in methods.items():
+        call = getattr(client, method)
+        if isinstance(response, (BaseException, list)):
+            call.side_effect = response
+        else:
+            call.return_value = response
+    return client

--- a/backend/tests/helpers/user_fixtures.py
+++ b/backend/tests/helpers/user_fixtures.py
@@ -7,9 +7,16 @@ import pytest
 from tests.helpers.users import UserRoutes
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from httpx import AsyncClient
 
 
 @pytest.fixture
 def user_routes(client: AsyncClient) -> UserRoutes:
     return UserRoutes(client)
+
+
+@pytest.fixture
+async def uploaded_user(user_routes: UserRoutes, users_dir: Path) -> dict:
+    return await user_routes.sign_in_and_upload(users_dir)

--- a/backend/tests/helpers/user_fixtures.py
+++ b/backend/tests/helpers/user_fixtures.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers.users import UserRoutes
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+@pytest.fixture
+def user_routes(client: AsyncClient) -> UserRoutes:
+    return UserRoutes(client)

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -72,6 +72,9 @@ class UserRoutes:
     async def delete_demo(self) -> Response:
         return await self.client.delete("/api/v1/users/demo")
 
+    async def download_export(self, token: str) -> Response:
+        return await self.client.get(f"/api/v1/users/export/download/{token}")
+
     async def init_upload(self) -> Response:
         return await self.client.post("/api/v1/users/upload/init")
 

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -24,6 +24,11 @@ class UserRoutes:
             f"/api/v1/auth/{provider}", json={"credential": credential}
         )
 
+    async def auth_ok(self, provider: str, credential: str = "fake") -> dict | None:
+        resp = await self.auth(provider, credential)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def sign_in(
         self, provider: str = "google", payload: dict | None = None
     ) -> None:
@@ -48,9 +53,19 @@ class UserRoutes:
             files={"file": ("data.zip", b"fake", "application/zip")},
         )
 
+    async def upload_ok(self) -> dict:
+        resp = await self.upload()
+        assert resp.status_code == 200
+        return resp.json()
+
     async def upload_with_extract(self, users_dir: Path) -> Response:
         with mock_extract(users_dir):
             return await self.upload()
+
+    async def upload_with_extract_ok(self, users_dir: Path) -> dict:
+        resp = await self.upload_with_extract(users_dir)
+        assert resp.status_code == 200
+        return resp.json()
 
     async def current(self) -> Response:
         return await self.client.get("/api/v1/users")
@@ -63,8 +78,18 @@ class UserRoutes:
     async def update(self, **payload: object) -> Response:
         return await self.client.patch("/api/v1/users", json=payload)
 
+    async def update_ok(self, **payload: object) -> dict:
+        resp = await self.update(**payload)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def delete(self) -> Response:
         return await self.client.delete("/api/v1/users")
+
+    async def delete_ok(self) -> dict:
+        resp = await self.delete()
+        assert resp.status_code == 200
+        return resp.json()
 
     async def demo(self, *, accept_language: str | None = None) -> Response:
         headers = (

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -114,6 +114,11 @@ class UserRoutes:
     async def download_export(self, token: str) -> Response:
         return await self.client.get(f"/api/v1/users/export/download/{token}")
 
+    async def download_export_ok(self, token: str) -> Response:
+        resp = await self.download_export(token)
+        assert resp.status_code == 200
+        return resp
+
     async def init_upload(self) -> Response:
         return await self.client.post("/api/v1/users/upload/init")
 

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -53,19 +53,9 @@ class UserRoutes:
             files={"file": ("data.zip", b"fake", "application/zip")},
         )
 
-    async def upload_ok(self) -> dict:
-        resp = await self.upload()
-        assert resp.status_code == 200
-        return resp.json()
-
     async def upload_with_extract(self, users_dir: Path) -> Response:
         with mock_extract(users_dir):
             return await self.upload()
-
-    async def upload_with_extract_ok(self, users_dir: Path) -> dict:
-        resp = await self.upload_with_extract(users_dir)
-        assert resp.status_code == 200
-        return resp.json()
 
     async def current(self) -> Response:
         return await self.client.get("/api/v1/users")
@@ -77,11 +67,6 @@ class UserRoutes:
 
     async def update(self, **payload: object) -> Response:
         return await self.client.patch("/api/v1/users", json=payload)
-
-    async def update_ok(self, **payload: object) -> dict:
-        resp = await self.update(**payload)
-        assert resp.status_code == 200
-        return resp.json()
 
     async def delete(self) -> Response:
         return await self.client.delete("/api/v1/users")
@@ -107,17 +92,8 @@ class UserRoutes:
     async def delete_demo(self) -> Response:
         return await self.client.delete("/api/v1/users/demo")
 
-    async def delete_demo_ok(self) -> None:
-        resp = await self.delete_demo()
-        assert resp.status_code == 204
-
     async def download_export(self, token: str) -> Response:
         return await self.client.get(f"/api/v1/users/export/download/{token}")
-
-    async def download_export_ok(self, token: str) -> Response:
-        resp = await self.download_export(token)
-        assert resp.status_code == 200
-        return resp
 
     async def init_upload(self) -> Response:
         return await self.client.post("/api/v1/users/upload/init")

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -55,6 +55,11 @@ class UserRoutes:
     async def current(self) -> Response:
         return await self.client.get("/api/v1/users")
 
+    async def current_ok(self) -> dict:
+        resp = await self.current()
+        assert resp.status_code == 200
+        return resp.json()
+
     async def update(self, **payload: object) -> Response:
         return await self.client.patch("/api/v1/users", json=payload)
 
@@ -69,8 +74,17 @@ class UserRoutes:
         )
         return await self.client.post("/api/v1/users/demo", headers=headers)
 
+    async def demo_ok(self, *, accept_language: str | None = None) -> dict:
+        resp = await self.demo(accept_language=accept_language)
+        assert resp.status_code == 200
+        return resp.json()
+
     async def delete_demo(self) -> Response:
         return await self.client.delete("/api/v1/users/demo")
+
+    async def delete_demo_ok(self) -> None:
+        resp = await self.delete_demo()
+        assert resp.status_code == 204
 
     async def download_export(self, token: str) -> Response:
         return await self.client.get(f"/api/v1/users/export/download/{token}")

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tests.factories import mock_extract, sign_in
+from tests.factories import (
+    mock_extract,
+    sign_in as factory_sign_in,
+    sign_in_and_upload as factory_sign_in_and_upload,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -20,6 +24,21 @@ class UserRoutes:
             f"/api/v1/auth/{provider}", json={"credential": credential}
         )
 
+    async def sign_in(
+        self, provider: str = "google", payload: dict | None = None
+    ) -> None:
+        await factory_sign_in(self.client, provider=provider, payload=payload)
+
+    async def sign_in_and_upload(
+        self,
+        users_dir: Path,
+        provider: str = "google",
+        payload: dict | None = None,
+    ) -> dict:
+        return await factory_sign_in_and_upload(
+            self.client, users_dir, provider=provider, payload=payload
+        )
+
     async def logout(self) -> Response:
         return await self.client.post("/api/v1/auth/logout")
 
@@ -28,6 +47,10 @@ class UserRoutes:
             "/api/v1/users/upload",
             files={"file": ("data.zip", b"fake", "application/zip")},
         )
+
+    async def upload_with_extract(self, users_dir: Path) -> Response:
+        with mock_extract(users_dir):
+            return await self.upload()
 
     async def current(self) -> Response:
         return await self.client.get("/api/v1/users")
@@ -53,7 +76,7 @@ class UserRoutes:
         return await self.client.post("/api/v1/users/upload/init")
 
     async def start_chunked_upload(self, provider: str = "google") -> str:
-        await sign_in(self.client, provider)
+        await factory_sign_in(self.client, provider)
         resp = await self.init_upload()
         assert resp.status_code == 200
         return resp.json()["upload_id"]

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -153,3 +153,12 @@ class UserRoutes:
     ) -> Response:
         with mock_extract(users_dir):
             return await self.complete_upload(upload_id)
+
+    async def complete_upload_with_extract_ok(
+        self,
+        upload_id: str,
+        users_dir: Path,
+    ) -> dict:
+        resp = await self.complete_upload_with_extract(upload_id, users_dir)
+        assert resp.status_code == 200
+        return resp.json()

--- a/backend/tests/helpers/users.py
+++ b/backend/tests/helpers/users.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tests.factories import mock_extract, sign_in
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import AsyncClient, Response
+
+
+@dataclass(frozen=True)
+class UserRoutes:
+    client: AsyncClient
+
+    async def auth(self, provider: str, credential: str = "fake") -> Response:
+        return await self.client.post(
+            f"/api/v1/auth/{provider}", json={"credential": credential}
+        )
+
+    async def logout(self) -> Response:
+        return await self.client.post("/api/v1/auth/logout")
+
+    async def upload(self) -> Response:
+        return await self.client.post(
+            "/api/v1/users/upload",
+            files={"file": ("data.zip", b"fake", "application/zip")},
+        )
+
+    async def current(self) -> Response:
+        return await self.client.get("/api/v1/users")
+
+    async def update(self, **payload: object) -> Response:
+        return await self.client.patch("/api/v1/users", json=payload)
+
+    async def delete(self) -> Response:
+        return await self.client.delete("/api/v1/users")
+
+    async def demo(self, *, accept_language: str | None = None) -> Response:
+        headers = (
+            {"Accept-Language": accept_language}
+            if accept_language is not None
+            else None
+        )
+        return await self.client.post("/api/v1/users/demo", headers=headers)
+
+    async def delete_demo(self) -> Response:
+        return await self.client.delete("/api/v1/users/demo")
+
+    async def init_upload(self) -> Response:
+        return await self.client.post("/api/v1/users/upload/init")
+
+    async def start_chunked_upload(self, provider: str = "google") -> str:
+        await sign_in(self.client, provider)
+        resp = await self.init_upload()
+        assert resp.status_code == 200
+        return resp.json()["upload_id"]
+
+    async def put_chunk(
+        self,
+        upload_id: str,
+        index: int,
+        content: bytes = b"fake-zip",
+    ) -> Response:
+        return await self.client.put(
+            f"/api/v1/users/upload/{upload_id}/{index}",
+            content=content,
+        )
+
+    async def put_chunk_ok(
+        self,
+        upload_id: str,
+        index: int,
+        content: bytes = b"fake-zip",
+    ) -> None:
+        resp = await self.put_chunk(upload_id, index, content)
+        assert resp.status_code == 204
+
+    async def complete_upload(self, upload_id: str) -> Response:
+        return await self.client.post(f"/api/v1/users/upload/{upload_id}/complete")
+
+    async def complete_upload_with_extract(
+        self,
+        upload_id: str,
+        users_dir: Path,
+    ) -> Response:
+        with mock_extract(users_dir):
+            return await self.complete_upload(upload_id)

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -10,71 +10,42 @@ from app.models.segment import Segment, SegmentKind
 
 from .factories import (
     AID,
+    AlbumScenario,
     insert_album,
     insert_album_media,
     insert_segment,
     insert_step,
     make_points,
     sign_in_and_upload,
-    sign_in_with_album,
 )
+from .helpers.albums import AlbumRoutes
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient, Response
+    from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-
-async def _get_segment_points(
-    client: AsyncClient,
-    *,
-    from_time: float = 0.0,
-    to_time: float = 1000.0,
-) -> tuple[Response, MagicMock]:
-    with patch(
-        "app.api.v1.routes.albums.enqueue_album_route_enrichment",
-    ) as mock_enqueue:
-        resp = await client.get(
-            f"/api/v1/albums/{AID}/segments/points",
-            params={"from_time": from_time, "to_time": to_time},
-        )
-    return resp, mock_enqueue
-
-
-async def _adjust_boundary(
-    client: AsyncClient,
-    *,
-    start_time: float = 100.0,
-    end_time: float = 300.0,
-    new_boundary_time: float = 200.0,
-    handle: str = "end",
-) -> Response:
-    return await client.patch(
-        f"/api/v1/albums/{AID}/segments/adjust-boundary",
-        json={
-            "start_time": start_time,
-            "end_time": end_time,
-            "new_boundary_time": new_boundary_time,
-            "handle": handle,
-        },
-    )
+pytest_plugins = ("tests.helpers.album_fixtures",)
 
 
 class TestReadAlbum:
     async def test_cannot_read_other_users_album(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        album_routes: AlbumRoutes,
+        tmp_path: Path,
     ) -> None:
         await sign_in_and_upload(client, tmp_path / "users")
         await insert_album(session, uid=9999, aid="other-trip")
 
-        resp = await client.get("/api/v1/albums/other-trip")
+        resp = await album_routes.get_album("other-trip")
         assert resp.status_code == 404
 
+    @pytest.mark.usefixtures("signed_album")
     async def test_returns_album_meta_without_media(
-        self, client: AsyncClient, session: AsyncSession
+        self, album_routes: AlbumRoutes
     ) -> None:
-        await sign_in_with_album(client, session)
-
-        resp = await client.get(f"/api/v1/albums/{AID}")
+        resp = await album_routes.get_album()
         assert resp.status_code == 200
         data = resp.json()
         assert "media" not in data
@@ -84,12 +55,14 @@ class TestReadAlbum:
 
 class TestReadSegments:
     async def test_returns_outlines_without_points(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
-        await insert_segment(session, album.uid)
+        await insert_segment(session, signed_album.uid)
 
-        resp = await client.get(f"/api/v1/albums/{AID}/segments")
+        resp = await album_routes.get_segments()
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
@@ -103,26 +76,28 @@ class TestReadSegments:
 
 class TestReadSegmentPoints:
     async def test_returns_segments_with_points_for_time_range(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=100.0,
             end_time=300.0,
             kind=SegmentKind.driving,
         )
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=500.0,
             end_time=700.0,
             kind=SegmentKind.hike,
         )
 
-        resp, mock_enqueue = await _get_segment_points(
-            client, from_time=50.0, to_time=400.0
+        resp, mock_enqueue = await album_routes.get_segment_points(
+            from_time=50.0, to_time=400.0
         )
         mock_enqueue.assert_not_called()
         assert resp.status_code == 200
@@ -135,18 +110,21 @@ class TestReadSegmentPoints:
 class TestSegmentPointsReadOnly:
     @pytest.mark.parametrize("kind", [SegmentKind.driving, SegmentKind.hike])
     async def test_segment_returns_stored_null_route(
-        self, client: AsyncClient, session: AsyncSession, kind: SegmentKind
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
+        kind: SegmentKind,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=100.0,
             end_time=300.0,
             kind=kind,
         )
 
-        resp, mock_enqueue = await _get_segment_points(client)
+        resp, mock_enqueue = await album_routes.get_segment_points()
 
         mock_enqueue.assert_not_called()
         assert resp.status_code == 200
@@ -155,12 +133,14 @@ class TestSegmentPointsReadOnly:
         assert data[0]["route"] is None
 
     async def test_already_matched_route_returned_as_stored(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         seg = await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=100.0,
             end_time=300.0,
             kind=SegmentKind.driving,
@@ -169,24 +149,18 @@ class TestSegmentPointsReadOnly:
         session.add(seg)
         await session.flush()
 
-        resp, mock_enqueue = await _get_segment_points(client)
+        resp, mock_enqueue = await album_routes.get_segment_points()
 
         mock_enqueue.assert_not_called()
         assert resp.json()[0]["route"] == [[4.0, 52.0], [4.01, 52.01]]
 
 
+@pytest.mark.usefixtures("signed_album")
 class TestUpdateAlbum:
-    async def test_update_cover_photos(
-        self, client: AsyncClient, session: AsyncSession
-    ) -> None:
-        await sign_in_with_album(client, session)
-
-        resp = await client.patch(
-            f"/api/v1/albums/{AID}",
-            json={
-                "front_cover_photo": "new_front.jpg",
-                "back_cover_photo": "new_back.jpg",
-            },
+    async def test_update_cover_photos(self, album_routes: AlbumRoutes) -> None:
+        resp = await album_routes.update_album(
+            front_cover_photo="new_front.jpg",
+            back_cover_photo="new_back.jpg",
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -194,11 +168,9 @@ class TestUpdateAlbum:
         assert data["back_cover_photo"] == "new_back.jpg"
 
     async def test_partial_update_preserves_other_fields(
-        self, client: AsyncClient, session: AsyncSession
+        self, album_routes: AlbumRoutes
     ) -> None:
-        await sign_in_with_album(client, session)
-
-        resp = await client.patch(f"/api/v1/albums/{AID}", json={"title": "Changed"})
+        resp = await album_routes.update_album(title="Changed")
         assert resp.status_code == 200
         data = resp.json()
         assert data["title"] == "Changed"
@@ -208,15 +180,14 @@ class TestUpdateAlbum:
 
 class TestUpdateStep:
     async def test_partial_update_preserves_other_fields(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
-        await insert_step(session, album.uid)
+        await insert_step(session, signed_album.uid)
 
-        resp = await client.patch(
-            f"/api/v1/albums/{AID}/steps/1",
-            json={"name": "New Name"},
-        )
+        resp = await album_routes.update_step(name="New Name")
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "New Name"
@@ -226,21 +197,20 @@ class TestUpdateStep:
         assert data["cover"] is None
 
     async def test_media_layout_update_rewrites_step_placements(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         for name in ("a.jpg", "b.jpg", "c.jpg", "cover.jpg", "unused.jpg"):
-            await insert_album_media(session, album.uid, name=name)
-        await insert_step(session, album.uid)
+            await insert_album_media(session, signed_album.uid, name=name)
+        await insert_step(session, signed_album.uid)
         await session.commit()
 
-        resp = await client.put(
-            f"/api/v1/albums/{AID}/steps/1/media-layout",
-            json={
-                "cover": "cover.jpg",
-                "pages": [["a.jpg", "b.jpg"], ["c.jpg"]],
-                "unused": ["unused.jpg"],
-            },
+        resp = await album_routes.update_media_layout(
+            cover="cover.jpg",
+            pages=[["a.jpg", "b.jpg"], ["c.jpg"]],
+            unused=["unused.jpg"],
         )
 
         assert resp.status_code == 200
@@ -249,22 +219,23 @@ class TestUpdateStep:
         assert data["pages"] == [["a.jpg", "b.jpg"], ["c.jpg"]]
         assert data["unused"] == ["unused.jpg"]
 
-        get_resp = await client.get(f"/api/v1/albums/{AID}/steps")
+        get_resp = await album_routes.get_steps()
         assert get_resp.status_code == 200
         assert get_resp.json()[0]["cover"] == "cover.jpg"
         assert get_resp.json()[0]["pages"] == [["a.jpg", "b.jpg"], ["c.jpg"]]
         assert get_resp.json()[0]["unused"] == ["unused.jpg"]
 
     async def test_media_layout_update_rejects_missing_album_media(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
-        await insert_step(session, album.uid)
+        await insert_step(session, signed_album.uid)
         await session.commit()
 
-        resp = await client.put(
-            f"/api/v1/albums/{AID}/steps/1/media-layout",
-            json={"cover": None, "pages": [["missing.jpg"]], "unused": []},
+        resp = await album_routes.update_media_layout(
+            cover=None, pages=[["missing.jpg"]], unused=[]
         )
 
         assert resp.status_code == 400
@@ -299,12 +270,14 @@ class TestAdjustSegmentBoundary:
         return seg1, seg2
 
     async def test_flight_segment_rejected(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=100.0,
             end_time=300.0,
             kind=SegmentKind.flight,
@@ -314,26 +287,28 @@ class TestAdjustSegmentBoundary:
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
             create=True,
         ) as mock_enqueue:
-            resp = await _adjust_boundary(client)
+            resp = await album_routes.adjust_boundary()
         assert resp.status_code == 400
         assert "flight" in resp.json()["detail"].lower()
         mock_enqueue.assert_not_called()
 
     async def test_adjust_end_handle_success(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
-        await self._setup_adjacent_segments(session, album.uid)
+        await self._setup_adjacent_segments(session, signed_album.uid)
 
         with patch(
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
             create=True,
         ) as mock_enqueue:
-            resp = await _adjust_boundary(client)
+            resp = await album_routes.adjust_boundary()
         assert resp.status_code == 200
         mock_enqueue.assert_called_once()
         _, _, called_uid, called_aid = mock_enqueue.call_args.args
-        assert (called_uid, called_aid) == (album.uid, AID)
+        assert (called_uid, called_aid) == (signed_album.uid, AID)
         data = resp.json()
         assert isinstance(data, list)
         assert len(data) == 2
@@ -342,12 +317,14 @@ class TestAdjustSegmentBoundary:
         assert "points" not in data[0]
 
     async def test_adjust_start_handle_success(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=100.0,
             end_time=200.0,
             kind=SegmentKind.driving,
@@ -355,15 +332,14 @@ class TestAdjustSegmentBoundary:
         )
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=200.0,
             end_time=500.0,
             kind=SegmentKind.hike,
             points=make_points([200.0, 300.0, 400.0, 500.0]),
         )
 
-        resp = await _adjust_boundary(
-            client,
+        resp = await album_routes.adjust_boundary(
             start_time=200.0,
             end_time=500.0,
             new_boundary_time=300.0,
@@ -375,12 +351,14 @@ class TestAdjustSegmentBoundary:
         assert len(data) == 2
 
     async def test_route_reset_after_boundary_adjust(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
         seg = await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=100.0,
             end_time=300.0,
             kind=SegmentKind.driving,
@@ -391,14 +369,14 @@ class TestAdjustSegmentBoundary:
         await session.flush()
         await insert_segment(
             session,
-            album.uid,
+            signed_album.uid,
             start_time=300.0,
             end_time=500.0,
             kind=SegmentKind.hike,
             points=make_points([300.0, 400.0, 500.0]),
         )
 
-        resp = await _adjust_boundary(client)
+        resp = await album_routes.adjust_boundary()
         assert resp.status_code == 200
         data = resp.json()
         for seg_data in data:
@@ -407,13 +385,15 @@ class TestAdjustSegmentBoundary:
 
 class TestPrintBundle:
     async def test_returns_full_bundle(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
     ) -> None:
-        album = await sign_in_with_album(client, session)
-        await insert_step(session, album.uid)
-        await insert_segment(session, album.uid)
+        await insert_step(session, signed_album.uid)
+        await insert_segment(session, signed_album.uid)
 
-        resp = await client.get(f"/api/v1/albums/{AID}/print-bundle")
+        resp = await album_routes.print_bundle()
         assert resp.status_code == 200
         data = resp.json()
         assert "album" in data
@@ -421,7 +401,7 @@ class TestPrintBundle:
         assert "segments" in data
         assert "total_distance_km" in data
         assert "media" in data["album"]
-        assert data["album"]["media"][0]["uid"] == album.uid
+        assert data["album"]["media"][0]["uid"] == signed_album.uid
         assert data["album"]["media"][0]["aid"] == AID
         assert data["album"]["media"][0]["byte_size"] == 1234
         assert "updated_at" in data["album"]["media"][0]
@@ -432,7 +412,7 @@ class TestPrintBundle:
 
 class TestDownloadPdf:
     async def test_valid_token_returns_file(
-        self, client: AsyncClient, tmp_path: Path
+        self, album_routes: AlbumRoutes, tmp_path: Path
     ) -> None:
         pdf_path = tmp_path / "test.pdf"
         pdf_path.write_bytes(b"%PDF-1.4 fake content")
@@ -441,7 +421,7 @@ class TestDownloadPdf:
             "app.api.v1.routes.albums.pop_pdf_token",
             return_value=(pdf_path, "my-album"),
         ):
-            resp = await client.get("/api/v1/albums/pdf/download/valid-token")
+            resp = await album_routes.download_pdf("valid-token")
 
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
     from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-pytest_plugins = ("tests.helpers.album_fixtures",)
-
 
 class TestReadAlbum:
     async def test_cannot_read_other_users_album(

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.models.segment import Segment, SegmentKind
 
 from .factories import (
@@ -131,8 +133,9 @@ class TestReadSegmentPoints:
 
 
 class TestSegmentPointsReadOnly:
-    async def test_unmatched_driving_segment_returns_stored_null_route(
-        self, client: AsyncClient, session: AsyncSession
+    @pytest.mark.parametrize("kind", [SegmentKind.driving, SegmentKind.hike])
+    async def test_segment_returns_stored_null_route(
+        self, client: AsyncClient, session: AsyncSession, kind: SegmentKind
     ) -> None:
         album = await sign_in_with_album(client, session)
         await insert_segment(
@@ -140,7 +143,7 @@ class TestSegmentPointsReadOnly:
             album.uid,
             start_time=100.0,
             end_time=300.0,
-            kind=SegmentKind.driving,
+            kind=kind,
         )
 
         resp, mock_enqueue = await _get_segment_points(client)
@@ -149,24 +152,6 @@ class TestSegmentPointsReadOnly:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["route"] is None
-
-    async def test_hike_segment_returns_stored_null_route(
-        self, client: AsyncClient, session: AsyncSession
-    ) -> None:
-        album = await sign_in_with_album(client, session)
-        await insert_segment(
-            session,
-            album.uid,
-            start_time=100.0,
-            end_time=300.0,
-            kind=SegmentKind.hike,
-        )
-
-        resp, mock_enqueue = await _get_segment_points(client)
-
-        mock_enqueue.assert_not_called()
-        data = resp.json()
         assert data[0]["route"] is None
 
     async def test_already_matched_route_returned_as_stored(

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from app.models.segment import Segment, SegmentKind
 
@@ -18,8 +18,43 @@ from .factories import (
 )
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Response
     from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+async def _get_segment_points(
+    client: AsyncClient,
+    *,
+    from_time: float = 0.0,
+    to_time: float = 1000.0,
+) -> tuple[Response, MagicMock]:
+    with patch(
+        "app.api.v1.routes.albums.enqueue_album_route_enrichment",
+    ) as mock_enqueue:
+        resp = await client.get(
+            f"/api/v1/albums/{AID}/segments/points",
+            params={"from_time": from_time, "to_time": to_time},
+        )
+    return resp, mock_enqueue
+
+
+async def _adjust_boundary(
+    client: AsyncClient,
+    *,
+    start_time: float = 100.0,
+    end_time: float = 300.0,
+    new_boundary_time: float = 200.0,
+    handle: str = "end",
+) -> Response:
+    return await client.patch(
+        f"/api/v1/albums/{AID}/segments/adjust-boundary",
+        json={
+            "start_time": start_time,
+            "end_time": end_time,
+            "new_boundary_time": new_boundary_time,
+            "handle": handle,
+        },
+    )
 
 
 class TestReadAlbum:
@@ -84,13 +119,9 @@ class TestReadSegmentPoints:
             kind=SegmentKind.hike,
         )
 
-        with patch(
-            "app.api.v1.routes.albums.enqueue_album_route_enrichment",
-        ) as mock_enqueue:
-            resp = await client.get(
-                f"/api/v1/albums/{AID}/segments/points",
-                params={"from_time": 50.0, "to_time": 400.0},
-            )
+        resp, mock_enqueue = await _get_segment_points(
+            client, from_time=50.0, to_time=400.0
+        )
         mock_enqueue.assert_not_called()
         assert resp.status_code == 200
         data = resp.json()
@@ -112,13 +143,7 @@ class TestSegmentPointsReadOnly:
             kind=SegmentKind.driving,
         )
 
-        with patch(
-            "app.api.v1.routes.albums.enqueue_album_route_enrichment",
-        ) as mock_enqueue:
-            resp = await client.get(
-                f"/api/v1/albums/{AID}/segments/points",
-                params={"from_time": 0.0, "to_time": 1000.0},
-            )
+        resp, mock_enqueue = await _get_segment_points(client)
 
         mock_enqueue.assert_not_called()
         assert resp.status_code == 200
@@ -138,13 +163,7 @@ class TestSegmentPointsReadOnly:
             kind=SegmentKind.hike,
         )
 
-        with patch(
-            "app.api.v1.routes.albums.enqueue_album_route_enrichment",
-        ) as mock_enqueue:
-            resp = await client.get(
-                f"/api/v1/albums/{AID}/segments/points",
-                params={"from_time": 0.0, "to_time": 1000.0},
-            )
+        resp, mock_enqueue = await _get_segment_points(client)
 
         mock_enqueue.assert_not_called()
         data = resp.json()
@@ -165,13 +184,7 @@ class TestSegmentPointsReadOnly:
         session.add(seg)
         await session.flush()
 
-        with patch(
-            "app.api.v1.routes.albums.enqueue_album_route_enrichment",
-        ) as mock_enqueue:
-            resp = await client.get(
-                f"/api/v1/albums/{AID}/segments/points",
-                params={"from_time": 0.0, "to_time": 1000.0},
-            )
+        resp, mock_enqueue = await _get_segment_points(client)
 
         mock_enqueue.assert_not_called()
         assert resp.json()[0]["route"] == [[4.0, 52.0], [4.01, 52.01]]
@@ -316,15 +329,7 @@ class TestAdjustSegmentBoundary:
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
             create=True,
         ) as mock_enqueue:
-            resp = await client.patch(
-                f"/api/v1/albums/{AID}/segments/adjust-boundary",
-                json={
-                    "start_time": 100.0,
-                    "end_time": 300.0,
-                    "new_boundary_time": 200.0,
-                    "handle": "end",
-                },
-            )
+            resp = await _adjust_boundary(client)
         assert resp.status_code == 400
         assert "flight" in resp.json()["detail"].lower()
         mock_enqueue.assert_not_called()
@@ -339,15 +344,7 @@ class TestAdjustSegmentBoundary:
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
             create=True,
         ) as mock_enqueue:
-            resp = await client.patch(
-                f"/api/v1/albums/{AID}/segments/adjust-boundary",
-                json={
-                    "start_time": 100.0,
-                    "end_time": 300.0,
-                    "new_boundary_time": 200.0,
-                    "handle": "end",
-                },
-            )
+            resp = await _adjust_boundary(client)
         assert resp.status_code == 200
         mock_enqueue.assert_called_once()
         _, _, called_uid, called_aid = mock_enqueue.call_args.args
@@ -380,14 +377,12 @@ class TestAdjustSegmentBoundary:
             points=make_points([200.0, 300.0, 400.0, 500.0]),
         )
 
-        resp = await client.patch(
-            f"/api/v1/albums/{AID}/segments/adjust-boundary",
-            json={
-                "start_time": 200.0,
-                "end_time": 500.0,
-                "new_boundary_time": 300.0,
-                "handle": "start",
-            },
+        resp = await _adjust_boundary(
+            client,
+            start_time=200.0,
+            end_time=500.0,
+            new_boundary_time=300.0,
+            handle="start",
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -418,15 +413,7 @@ class TestAdjustSegmentBoundary:
             points=make_points([300.0, 400.0, 500.0]),
         )
 
-        resp = await client.patch(
-            f"/api/v1/albums/{AID}/segments/adjust-boundary",
-            json={
-                "start_time": 100.0,
-                "end_time": 300.0,
-                "new_boundary_time": 200.0,
-                "handle": "end",
-            },
-        )
+        resp = await _adjust_boundary(client)
         assert resp.status_code == 200
         data = resp.json()
         for seg_data in data:

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -51,9 +51,7 @@ class TestReadAlbum:
     async def test_returns_album_meta_without_media(
         self, album_routes: AlbumRoutes
     ) -> None:
-        resp = await album_routes.get_album()
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await album_routes.get_album_ok()
         assert "media" not in data
         assert "steps" not in data
         assert "segments" not in data
@@ -68,9 +66,7 @@ class TestReadSegments:
     ) -> None:
         await insert_segment(session, signed_album.uid)
 
-        resp = await album_routes.get_segments()
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await album_routes.get_segments_ok()
         assert len(data) == 1
         outline = data[0]
         assert outline["kind"] == "driving"
@@ -102,12 +98,10 @@ class TestReadSegmentPoints:
             kind=SegmentKind.hike,
         )
 
-        resp, mock_enqueue = await album_routes.get_segment_points(
+        data, mock_enqueue = await album_routes.get_segment_points_ok(
             from_time=50.0, to_time=400.0
         )
         mock_enqueue.assert_not_called()
-        assert resp.status_code == 200
-        data = resp.json()
         assert len(data) == 1
         assert data[0]["kind"] == "driving"
         assert len(data[0]["points"]) == 3
@@ -130,11 +124,9 @@ class TestSegmentPointsReadOnly:
             kind=kind,
         )
 
-        resp, mock_enqueue = await album_routes.get_segment_points()
+        data, mock_enqueue = await album_routes.get_segment_points_ok()
 
         mock_enqueue.assert_not_called()
-        assert resp.status_code == 200
-        data = resp.json()
         assert len(data) == 1
         assert data[0]["route"] is None
 
@@ -155,30 +147,26 @@ class TestSegmentPointsReadOnly:
         session.add(seg)
         await session.flush()
 
-        resp, mock_enqueue = await album_routes.get_segment_points()
+        data, mock_enqueue = await album_routes.get_segment_points_ok()
 
         mock_enqueue.assert_not_called()
-        assert resp.json()[0]["route"] == [[4.0, 52.0], [4.01, 52.01]]
+        assert data[0]["route"] == [[4.0, 52.0], [4.01, 52.01]]
 
 
 @pytest.mark.usefixtures("signed_album")
 class TestUpdateAlbum:
     async def test_update_cover_photos(self, album_routes: AlbumRoutes) -> None:
-        resp = await album_routes.update_album(
+        data = await album_routes.update_album_ok(
             front_cover_photo="new_front.jpg",
             back_cover_photo="new_back.jpg",
         )
-        assert resp.status_code == 200
-        data = resp.json()
         assert data["front_cover_photo"] == "new_front.jpg"
         assert data["back_cover_photo"] == "new_back.jpg"
 
     async def test_partial_update_preserves_other_fields(
         self, album_routes: AlbumRoutes
     ) -> None:
-        resp = await album_routes.update_album(title="Changed")
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await album_routes.update_album_ok(title="Changed")
         assert data["title"] == "Changed"
         assert data["subtitle"] == "A subtitle"
         assert data["front_cover_photo"] == "photo1.jpg"
@@ -193,9 +181,7 @@ class TestUpdateStep:
     ) -> None:
         await insert_step(session, signed_album.uid)
 
-        resp = await album_routes.update_step(name="New Name")
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await album_routes.update_step_ok(name="New Name")
         assert data["name"] == "New Name"
         assert data["pages"] == [["photo1.jpg"]]
         assert data["unused"] == ["photo2.jpg"]
@@ -218,14 +204,10 @@ class TestUpdateStep:
         await insert_step(session, signed_album.uid)
         await session.commit()
 
-        resp = await album_routes.update_media_layout(**expected_layout)
+        data = await album_routes.update_media_layout_ok(**expected_layout)
+        _assert_step_layout(data, **expected_layout)
 
-        assert resp.status_code == 200
-        _assert_step_layout(resp.json(), **expected_layout)
-
-        get_resp = await album_routes.get_steps()
-        assert get_resp.status_code == 200
-        _assert_step_layout(get_resp.json()[0], **expected_layout)
+        _assert_step_layout((await album_routes.get_steps_ok())[0], **expected_layout)
 
     async def test_media_layout_update_rejects_missing_album_media(
         self,
@@ -306,12 +288,10 @@ class TestAdjustSegmentBoundary:
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
             create=True,
         ) as mock_enqueue:
-            resp = await album_routes.adjust_boundary()
-        assert resp.status_code == 200
+            data = await album_routes.adjust_boundary_ok()
         mock_enqueue.assert_called_once()
         _, _, called_uid, called_aid = mock_enqueue.call_args.args
         assert (called_uid, called_aid) == (signed_album.uid, AID)
-        data = resp.json()
         assert isinstance(data, list)
         assert len(data) == 2
         assert "start_coord" in data[0]
@@ -341,14 +321,12 @@ class TestAdjustSegmentBoundary:
             points=make_points([200.0, 300.0, 400.0, 500.0]),
         )
 
-        resp = await album_routes.adjust_boundary(
+        data = await album_routes.adjust_boundary_ok(
             start_time=200.0,
             end_time=500.0,
             new_boundary_time=300.0,
             handle="start",
         )
-        assert resp.status_code == 200
-        data = resp.json()
         assert isinstance(data, list)
         assert len(data) == 2
 
@@ -378,9 +356,7 @@ class TestAdjustSegmentBoundary:
             points=make_points([300.0, 400.0, 500.0]),
         )
 
-        resp = await album_routes.adjust_boundary()
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await album_routes.adjust_boundary_ok()
         for seg_data in data:
             assert seg_data.get("route") is None
 
@@ -395,9 +371,7 @@ class TestPrintBundle:
         await insert_step(session, signed_album.uid)
         await insert_segment(session, signed_album.uid)
 
-        resp = await album_routes.print_bundle()
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await album_routes.print_bundle_ok()
         assert "album" in data
         assert "steps" in data
         assert "segments" in data

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -16,24 +16,20 @@ from .factories import (
     insert_segment,
     insert_step,
     make_points,
-    sign_in_and_upload,
 )
 from .helpers.albums import AlbumRoutes
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 class TestReadAlbum:
+    @pytest.mark.usefixtures("uploaded_user")
     async def test_cannot_read_other_users_album(
         self,
-        client: AsyncClient,
         session: AsyncSession,
         album_routes: AlbumRoutes,
-        tmp_path: Path,
     ) -> None:
-        await sign_in_and_upload(client, tmp_path / "users")
         await insert_album(session, uid=9999, aid="other-trip")
 
         resp = await album_routes.get_album("other-trip")

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -14,6 +14,7 @@ from .factories import (
     insert_step,
     make_points,
     sign_in_and_upload,
+    sign_in_with_album,
 )
 
 if TYPE_CHECKING:
@@ -32,15 +33,13 @@ class TestReadAlbum:
         assert resp.status_code == 404
 
     async def test_returns_album_meta_without_media(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        await sign_in_with_album(client, session)
 
         resp = await client.get(f"/api/v1/albums/{AID}")
         assert resp.status_code == 200
         data = resp.json()
-        # AlbumMeta excludes heavy fields - only meta returned
         assert "media" not in data
         assert "steps" not in data
         assert "segments" not in data
@@ -48,11 +47,10 @@ class TestReadAlbum:
 
 class TestReadSegments:
     async def test_returns_outlines_without_points(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        await insert_segment(session, uid)
+        album = await sign_in_with_album(client, session)
+        await insert_segment(session, album.uid)
 
         resp = await client.get(f"/api/v1/albums/{AID}/segments")
         assert resp.status_code == 200
@@ -68,21 +66,27 @@ class TestReadSegments:
 
 class TestReadSegmentPoints:
     async def test_returns_segments_with_points_for_time_range(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        album = await sign_in_with_album(client, session)
         await insert_segment(
-            session, uid, start_time=100.0, end_time=300.0, kind=SegmentKind.driving
+            session,
+            album.uid,
+            start_time=100.0,
+            end_time=300.0,
+            kind=SegmentKind.driving,
         )
         await insert_segment(
-            session, uid, start_time=500.0, end_time=700.0, kind=SegmentKind.hike
+            session,
+            album.uid,
+            start_time=500.0,
+            end_time=700.0,
+            kind=SegmentKind.hike,
         )
 
         with patch(
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
         ) as mock_enqueue:
-            # Request range that only covers the first segment
             resp = await client.get(
                 f"/api/v1/albums/{AID}/segments/points",
                 params={"from_time": 50.0, "to_time": 400.0},
@@ -97,12 +101,15 @@ class TestReadSegmentPoints:
 
 class TestSegmentPointsReadOnly:
     async def test_unmatched_driving_segment_returns_stored_null_route(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        album = await sign_in_with_album(client, session)
         await insert_segment(
-            session, uid, start_time=100.0, end_time=300.0, kind=SegmentKind.driving
+            session,
+            album.uid,
+            start_time=100.0,
+            end_time=300.0,
+            kind=SegmentKind.driving,
         )
 
         with patch(
@@ -120,12 +127,15 @@ class TestSegmentPointsReadOnly:
         assert data[0]["route"] is None
 
     async def test_hike_segment_returns_stored_null_route(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        album = await sign_in_with_album(client, session)
         await insert_segment(
-            session, uid, start_time=100.0, end_time=300.0, kind=SegmentKind.hike
+            session,
+            album.uid,
+            start_time=100.0,
+            end_time=300.0,
+            kind=SegmentKind.hike,
         )
 
         with patch(
@@ -141,12 +151,15 @@ class TestSegmentPointsReadOnly:
         assert data[0]["route"] is None
 
     async def test_already_matched_route_returned_as_stored(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        album = await sign_in_with_album(client, session)
         seg = await insert_segment(
-            session, uid, start_time=100.0, end_time=300.0, kind=SegmentKind.driving
+            session,
+            album.uid,
+            start_time=100.0,
+            end_time=300.0,
+            kind=SegmentKind.driving,
         )
         seg.route = [(4.0, 52.0), (4.01, 52.01)]
         session.add(seg)
@@ -166,10 +179,9 @@ class TestSegmentPointsReadOnly:
 
 class TestUpdateAlbum:
     async def test_update_cover_photos(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        await sign_in_with_album(client, session)
 
         resp = await client.patch(
             f"/api/v1/albums/{AID}",
@@ -184,10 +196,9 @@ class TestUpdateAlbum:
         assert data["back_cover_photo"] == "new_back.jpg"
 
     async def test_partial_update_preserves_other_fields(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        await sign_in_with_album(client, session)
 
         resp = await client.patch(f"/api/v1/albums/{AID}", json={"title": "Changed"})
         assert resp.status_code == 200
@@ -199,11 +210,10 @@ class TestUpdateAlbum:
 
 class TestUpdateStep:
     async def test_partial_update_preserves_other_fields(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        await insert_step(session, uid)
+        album = await sign_in_with_album(client, session)
+        await insert_step(session, album.uid)
 
         resp = await client.patch(
             f"/api/v1/albums/{AID}/steps/1",
@@ -218,16 +228,12 @@ class TestUpdateStep:
         assert data["cover"] is None
 
     async def test_media_layout_update_rewrites_step_placements(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        await insert_album_media(session, uid, name="a.jpg")
-        await insert_album_media(session, uid, name="b.jpg")
-        await insert_album_media(session, uid, name="c.jpg")
-        await insert_album_media(session, uid, name="cover.jpg")
-        await insert_album_media(session, uid, name="unused.jpg")
-        await insert_step(session, uid)
+        album = await sign_in_with_album(client, session)
+        for name in ("a.jpg", "b.jpg", "c.jpg", "cover.jpg", "unused.jpg"):
+            await insert_album_media(session, album.uid, name=name)
+        await insert_step(session, album.uid)
         await session.commit()
 
         resp = await client.put(
@@ -252,11 +258,10 @@ class TestUpdateStep:
         assert get_resp.json()[0]["unused"] == ["unused.jpg"]
 
     async def test_media_layout_update_rejects_missing_album_media(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        await insert_step(session, uid)
+        album = await sign_in_with_album(client, session)
+        await insert_step(session, album.uid)
         await session.commit()
 
         resp = await client.put(
@@ -296,12 +301,15 @@ class TestAdjustSegmentBoundary:
         return seg1, seg2
 
     async def test_flight_segment_rejected(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
+        album = await sign_in_with_album(client, session)
         await insert_segment(
-            session, uid, start_time=100.0, end_time=300.0, kind=SegmentKind.flight
+            session,
+            album.uid,
+            start_time=100.0,
+            end_time=300.0,
+            kind=SegmentKind.flight,
         )
 
         with patch(
@@ -322,11 +330,10 @@ class TestAdjustSegmentBoundary:
         mock_enqueue.assert_not_called()
 
     async def test_adjust_end_handle_success(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        await self._setup_adjacent_segments(session, uid)
+        album = await sign_in_with_album(client, session)
+        await self._setup_adjacent_segments(session, album.uid)
 
         with patch(
             "app.api.v1.routes.albums.enqueue_album_route_enrichment",
@@ -344,9 +351,8 @@ class TestAdjustSegmentBoundary:
         assert resp.status_code == 200
         mock_enqueue.assert_called_once()
         _, _, called_uid, called_aid = mock_enqueue.call_args.args
-        assert (called_uid, called_aid) == (uid, AID)
+        assert (called_uid, called_aid) == (album.uid, AID)
         data = resp.json()
-        # Response is now a flat list of SegmentOutline objects
         assert isinstance(data, list)
         assert len(data) == 2
         assert "start_coord" in data[0]
@@ -354,14 +360,12 @@ class TestAdjustSegmentBoundary:
         assert "points" not in data[0]
 
     async def test_adjust_start_handle_success(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        # seg1 ends at 200, seg2 starts at 200 (gap-free boundary)
+        album = await sign_in_with_album(client, session)
         await insert_segment(
             session,
-            uid,
+            album.uid,
             start_time=100.0,
             end_time=200.0,
             kind=SegmentKind.driving,
@@ -369,14 +373,13 @@ class TestAdjustSegmentBoundary:
         )
         await insert_segment(
             session,
-            uid,
+            album.uid,
             start_time=200.0,
             end_time=500.0,
             kind=SegmentKind.hike,
             points=make_points([200.0, 300.0, 400.0, 500.0]),
         )
 
-        # Move the hike's start boundary forward (shrink it)
         resp = await client.patch(
             f"/api/v1/albums/{AID}/segments/adjust-boundary",
             json={
@@ -392,26 +395,23 @@ class TestAdjustSegmentBoundary:
         assert len(data) == 2
 
     async def test_route_reset_after_boundary_adjust(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        # Insert segment with a route
+        album = await sign_in_with_album(client, session)
         seg = await insert_segment(
             session,
-            uid,
+            album.uid,
             start_time=100.0,
             end_time=300.0,
             kind=SegmentKind.driving,
             points=make_points([100.0, 200.0, 300.0]),
         )
-        # Manually set route on the segment
         seg.route = [(4.0, 52.0), (4.01, 52.01)]
         session.add(seg)
         await session.flush()
         await insert_segment(
             session,
-            uid,
+            album.uid,
             start_time=300.0,
             end_time=500.0,
             kind=SegmentKind.hike,
@@ -429,19 +429,17 @@ class TestAdjustSegmentBoundary:
         )
         assert resp.status_code == 200
         data = resp.json()
-        # Both new segments should have route=None (reset by split_segments)
         for seg_data in data:
             assert seg_data.get("route") is None
 
 
 class TestPrintBundle:
     async def test_returns_full_bundle(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        uid = (await sign_in_and_upload(client, tmp_path / "users"))["id"]
-        await insert_album(session, uid)
-        await insert_step(session, uid)
-        await insert_segment(session, uid)
+        album = await sign_in_with_album(client, session)
+        await insert_step(session, album.uid)
+        await insert_segment(session, album.uid)
 
         resp = await client.get(f"/api/v1/albums/{AID}/print-bundle")
         assert resp.status_code == 200
@@ -450,9 +448,8 @@ class TestPrintBundle:
         assert "steps" in data
         assert "segments" in data
         assert "total_distance_km" in data
-        # Album should include media (full Album, not AlbumMeta)
         assert "media" in data["album"]
-        assert data["album"]["media"][0]["uid"] == uid
+        assert data["album"]["media"][0]["uid"] == album.uid
         assert data["album"]["media"][0]["aid"] == AID
         assert data["album"]["media"][0]["byte_size"] == 1234
         assert "updated_at" in data["album"]["media"][0]

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -397,9 +397,8 @@ class TestDownloadPdf:
             "app.api.v1.routes.albums.pop_pdf_token",
             return_value=(pdf_path, "my-album"),
         ):
-            resp = await album_routes.download_pdf("valid-token")
+            resp = await album_routes.download_pdf_ok("valid-token")
 
-        assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"
         assert "my-album.pdf" in resp.headers.get("content-disposition", "")
         assert resp.content == b"%PDF-1.4 fake content"

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -23,6 +23,18 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
+def _assert_step_layout(
+    data: dict[str, object],
+    *,
+    cover: str | None,
+    pages: list[list[str]],
+    unused: list[str],
+) -> None:
+    assert data["cover"] == cover
+    assert data["pages"] == pages
+    assert data["unused"] == unused
+
+
 class TestReadAlbum:
     @pytest.mark.usefixtures("uploaded_user")
     async def test_cannot_read_other_users_album(
@@ -196,28 +208,24 @@ class TestUpdateStep:
         signed_album: AlbumScenario,
         album_routes: AlbumRoutes,
     ) -> None:
+        expected_layout = {
+            "cover": "cover.jpg",
+            "pages": [["a.jpg", "b.jpg"], ["c.jpg"]],
+            "unused": ["unused.jpg"],
+        }
         for name in ("a.jpg", "b.jpg", "c.jpg", "cover.jpg", "unused.jpg"):
             await insert_album_media(session, signed_album.uid, name=name)
         await insert_step(session, signed_album.uid)
         await session.commit()
 
-        resp = await album_routes.update_media_layout(
-            cover="cover.jpg",
-            pages=[["a.jpg", "b.jpg"], ["c.jpg"]],
-            unused=["unused.jpg"],
-        )
+        resp = await album_routes.update_media_layout(**expected_layout)
 
         assert resp.status_code == 200
-        data = resp.json()
-        assert data["cover"] == "cover.jpg"
-        assert data["pages"] == [["a.jpg", "b.jpg"], ["c.jpg"]]
-        assert data["unused"] == ["unused.jpg"]
+        _assert_step_layout(resp.json(), **expected_layout)
 
         get_resp = await album_routes.get_steps()
         assert get_resp.status_code == 200
-        assert get_resp.json()[0]["cover"] == "cover.jpg"
-        assert get_resp.json()[0]["pages"] == [["a.jpg", "b.jpg"], ["c.jpg"]]
-        assert get_resp.json()[0]["unused"] == ["unused.jpg"]
+        _assert_step_layout(get_resp.json()[0], **expected_layout)
 
     async def test_media_layout_update_rejects_missing_album_media(
         self,

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -51,7 +51,9 @@ class TestReadAlbum:
     async def test_returns_album_meta_without_media(
         self, album_routes: AlbumRoutes
     ) -> None:
-        data = await album_routes.get_album_ok()
+        resp = await album_routes.get_album()
+        assert resp.status_code == 200
+        data = resp.json()
         assert "media" not in data
         assert "steps" not in data
         assert "segments" not in data
@@ -66,7 +68,9 @@ class TestReadSegments:
     ) -> None:
         await insert_segment(session, signed_album.uid)
 
-        data = await album_routes.get_segments_ok()
+        resp = await album_routes.get_segments()
+        assert resp.status_code == 200
+        data = resp.json()
         assert len(data) == 1
         outline = data[0]
         assert outline["kind"] == "driving"
@@ -181,7 +185,9 @@ class TestUpdateStep:
     ) -> None:
         await insert_step(session, signed_album.uid)
 
-        data = await album_routes.update_step_ok(name="New Name")
+        resp = await album_routes.update_step(name="New Name")
+        assert resp.status_code == 200
+        data = resp.json()
         assert data["name"] == "New Name"
         assert data["pages"] == [["photo1.jpg"]]
         assert data["unused"] == ["photo2.jpg"]
@@ -204,10 +210,14 @@ class TestUpdateStep:
         await insert_step(session, signed_album.uid)
         await session.commit()
 
-        data = await album_routes.update_media_layout_ok(**expected_layout)
+        resp = await album_routes.update_media_layout(**expected_layout)
+        assert resp.status_code == 200
+        data = resp.json()
         _assert_step_layout(data, **expected_layout)
 
-        _assert_step_layout((await album_routes.get_steps_ok())[0], **expected_layout)
+        get_resp = await album_routes.get_steps()
+        assert get_resp.status_code == 200
+        _assert_step_layout(get_resp.json()[0], **expected_layout)
 
     async def test_media_layout_update_rejects_missing_album_media(
         self,
@@ -371,7 +381,9 @@ class TestPrintBundle:
         await insert_step(session, signed_album.uid)
         await insert_segment(session, signed_album.uid)
 
-        data = await album_routes.print_bundle_ok()
+        resp = await album_routes.print_bundle()
+        assert resp.status_code == 200
+        data = resp.json()
         assert "album" in data
         assert "steps" in data
         assert "segments" in data
@@ -397,8 +409,9 @@ class TestDownloadPdf:
             "app.api.v1.routes.albums.pop_pdf_token",
             return_value=(pdf_path, "my-album"),
         ):
-            resp = await album_routes.download_pdf_ok("valid-token")
+            resp = await album_routes.download_pdf("valid-token")
 
+        assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"
         assert "my-album.pdf" in resp.headers.get("content-disposition", "")
         assert resp.content == b"%PDF-1.4 fake content"

--- a/backend/tests/test_albums_media.py
+++ b/backend/tests/test_albums_media.py
@@ -20,10 +20,7 @@ async def test_read_media_returns_album_media_rows(
     )
     await session.commit()
 
-    resp = await album_routes.get_media()
-
-    assert resp.status_code == 200
-    assert resp.json() == [
+    assert await album_routes.get_media_ok() == [
         {
             "uid": uid,
             "aid": AID,

--- a/backend/tests/test_albums_media.py
+++ b/backend/tests/test_albums_media.py
@@ -1,23 +1,20 @@
 from typing import TYPE_CHECKING
 
-from app.core.config import get_settings
-
-from .factories import AID, insert_album, insert_album_media, sign_in_and_upload
+from .factories import AID, AlbumScenario, insert_album_media
+from .helpers.albums import AlbumRoutes
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
+
+pytest_plugins = ("tests.helpers.album_fixtures",)
 
 
 async def test_read_media_returns_album_media_rows(
-    client: AsyncClient,
     session: AsyncSession,
+    signed_album: AlbumScenario,
+    album_routes: AlbumRoutes,
 ) -> None:
-    user_data = await sign_in_and_upload(
-        client, get_settings().USERS_FOLDER, provider="google"
-    )
-    uid = user_data["id"]
-    await insert_album(session, uid)
+    uid = signed_album.uid
     media = await insert_album_media(
         session,
         uid,
@@ -25,7 +22,7 @@ async def test_read_media_returns_album_media_rows(
     )
     await session.commit()
 
-    resp = await client.get(f"/api/v1/albums/{AID}/media")
+    resp = await album_routes.get_media()
 
     assert resp.status_code == 200
     assert resp.json() == [

--- a/backend/tests/test_albums_media.py
+++ b/backend/tests/test_albums_media.py
@@ -6,8 +6,6 @@ from .helpers.albums import AlbumRoutes
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-pytest_plugins = ("tests.helpers.album_fixtures",)
-
 
 async def test_read_media_returns_album_media_rows(
     session: AsyncSession,

--- a/backend/tests/test_albums_media.py
+++ b/backend/tests/test_albums_media.py
@@ -20,7 +20,9 @@ async def test_read_media_returns_album_media_rows(
     )
     await session.commit()
 
-    assert await album_routes.get_media_ok() == [
+    resp = await album_routes.get_media()
+    assert resp.status_code == 200
+    assert resp.json() == [
         {
             "uid": uid,
             "aid": AID,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -19,24 +19,10 @@ from .factories import (
     sign_in,
     sign_in_and_upload,
 )
+from .helpers.users import UserRoutes
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient, Response
-
-
-async def _auth(
-    client: AsyncClient, provider: str, credential: str = "fake"
-) -> Response:
-    return await client.post(
-        f"/api/v1/auth/{provider}", json={"credential": credential}
-    )
-
-
-async def _upload(client: AsyncClient) -> Response:
-    return await client.post(
-        "/api/v1/users/upload",
-        files={"file": ("data.zip", b"fake", "application/zip")},
-    )
+    from httpx import AsyncClient
 
 
 @pytest.mark.parametrize(
@@ -48,35 +34,44 @@ async def _upload(client: AsyncClient) -> Response:
 )
 class TestAuthProvider:
     async def test_invalid_jwt(
-        self, client: AsyncClient, provider: str, sub_field: str, sub_value: str
+        self,
+        user_routes: UserRoutes,
+        provider: str,
+        sub_field: str,
+        sub_value: str,
     ) -> None:
         _ = sub_field, sub_value
         with mock_jwt(provider, decode_error=True):
-            resp = await _auth(client, provider, "bad")
+            resp = await user_routes.auth(provider, "bad")
         assert resp.status_code == 401
 
     async def test_new_user_returns_null(
-        self, client: AsyncClient, provider: str, sub_field: str, sub_value: str
+        self,
+        user_routes: UserRoutes,
+        provider: str,
+        sub_field: str,
+        sub_value: str,
     ) -> None:
         _ = sub_field, sub_value
         with mock_jwt(provider):
-            resp = await _auth(client, provider)
+            resp = await user_routes.auth(provider)
         assert resp.status_code == 200
         assert resp.json() is None
 
     async def test_existing_user_returns_user(
         self,
         client: AsyncClient,
+        user_routes: UserRoutes,
         tmp_path: Path,
         provider: str,
         sub_field: str,
         sub_value: str,
     ) -> None:
         await sign_in_and_upload(client, tmp_path / "users", provider=provider)
-        await client.post("/api/v1/auth/logout")
+        await user_routes.logout()
 
         with mock_jwt(provider):
-            resp = await _auth(client, provider)
+            resp = await user_routes.auth(provider)
         assert resp.status_code == 200
         user = resp.json()
         assert user is not None
@@ -84,18 +79,18 @@ class TestAuthProvider:
 
 
 class TestAuthMicrosoftSpecific:
-    async def test_bad_issuer_returns_401(self, client: AsyncClient) -> None:
+    async def test_bad_issuer_returns_401(self, user_routes: UserRoutes) -> None:
         bad_iss = {**MICROSOFT_PAYLOAD, "iss": "https://evil.example.com/v2.0"}
         with mock_jwt("microsoft", payload=bad_iss):
-            resp = await _auth(client, "microsoft")
+            resp = await user_routes.auth("microsoft")
         assert resp.status_code == 401
 
     async def test_not_configured_returns_501(
-        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+        self, user_routes: UserRoutes, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(get_settings(), "VITE_MICROSOFT_CLIENT_ID", "")
         with mock_jwt("microsoft", ensure_configured=False):
-            resp = await _auth(client, "microsoft")
+            resp = await user_routes.auth("microsoft")
         assert resp.status_code == 501
 
     async def test_falls_back_to_name_when_no_given_name(
@@ -109,16 +104,18 @@ class TestAuthMicrosoftSpecific:
 
 
 class TestLogout:
-    async def test_clears_session(self, client: AsyncClient, tmp_path: Path) -> None:
+    async def test_clears_session(
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+    ) -> None:
         await sign_in_and_upload(client, tmp_path / "users")
-        await client.post("/api/v1/auth/logout")
-        resp = await client.get("/api/v1/users")
+        await user_routes.logout()
+        resp = await user_routes.current()
         assert resp.status_code == 401
 
 
 class TestUpload:
-    async def test_no_session(self, client: AsyncClient) -> None:
-        resp = await _upload(client)
+    async def test_no_session(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.upload()
         assert resp.status_code == 401
 
     async def test_new_user_google(self, client: AsyncClient, tmp_path: Path) -> None:
@@ -138,17 +135,17 @@ class TestUpload:
         assert user["first_name"] == "Test"  # from given_name in token
 
     async def test_falls_back_to_zip_name(
-        self, client: AsyncClient, tmp_path: Path
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
     ) -> None:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
         await sign_in(client, payload=no_name)
         with mock_extract(tmp_path / "users"):
-            resp = await _upload(client)
+            resp = await user_routes.upload()
         user = resp.json()["user"]
         assert user["first_name"] == "Zip"
 
     async def test_reupload_updates_trips(
-        self, client: AsyncClient, tmp_path: Path
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
     ) -> None:
         await sign_in_and_upload(client, tmp_path / "users")
 
@@ -160,30 +157,36 @@ class TestUpload:
             "app.api.v1.routes.users.extract_and_scan",
             return_value=(folder, PS_USER, new_trips),
         ):
-            resp = await _upload(client)
+            resp = await user_routes.upload()
         assert resp.status_code == 200
         assert resp.json()["trips"][0]["id"] == "trip-2"
 
 
 class TestUpdateUser:
-    async def test_update_locale(self, client: AsyncClient, tmp_path: Path) -> None:
+    async def test_update_locale(
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+    ) -> None:
         await sign_in_and_upload(client, tmp_path / "users")
-        resp = await client.patch("/api/v1/users", json={"locale": "he-IL"})
+        resp = await user_routes.update(locale="he-IL")
         assert resp.status_code == 200
         assert resp.json()["locale"] == "he-IL"
 
 
 class TestDeleteUser:
-    async def test_clears_session(self, client: AsyncClient, tmp_path: Path) -> None:
+    async def test_clears_session(
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+    ) -> None:
         await sign_in_and_upload(client, tmp_path / "users")
-        resp = await client.delete("/api/v1/users")
+        resp = await user_routes.delete()
         assert resp.status_code == 200
-        resp = await client.get("/api/v1/users")
+        resp = await user_routes.current()
         assert resp.status_code == 401
 
-    async def test_removes_folder(self, client: AsyncClient, tmp_path: Path) -> None:
+    async def test_removes_folder(
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+    ) -> None:
         user = await sign_in_and_upload(client, tmp_path / "users")
         user_folder = tmp_path / "users" / str(user["id"])
         assert user_folder.exists()
-        await client.delete("/api/v1/users")
+        await user_routes.delete()
         assert not user_folder.exists()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -14,15 +13,9 @@ from .factories import (
     GOOGLE_PAYLOAD,
     MICROSOFT_PAYLOAD,
     PS_USER,
-    mock_extract,
     mock_jwt,
-    sign_in,
-    sign_in_and_upload,
 )
 from .helpers.users import UserRoutes
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.parametrize(
@@ -60,14 +53,13 @@ class TestAuthProvider:
 
     async def test_existing_user_returns_user(
         self,
-        client: AsyncClient,
         user_routes: UserRoutes,
-        tmp_path: Path,
+        users_dir: Path,
         provider: str,
         sub_field: str,
         sub_value: str,
     ) -> None:
-        await sign_in_and_upload(client, tmp_path / "users", provider=provider)
+        await user_routes.sign_in_and_upload(users_dir, provider=provider)
         await user_routes.logout()
 
         with mock_jwt(provider):
@@ -94,20 +86,18 @@ class TestAuthMicrosoftSpecific:
         assert resp.status_code == 501
 
     async def test_falls_back_to_name_when_no_given_name(
-        self, client: AsyncClient, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
         no_given = {k: v for k, v in MICROSOFT_PAYLOAD.items() if k != "given_name"}
-        user = await sign_in_and_upload(
-            client, tmp_path / "users", provider="microsoft", payload=no_given
+        user = await user_routes.sign_in_and_upload(
+            users_dir, provider="microsoft", payload=no_given
         )
         assert user["first_name"] == "Test Microsoft"
 
 
 class TestLogout:
-    async def test_clears_session(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
-    ) -> None:
-        await sign_in_and_upload(client, tmp_path / "users")
+    @pytest.mark.usefixtures("uploaded_user")
+    async def test_clears_session(self, user_routes: UserRoutes) -> None:
         await user_routes.logout()
         resp = await user_routes.current()
         assert resp.status_code == 401
@@ -118,41 +108,36 @@ class TestUpload:
         resp = await user_routes.upload()
         assert resp.status_code == 401
 
-    async def test_new_user_google(self, client: AsyncClient, tmp_path: Path) -> None:
-        user = await sign_in_and_upload(client, tmp_path / "users")
-        assert user["google_sub"] == "google-123"
-        assert user["microsoft_sub"] is None
-        assert user["first_name"] == "Test"  # Google name preferred over ZIP
+    async def test_new_user_google(self, uploaded_user: dict) -> None:
+        assert uploaded_user["google_sub"] == "google-123"
+        assert uploaded_user["microsoft_sub"] is None
+        assert uploaded_user["first_name"] == "Test"  # Google name preferred over ZIP
 
     async def test_new_user_microsoft(
-        self, client: AsyncClient, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
-        user = await sign_in_and_upload(
-            client, tmp_path / "users", provider="microsoft"
-        )
+        user = await user_routes.sign_in_and_upload(users_dir, provider="microsoft")
         assert user["microsoft_sub"] == "microsoft-456"
         assert user["google_sub"] is None
         assert user["first_name"] == "Test"  # from given_name in token
 
     async def test_falls_back_to_zip_name(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
-        await sign_in(client, payload=no_name)
-        with mock_extract(tmp_path / "users"):
-            resp = await user_routes.upload()
+        await user_routes.sign_in(payload=no_name)
+        resp = await user_routes.upload_with_extract(users_dir)
         user = resp.json()["user"]
         assert user["first_name"] == "Zip"
 
+    @pytest.mark.usefixtures("uploaded_user")
     async def test_reupload_updates_trips(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
-        await sign_in_and_upload(client, tmp_path / "users")
-
         new_trips = [
             TripMeta(id="trip-2", title="New Trip", step_count=3, country_codes=["de"])
         ]
-        folder = Path(tempfile.mkdtemp(dir=tmp_path / "users"))
+        folder = Path(tempfile.mkdtemp(dir=users_dir))
         with patch(
             "app.api.v1.routes.users.extract_and_scan",
             return_value=(folder, PS_USER, new_trips),
@@ -163,30 +148,25 @@ class TestUpload:
 
 
 class TestUpdateUser:
-    async def test_update_locale(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
-    ) -> None:
-        await sign_in_and_upload(client, tmp_path / "users")
+    @pytest.mark.usefixtures("uploaded_user")
+    async def test_update_locale(self, user_routes: UserRoutes) -> None:
         resp = await user_routes.update(locale="he-IL")
         assert resp.status_code == 200
         assert resp.json()["locale"] == "he-IL"
 
 
 class TestDeleteUser:
-    async def test_clears_session(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
-    ) -> None:
-        await sign_in_and_upload(client, tmp_path / "users")
+    @pytest.mark.usefixtures("uploaded_user")
+    async def test_clears_session(self, user_routes: UserRoutes) -> None:
         resp = await user_routes.delete()
         assert resp.status_code == 200
         resp = await user_routes.current()
         assert resp.status_code == 401
 
     async def test_removes_folder(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path, uploaded_user: dict
     ) -> None:
-        user = await sign_in_and_upload(client, tmp_path / "users")
-        user_folder = tmp_path / "users" / str(user["id"])
+        user_folder = users_dir / str(uploaded_user["id"])
         assert user_folder.exists()
         await user_routes.delete()
         assert not user_folder.exists()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -21,7 +21,22 @@ from .factories import (
 )
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Response
+
+
+async def _auth(
+    client: AsyncClient, provider: str, credential: str = "fake"
+) -> Response:
+    return await client.post(
+        f"/api/v1/auth/{provider}", json={"credential": credential}
+    )
+
+
+async def _upload(client: AsyncClient) -> Response:
+    return await client.post(
+        "/api/v1/users/upload",
+        files={"file": ("data.zip", b"fake", "application/zip")},
+    )
 
 
 @pytest.mark.parametrize(
@@ -37,9 +52,7 @@ class TestAuthProvider:
     ) -> None:
         _ = sub_field, sub_value
         with mock_jwt(provider, decode_error=True):
-            resp = await client.post(
-                f"/api/v1/auth/{provider}", json={"credential": "bad"}
-            )
+            resp = await _auth(client, provider, "bad")
         assert resp.status_code == 401
 
     async def test_new_user_returns_null(
@@ -47,9 +60,7 @@ class TestAuthProvider:
     ) -> None:
         _ = sub_field, sub_value
         with mock_jwt(provider):
-            resp = await client.post(
-                f"/api/v1/auth/{provider}", json={"credential": "fake"}
-            )
+            resp = await _auth(client, provider)
         assert resp.status_code == 200
         assert resp.json() is None
 
@@ -65,9 +76,7 @@ class TestAuthProvider:
         await client.post("/api/v1/auth/logout")
 
         with mock_jwt(provider):
-            resp = await client.post(
-                f"/api/v1/auth/{provider}", json={"credential": "fake"}
-            )
+            resp = await _auth(client, provider)
         assert resp.status_code == 200
         user = resp.json()
         assert user is not None
@@ -75,14 +84,10 @@ class TestAuthProvider:
 
 
 class TestAuthMicrosoftSpecific:
-    """Tests specific to Microsoft auth."""
-
     async def test_bad_issuer_returns_401(self, client: AsyncClient) -> None:
         bad_iss = {**MICROSOFT_PAYLOAD, "iss": "https://evil.example.com/v2.0"}
         with mock_jwt("microsoft", payload=bad_iss):
-            resp = await client.post(
-                "/api/v1/auth/microsoft", json={"credential": "fake"}
-            )
+            resp = await _auth(client, "microsoft")
         assert resp.status_code == 401
 
     async def test_not_configured_returns_501(
@@ -90,9 +95,7 @@ class TestAuthMicrosoftSpecific:
     ) -> None:
         monkeypatch.setattr(get_settings(), "VITE_MICROSOFT_CLIENT_ID", "")
         with mock_jwt("microsoft", ensure_configured=False):
-            resp = await client.post(
-                "/api/v1/auth/microsoft", json={"credential": "fake"}
-            )
+            resp = await _auth(client, "microsoft")
         assert resp.status_code == 501
 
     async def test_falls_back_to_name_when_no_given_name(
@@ -115,10 +118,7 @@ class TestLogout:
 
 class TestUpload:
     async def test_no_session(self, client: AsyncClient) -> None:
-        resp = await client.post(
-            "/api/v1/users/upload",
-            files={"file": ("data.zip", b"fake", "application/zip")},
-        )
+        resp = await _upload(client)
         assert resp.status_code == 401
 
     async def test_new_user_google(self, client: AsyncClient, tmp_path: Path) -> None:
@@ -143,10 +143,7 @@ class TestUpload:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
         await sign_in(client, payload=no_name)
         with mock_extract(tmp_path / "users"):
-            resp = await client.post(
-                "/api/v1/users/upload",
-                files={"file": ("data.zip", b"fake", "application/zip")},
-            )
+            resp = await _upload(client)
         user = resp.json()["user"]
         assert user["first_name"] == "Zip"
 
@@ -163,10 +160,7 @@ class TestUpload:
             "app.api.v1.routes.users.extract_and_scan",
             return_value=(folder, PS_USER, new_trips),
         ):
-            resp = await client.post(
-                "/api/v1/users/upload",
-                files={"file": ("data.zip", b"fake", "application/zip")},
-            )
+            resp = await _upload(client)
         assert resp.status_code == 200
         assert resp.json()["trips"][0]["id"] == "trip-2"
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -122,7 +122,9 @@ class TestUpload:
     ) -> None:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
         await user_routes.sign_in(payload=no_name)
-        user = (await user_routes.upload_with_extract_ok(users_dir))["user"]
+        resp = await user_routes.upload_with_extract(users_dir)
+        assert resp.status_code == 200
+        user = resp.json()["user"]
         assert user["first_name"] == "Zip"
 
     @pytest.mark.usefixtures("uploaded_user")
@@ -137,14 +139,17 @@ class TestUpload:
             "app.api.v1.routes.users.extract_and_scan",
             return_value=(folder, PS_USER, new_trips),
         ):
-            data = await user_routes.upload_ok()
-        assert data["trips"][0]["id"] == "trip-2"
+            resp = await user_routes.upload()
+        assert resp.status_code == 200
+        assert resp.json()["trips"][0]["id"] == "trip-2"
 
 
 class TestUpdateUser:
     @pytest.mark.usefixtures("uploaded_user")
     async def test_update_locale(self, user_routes: UserRoutes) -> None:
-        assert (await user_routes.update_ok(locale="he-IL"))["locale"] == "he-IL"
+        resp = await user_routes.update(locale="he-IL")
+        assert resp.status_code == 200
+        assert resp.json()["locale"] == "he-IL"
 
 
 class TestDeleteUser:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -47,9 +47,7 @@ class TestAuthProvider:
     ) -> None:
         _ = sub_field, sub_value
         with mock_jwt(provider):
-            resp = await user_routes.auth(provider)
-        assert resp.status_code == 200
-        assert resp.json() is None
+            assert await user_routes.auth_ok(provider) is None
 
     async def test_existing_user_returns_user(
         self,
@@ -63,9 +61,7 @@ class TestAuthProvider:
         await user_routes.logout()
 
         with mock_jwt(provider):
-            resp = await user_routes.auth(provider)
-        assert resp.status_code == 200
-        user = resp.json()
+            user = await user_routes.auth_ok(provider)
         assert user is not None
         assert user[sub_field] == sub_value
 
@@ -126,8 +122,7 @@ class TestUpload:
     ) -> None:
         no_name = {**GOOGLE_PAYLOAD, "given_name": "", "family_name": ""}
         await user_routes.sign_in(payload=no_name)
-        resp = await user_routes.upload_with_extract(users_dir)
-        user = resp.json()["user"]
+        user = (await user_routes.upload_with_extract_ok(users_dir))["user"]
         assert user["first_name"] == "Zip"
 
     @pytest.mark.usefixtures("uploaded_user")
@@ -142,24 +137,20 @@ class TestUpload:
             "app.api.v1.routes.users.extract_and_scan",
             return_value=(folder, PS_USER, new_trips),
         ):
-            resp = await user_routes.upload()
-        assert resp.status_code == 200
-        assert resp.json()["trips"][0]["id"] == "trip-2"
+            data = await user_routes.upload_ok()
+        assert data["trips"][0]["id"] == "trip-2"
 
 
 class TestUpdateUser:
     @pytest.mark.usefixtures("uploaded_user")
     async def test_update_locale(self, user_routes: UserRoutes) -> None:
-        resp = await user_routes.update(locale="he-IL")
-        assert resp.status_code == 200
-        assert resp.json()["locale"] == "he-IL"
+        assert (await user_routes.update_ok(locale="he-IL"))["locale"] == "he-IL"
 
 
 class TestDeleteUser:
     @pytest.mark.usefixtures("uploaded_user")
     async def test_clears_session(self, user_routes: UserRoutes) -> None:
-        resp = await user_routes.delete()
-        assert resp.status_code == 200
+        await user_routes.delete_ok()
         resp = await user_routes.current()
         assert resp.status_code == 401
 
@@ -168,5 +159,5 @@ class TestDeleteUser:
     ) -> None:
         user_folder = users_dir / str(uploaded_user["id"])
         assert user_folder.exists()
-        await user_routes.delete()
+        await user_routes.delete_ok()
         assert not user_folder.exists()

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -8,9 +8,9 @@ from uuid import uuid4
 from app.core.config import get_settings
 from app.logic.layout.builder import _load_photos, _step_media, build_step_layout
 from app.logic.layout.media import Media
-from app.models.polarsteps import Location, PSStep
+from app.models.polarsteps import PSStep
 from app.models.user import User
-from tests.factories import collect_async, create_test_jpeg
+from tests.factories import collect_async, create_test_jpeg, make_ps_step, make_user
 
 if TYPE_CHECKING:
     import pytest
@@ -23,28 +23,20 @@ def _media_name(ext: str = "jpg") -> str:
 
 
 def _make_step() -> PSStep:
-    return PSStep(
-        id=1,
+    return make_ps_step(
+        1,
         name="Test Step",
-        slug="test-step",
         description="",
         timestamp=1_700_000_000.0,
         timezone_id="Europe/Amsterdam",
-        location=Location(
-            name="Test", detail="", country_code="nl", lat=52.37, lon=4.89
-        ),
     )
 
 
 def _make_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> User:
     monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
-    return User(
-        id=1,
+    return make_user(
+        1,
         google_sub="g-1",
-        first_name="Test",
-        locale="en-US",
-        unit_is_km=True,
-        temperature_is_celsius=True,
     )
 
 

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -1,5 +1,3 @@
-"""Unit tests for the UploadStore chunked-upload manager."""
-
 import asyncio
 import shutil
 from collections.abc import AsyncIterator
@@ -10,11 +8,24 @@ from starlette.requests import ClientDisconnect
 
 from app.logic.chunked_upload import UploadStore
 
-MAX_BYTES = 1024 * 1024  # 1 MiB - small limit for tests
+MAX_BYTES = 1024 * 1024
 
 
 async def _one(data: bytes) -> AsyncIterator[bytes]:
     yield data
+
+
+async def _chunks(count: int, size: int = 1024 * 1024) -> AsyncIterator[bytes]:
+    for _ in range(count):
+        yield b"\x00" * size
+
+
+def _assembled_bytes(store: UploadStore, upload_id: str) -> bytes:
+    assembled, _ = store.assemble(upload_id, owner="test")
+    try:
+        return assembled.read()
+    finally:
+        assembled.close()
 
 
 @pytest.fixture
@@ -28,55 +39,33 @@ class TestWriteChunkStream:
     async def test_writes_stream_to_disk(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner="test")
 
-        async def gen() -> AsyncIterator[bytes]:
-            yield b"hello "
-            yield b"world"
+        await store.write_chunk_stream(upload_id, 0, _one(b"hello world"))
+        assert _assembled_bytes(store, upload_id) == b"hello world"
 
-        await store.write_chunk_stream(upload_id, 0, gen())
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"hello world"
-        finally:
-            assembled.close()
-
-    async def test_rejects_negative_index(self, store: UploadStore) -> None:
+    @pytest.mark.parametrize("index", [-1, 10_000])
+    async def test_rejects_out_of_range_index(
+        self, store: UploadStore, index: int
+    ) -> None:
         upload_id = store.create(MAX_BYTES, owner="test")
         with pytest.raises(ValueError, match="out of range"):
-            await store.write_chunk_stream(upload_id, -1, _one(b"x"))
-
-    async def test_rejects_index_above_9999(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
-        with pytest.raises(ValueError, match="out of range"):
-            await store.write_chunk_stream(upload_id, 10_000, _one(b"x"))
+            await store.write_chunk_stream(upload_id, index, _one(b"x"))
 
     async def test_rejects_chunk_exceeding_limit_mid_stream(
         self, store: UploadStore
     ) -> None:
-        """A chunk that grows past _CHUNK_LIMIT mid-stream is aborted."""
         upload_id = store.create(MAX_BYTES, owner="test")
 
-        # _CHUNK_LIMIT is 80 MiB + 1 KiB. Stream 81 MiB in 1 MiB pieces.
-        async def gen() -> AsyncIterator[bytes]:
-            for _ in range(81):
-                yield b"\x00" * (1024 * 1024)
-
         with pytest.raises(ValueError, match="exceeds"):
-            await store.write_chunk_stream(upload_id, 0, gen())
+            await store.write_chunk_stream(upload_id, 0, _chunks(81))
 
     async def test_tempfile_cleaned_up_on_error(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner="test")
 
-        async def gen() -> AsyncIterator[bytes]:
-            for _ in range(81):
-                yield b"\x00" * (1024 * 1024)
-
         with pytest.raises(ValueError, match="exceeds"):
-            await store.write_chunk_stream(upload_id, 0, gen())
+            await store.write_chunk_stream(upload_id, 0, _chunks(81))
 
-        # No .part files should remain in the session directory
         session_dir = store._sessions[upload_id].dir
-        leftover = list(session_dir.glob("*.part"))
-        assert leftover == []
+        assert list(session_dir.glob("*.part")) == []
 
     async def test_rejects_accumulated_overflow(self, store: UploadStore) -> None:
         upload_id = store.create(100, owner="test")
@@ -86,7 +75,6 @@ class TestWriteChunkStream:
             await store.write_chunk_stream(upload_id, 1, _one(b"\x00" * 20))
 
     async def test_rejects_too_many_chunks(self, store: UploadStore) -> None:
-        # max_chunks = MAX_BYTES // _CHUNK_LIMIT + 2 = 0 + 2 = 2 for 1 MiB
         upload_id = store.create(MAX_BYTES, owner="test")
         await store.write_chunk_stream(upload_id, 0, _one(b"a"))
         await store.write_chunk_stream(upload_id, 1, _one(b"b"))
@@ -96,39 +84,29 @@ class TestWriteChunkStream:
     async def test_retry_not_falsely_rejected_by_overflow(
         self, store: UploadStore
     ) -> None:
-        """Retrying a chunk should deduct old size before the overflow check."""
         upload_id = store.create(100, owner="test")
         await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
-        # Retry with a smaller chunk - effective total = 11, well under 100
         await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 11))
 
     async def test_idempotent_retry_adjusts_size(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner="test")
         await store.write_chunk_stream(upload_id, 0, _one(b"hello"))
-        # Re-upload same index with different data - should succeed and
-        # correct the accumulated size (not double-count).
         await store.write_chunk_stream(upload_id, 0, _one(b"world!"))
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"world!"
-        finally:
-            assembled.close()
+        assert _assembled_bytes(store, upload_id) == b"world!"
 
     async def test_idempotent_retry_does_not_count_toward_chunk_limit(
         self, store: UploadStore
     ) -> None:
-        # max_chunks = 2 for 1 MiB limit
         upload_id = store.create(MAX_BYTES, owner="test")
         await store.write_chunk_stream(upload_id, 0, _one(b"a"))
-        await store.write_chunk_stream(upload_id, 0, _one(b"a"))  # retry
-        await store.write_chunk_stream(upload_id, 1, _one(b"b"))  # distinct chunk
+        await store.write_chunk_stream(upload_id, 0, _one(b"a"))
+        await store.write_chunk_stream(upload_id, 1, _one(b"b"))
 
     async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
         with pytest.raises(KeyError):
             await store.write_chunk_stream("nonexistent", 0, _one(b"x"))
 
     async def test_client_disconnect_propagates(self, store: UploadStore) -> None:
-        """ClientDisconnect from the stream must not be translated to KeyError."""
         upload_id = store.create(MAX_BYTES, owner="test")
 
         async def gen() -> AsyncIterator[bytes]:
@@ -138,54 +116,31 @@ class TestWriteChunkStream:
         with pytest.raises(ClientDisconnect):
             await store.write_chunk_stream(upload_id, 0, gen())
 
-        # Tempfile cleaned up, session still alive for retry
         session_dir = store._sessions[upload_id].dir
         assert list(session_dir.glob("*.part")) == []
 
     async def test_concurrent_same_index_writes_do_not_corrupt(
         self, store: UploadStore
     ) -> None:
-        """Two concurrent writes for the same chunk index must not corrupt."""
         upload_id = store.create(MAX_BYTES, owner="test")
 
-        async def gen_a() -> AsyncIterator[bytes]:
-            yield b"AAAA"
-
-        async def gen_b() -> AsyncIterator[bytes]:
-            yield b"BBBB"
-
-        # Both writes target index 0 - whichever renames last wins, but
-        # neither should produce garbage bytes in the final chunk.
         await asyncio.gather(
-            store.write_chunk_stream(upload_id, 0, gen_a()),
-            store.write_chunk_stream(upload_id, 0, gen_b()),
+            store.write_chunk_stream(upload_id, 0, _one(b"AAAA")),
+            store.write_chunk_stream(upload_id, 0, _one(b"BBBB")),
         )
 
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            final = assembled.read()
-            assert final in (b"AAAA", b"BBBB")
-        finally:
-            assembled.close()
+        assert _assembled_bytes(store, upload_id) in (b"AAAA", b"BBBB")
 
     async def test_concurrent_different_index_writes(self, store: UploadStore) -> None:
-        """Concurrent writes to different indices produce the union."""
         upload_id = store.create(MAX_BYTES, owner="test")
 
-        async def gen(payload: bytes) -> AsyncIterator[bytes]:
-            yield payload
-
         await asyncio.gather(
-            store.write_chunk_stream(upload_id, 0, gen(b"AAA")),
-            store.write_chunk_stream(upload_id, 1, gen(b"BBB")),
-            store.write_chunk_stream(upload_id, 2, gen(b"CCC")),
+            store.write_chunk_stream(upload_id, 0, _one(b"AAA")),
+            store.write_chunk_stream(upload_id, 1, _one(b"BBB")),
+            store.write_chunk_stream(upload_id, 2, _one(b"CCC")),
         )
 
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"AAABBBCCC"
-        finally:
-            assembled.close()
+        assert _assembled_bytes(store, upload_id) == b"AAABBBCCC"
 
 
 class TestAssemble:
@@ -194,11 +149,7 @@ class TestAssemble:
         await store.write_chunk_stream(upload_id, 1, _one(b"BBB"))
         await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
 
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"AAABBB"
-        finally:
-            assembled.close()
+        assert _assembled_bytes(store, upload_id) == b"AAABBB"
 
     async def test_no_chunks_raises(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner="test")
@@ -214,7 +165,6 @@ class TestAssemble:
         await store.write_chunk_stream(upload_id, 0, _one(b"x"))
         assembled, _ = store.assemble(upload_id, owner="test")
         assembled.close()
-        # Second assemble should fail - session was consumed
         with pytest.raises(KeyError):
             store.assemble(upload_id, owner="test")
 
@@ -229,23 +179,17 @@ class TestAssemble:
     async def test_non_contiguous_chunks_raises(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner="test")
         await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
-        await store.write_chunk_stream(upload_id, 2, _one(b"CCC"))  # skipped index 1
+        await store.write_chunk_stream(upload_id, 2, _one(b"CCC"))
         with pytest.raises(ValueError, match="not contiguous"):
             store.assemble(upload_id, owner="test")
 
     async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
-        """Orphan .part tempfiles from crashed streaming writes are ignored."""
         upload_id = store.create(MAX_BYTES, owner="test")
         await store.write_chunk_stream(upload_id, 0, _one(b"real"))
-        # Simulate a stale tempfile from a crashed mid-commit streaming write
         session = store._sessions[upload_id]
         (session.dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
 
-        assembled, _ = store.assemble(upload_id, owner="test")
-        try:
-            assert assembled.read() == b"real"
-        finally:
-            assembled.close()
+        assert _assembled_bytes(store, upload_id) == b"real"
 
 
 class TestEviction:
@@ -263,13 +207,10 @@ class TestEviction:
     async def test_eviction_during_write_surfaces_as_key_error(
         self, store: UploadStore
     ) -> None:
-        """A write already in flight when eviction runs raises KeyError, not OSError."""
         upload_id = store.create(MAX_BYTES, owner="test")
         session = store._sessions[upload_id]
 
         async def gen() -> AsyncIterator[bytes]:
-            # Simulate TTL eviction firing after the session lookup but before
-            # the write completes: dir gone, session popped from registry.
             shutil.rmtree(session.dir)
             store._sessions.pop(upload_id)
             session.timer.cancel()

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -9,6 +9,7 @@ from starlette.requests import ClientDisconnect
 from app.logic.chunked_upload import UploadStore
 
 MAX_BYTES = 1024 * 1024
+OWNER = "test"
 
 
 async def _one(data: bytes) -> AsyncIterator[bytes]:
@@ -21,7 +22,7 @@ async def _chunks(count: int, size: int = 1024 * 1024) -> AsyncIterator[bytes]:
 
 
 def _assembled_bytes(store: UploadStore, upload_id: str) -> bytes:
-    assembled, _ = store.assemble(upload_id, owner="test")
+    assembled, _ = store.assemble(upload_id, owner=OWNER)
     try:
         return assembled.read()
     finally:
@@ -37,7 +38,7 @@ async def store(tmp_path: Path) -> AsyncIterator[UploadStore]:
 
 class TestWriteChunkStream:
     async def test_writes_stream_to_disk(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
 
         await store.write_chunk_stream(upload_id, 0, _one(b"hello world"))
         assert _assembled_bytes(store, upload_id) == b"hello world"
@@ -46,20 +47,20 @@ class TestWriteChunkStream:
     async def test_rejects_out_of_range_index(
         self, store: UploadStore, index: int
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         with pytest.raises(ValueError, match="out of range"):
             await store.write_chunk_stream(upload_id, index, _one(b"x"))
 
     async def test_rejects_chunk_exceeding_limit_mid_stream(
         self, store: UploadStore
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
 
         with pytest.raises(ValueError, match="exceeds"):
             await store.write_chunk_stream(upload_id, 0, _chunks(81))
 
     async def test_tempfile_cleaned_up_on_error(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
 
         with pytest.raises(ValueError, match="exceeds"):
             await store.write_chunk_stream(upload_id, 0, _chunks(81))
@@ -68,14 +69,14 @@ class TestWriteChunkStream:
         assert list(session_dir.glob("*.part")) == []
 
     async def test_rejects_accumulated_overflow(self, store: UploadStore) -> None:
-        upload_id = store.create(100, owner="test")
+        upload_id = store.create(100, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
 
         with pytest.raises(OverflowError):
             await store.write_chunk_stream(upload_id, 1, _one(b"\x00" * 20))
 
     async def test_rejects_too_many_chunks(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"a"))
         await store.write_chunk_stream(upload_id, 1, _one(b"b"))
         with pytest.raises(ValueError, match="Too many chunks"):
@@ -84,12 +85,12 @@ class TestWriteChunkStream:
     async def test_retry_not_falsely_rejected_by_overflow(
         self, store: UploadStore
     ) -> None:
-        upload_id = store.create(100, owner="test")
+        upload_id = store.create(100, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
         await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 11))
 
     async def test_idempotent_retry_adjusts_size(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"hello"))
         await store.write_chunk_stream(upload_id, 0, _one(b"world!"))
         assert _assembled_bytes(store, upload_id) == b"world!"
@@ -97,7 +98,7 @@ class TestWriteChunkStream:
     async def test_idempotent_retry_does_not_count_toward_chunk_limit(
         self, store: UploadStore
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"a"))
         await store.write_chunk_stream(upload_id, 0, _one(b"a"))
         await store.write_chunk_stream(upload_id, 1, _one(b"b"))
@@ -107,7 +108,7 @@ class TestWriteChunkStream:
             await store.write_chunk_stream("nonexistent", 0, _one(b"x"))
 
     async def test_client_disconnect_propagates(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
 
         async def gen() -> AsyncIterator[bytes]:
             yield b"partial"
@@ -122,7 +123,7 @@ class TestWriteChunkStream:
     async def test_concurrent_same_index_writes_do_not_corrupt(
         self, store: UploadStore
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
 
         await asyncio.gather(
             store.write_chunk_stream(upload_id, 0, _one(b"AAAA")),
@@ -132,7 +133,7 @@ class TestWriteChunkStream:
         assert _assembled_bytes(store, upload_id) in (b"AAAA", b"BBBB")
 
     async def test_concurrent_different_index_writes(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
 
         await asyncio.gather(
             store.write_chunk_stream(upload_id, 0, _one(b"AAA")),
@@ -145,28 +146,28 @@ class TestWriteChunkStream:
 
 class TestAssemble:
     async def test_chunks_concatenated_in_order(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 1, _one(b"BBB"))
         await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
 
         assert _assembled_bytes(store, upload_id) == b"AAABBB"
 
     async def test_no_chunks_raises(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         with pytest.raises(ValueError, match="No chunks"):
-            store.assemble(upload_id, owner="test")
+            store.assemble(upload_id, owner=OWNER)
 
     async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
         with pytest.raises(KeyError):
-            store.assemble("nonexistent", owner="test")
+            store.assemble("nonexistent", owner=OWNER)
 
     async def test_session_removed_after_assemble(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"x"))
-        assembled, _ = store.assemble(upload_id, owner="test")
+        assembled, _ = store.assemble(upload_id, owner=OWNER)
         assembled.close()
         with pytest.raises(KeyError):
-            store.assemble(upload_id, owner="test")
+            store.assemble(upload_id, owner=OWNER)
 
     async def test_wrong_owner_raises_permission_error(
         self, store: UploadStore
@@ -177,14 +178,14 @@ class TestAssemble:
             store.assemble(upload_id, owner="bob")
 
     async def test_non_contiguous_chunks_raises(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
         await store.write_chunk_stream(upload_id, 2, _one(b"CCC"))
         with pytest.raises(ValueError, match="not contiguous"):
-            store.assemble(upload_id, owner="test")
+            store.assemble(upload_id, owner=OWNER)
 
     async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"real"))
         session = store._sessions[upload_id]
         (session.dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
@@ -196,18 +197,18 @@ class TestEviction:
     async def test_expired_session_is_cleaned_up(self, tmp_path: Path) -> None:
         store = UploadStore(base=tmp_path / "chunked-uploads")
         async with store.lifespan():
-            upload_id = store.create(MAX_BYTES, owner="test")
+            upload_id = store.create(MAX_BYTES, owner=OWNER)
             await store.write_chunk_stream(upload_id, 0, _one(b"data"))
 
             store._evict(upload_id)
 
             with pytest.raises(KeyError):
-                store.assemble(upload_id, owner="test")
+                store.assemble(upload_id, owner=OWNER)
 
     async def test_eviction_during_write_surfaces_as_key_error(
         self, store: UploadStore
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="test")
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
         session = store._sessions[upload_id]
 
         async def gen() -> AsyncIterator[bytes]:

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -1,5 +1,3 @@
-"""Integration tests for the chunked upload endpoints (init/chunk/complete)."""
-
 from __future__ import annotations
 
 import asyncio
@@ -15,15 +13,40 @@ from app.logic.chunked_upload import upload_store
 from .factories import mock_extract, sign_in, sign_in_and_upload
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Response
 
 
 async def _init(client: AsyncClient, provider: str = "google") -> str:
-    """Sign in then POST /upload/init, return upload_id."""
     await sign_in(client, provider)
     resp = await client.post("/api/v1/users/upload/init")
     assert resp.status_code == 200
     return resp.json()["upload_id"]
+
+
+async def _put_chunk(
+    client: AsyncClient,
+    upload_id: str,
+    index: int,
+    content: bytes = b"fake-zip",
+) -> None:
+    resp = await client.put(
+        f"/api/v1/users/upload/{upload_id}/{index}",
+        content=content,
+    )
+    assert resp.status_code == 204
+
+
+def _users_dir(tmp_path: Path) -> Path:
+    users_dir = tmp_path / "users"
+    users_dir.mkdir(exist_ok=True)
+    return users_dir
+
+
+async def _complete_with_extract(
+    client: AsyncClient, upload_id: str, users_dir: Path
+) -> Response:
+    with mock_extract(users_dir):
+        return await client.post(f"/api/v1/users/upload/{upload_id}/complete")
 
 
 class TestInitChunkedUpload:
@@ -40,11 +63,7 @@ class TestInitChunkedUpload:
 class TestUploadChunk:
     async def test_accepts_valid_chunk(self, client: AsyncClient) -> None:
         upload_id = await _init(client)
-        resp = await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"chunk-data",
-        )
-        assert resp.status_code == 204
+        await _put_chunk(client, upload_id, 0, b"chunk-data")
 
     async def test_rejects_unknown_session(self, client: AsyncClient) -> None:
         resp = await client.put(
@@ -62,31 +81,17 @@ class TestUploadChunk:
         assert resp.status_code == 400
 
     async def test_idempotent_retry(self, client: AsyncClient, tmp_path: Path) -> None:
-        """Re-uploading the same chunk index uses the latest data."""
         upload_id = await _init(client)
 
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"first-attempt",
-        )
-        resp = await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"retry-attempt",
-        )
-        assert resp.status_code == 204
+        await _put_chunk(client, upload_id, 0, b"first-attempt")
+        await _put_chunk(client, upload_id, 0, b"retry-attempt")
 
-        users_dir = tmp_path / "users"
-        users_dir.mkdir(exist_ok=True)
-        with mock_extract(users_dir):
-            complete = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-            )
+        complete = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
         assert complete.status_code == 200
 
     async def test_client_disconnect_returns_quietly(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Browser abort mid-upload should not produce a 500 traceback."""
         upload_id = await _init(client)
 
         async def raise_disconnect(*_args: object, **_kwargs: object) -> None:
@@ -103,8 +108,6 @@ class TestUploadChunk:
     async def test_rejects_overflow(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Accumulated chunks exceeding max_bytes return 413."""
-        # Set a tiny limit so a small chunk triggers overflow
         monkeypatch.setattr(get_settings(), "VITE_MAX_UPLOAD_GB", 0)
         await sign_in(client)
         init_resp = await client.post("/api/v1/users/upload/init")
@@ -121,21 +124,10 @@ class TestCompleteChunkedUpload:
     async def test_happy_path(self, client: AsyncClient, tmp_path: Path) -> None:
         upload_id = await _init(client)
 
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"fake-zip-part1",
-        )
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/1",
-            content=b"fake-zip-part2",
-        )
+        await _put_chunk(client, upload_id, 0, b"fake-zip-part1")
+        await _put_chunk(client, upload_id, 1, b"fake-zip-part2")
 
-        users_dir = tmp_path / "users"
-        users_dir.mkdir(exist_ok=True)
-        with mock_extract(users_dir):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-            )
+        resp = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
         assert resp.status_code == 200
         body = resp.json()
         assert body["user"]["id"] == 999
@@ -156,7 +148,6 @@ class TestCompleteChunkedUpload:
         assert resp.status_code == 401
 
     async def test_bad_zip_returns_406(self, client: AsyncClient) -> None:
-        """Assembled chunks that aren't a valid ZIP should return 406."""
         upload_id = await _init(client)
         await client.put(
             f"/api/v1/users/upload/{upload_id}/0",
@@ -169,54 +160,32 @@ class TestCompleteChunkedUpload:
     async def test_both_providers(
         self, client: AsyncClient, tmp_path: Path, provider: str
     ) -> None:
-        """Chunked upload works with both Google and Microsoft auth."""
         upload_id = await _init(client, provider=provider)
 
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"fake-zip",
-        )
+        await _put_chunk(client, upload_id, 0)
 
-        users_dir = tmp_path / "users"
-        users_dir.mkdir(exist_ok=True)
-        with mock_extract(users_dir):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-            )
+        resp = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
         assert resp.status_code == 200
 
     async def test_reupload_via_session_cookie(
         self, client: AsyncClient, tmp_path: Path
     ) -> None:
-        """Logged-in user can re-upload without credential/provider."""
-        users_dir = tmp_path / "users"
-        users_dir.mkdir(exist_ok=True)
+        users_dir = _users_dir(tmp_path)
         await sign_in_and_upload(client, users_dir)
 
         init_resp = await client.post("/api/v1/users/upload/init")
         assert init_resp.status_code == 200
         upload_id = init_resp.json()["upload_id"]
 
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"fake-zip",
-        )
+        await _put_chunk(client, upload_id, 0)
 
-        with mock_extract(users_dir):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-            )
+        resp = await _complete_with_extract(client, upload_id, users_dir)
         assert resp.status_code == 200
         assert resp.json()["user"]["id"] == 999
 
     async def test_rejects_wrong_owner(self, client: AsyncClient) -> None:
-        """Complete by a different user than init returns 403."""
-        # Init as Google user (owner = "google:google-123")
         upload_id = await _init(client)
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"chunk",
-        )
+        await _put_chunk(client, upload_id, 0, b"chunk")
         await sign_in(client, provider="microsoft")
         resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
         assert resp.status_code == 403
@@ -226,27 +195,14 @@ class TestParallelChunkedUpload:
     async def test_parallel_chunks_complete_cleanly(
         self, client: AsyncClient, tmp_path: Path
     ) -> None:
-        """4 concurrent PUTs to one session finish and complete succeeds."""
         upload_id = await _init(client)
-
-        async def put_chunk(index: int, data: bytes) -> None:
-            resp = await client.put(
-                f"/api/v1/users/upload/{upload_id}/{index}",
-                content=data,
-            )
-            assert resp.status_code == 204
 
         await asyncio.gather(
             *(
-                put_chunk(i, p)
+                _put_chunk(client, upload_id, i, p)
                 for i, p in enumerate([b"AAAA", b"BBBB", b"CCCC", b"DDDD"])
             )
         )
 
-        users_dir = tmp_path / "users"
-        users_dir.mkdir(exist_ok=True)
-        with mock_extract(users_dir):
-            resp = await client.post(
-                f"/api/v1/users/upload/{upload_id}/complete",
-            )
+        resp = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
         assert resp.status_code == 200

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -10,30 +10,11 @@ from starlette.requests import ClientDisconnect
 from app.core.config import get_settings
 from app.logic.chunked_upload import upload_store
 
-from .factories import mock_extract, sign_in, sign_in_and_upload
+from .factories import sign_in, sign_in_and_upload
+from .helpers.users import UserRoutes
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient, Response
-
-
-async def _init(client: AsyncClient, provider: str = "google") -> str:
-    await sign_in(client, provider)
-    resp = await client.post("/api/v1/users/upload/init")
-    assert resp.status_code == 200
-    return resp.json()["upload_id"]
-
-
-async def _put_chunk(
-    client: AsyncClient,
-    upload_id: str,
-    index: int,
-    content: bytes = b"fake-zip",
-) -> None:
-    resp = await client.put(
-        f"/api/v1/users/upload/{upload_id}/{index}",
-        content=content,
-    )
-    assert resp.status_code == 204
+    from httpx import AsyncClient
 
 
 def _users_dir(tmp_path: Path) -> Path:
@@ -42,167 +23,162 @@ def _users_dir(tmp_path: Path) -> Path:
     return users_dir
 
 
-async def _complete_with_extract(
-    client: AsyncClient, upload_id: str, users_dir: Path
-) -> Response:
-    with mock_extract(users_dir):
-        return await client.post(f"/api/v1/users/upload/{upload_id}/complete")
-
-
 class TestInitChunkedUpload:
-    async def test_returns_upload_id(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
+    async def test_returns_upload_id(self, user_routes: UserRoutes) -> None:
+        upload_id = await user_routes.start_chunked_upload()
         assert isinstance(upload_id, str)
         assert len(upload_id) > 10  # token_urlsafe produces ~43 chars
 
-    async def test_rejects_unauthenticated(self, client: AsyncClient) -> None:
-        resp = await client.post("/api/v1/users/upload/init")
+    async def test_rejects_unauthenticated(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.init_upload()
         assert resp.status_code == 401
 
 
 class TestUploadChunk:
-    async def test_accepts_valid_chunk(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
-        await _put_chunk(client, upload_id, 0, b"chunk-data")
+    async def test_accepts_valid_chunk(self, user_routes: UserRoutes) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        await user_routes.put_chunk_ok(upload_id, 0, b"chunk-data")
 
-    async def test_rejects_unknown_session(self, client: AsyncClient) -> None:
-        resp = await client.put(
-            "/api/v1/users/upload/nonexistent/0",
-            content=b"chunk-data",
-        )
+    async def test_rejects_unknown_session(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.put_chunk("nonexistent", 0, b"chunk-data")
         assert resp.status_code == 404
 
-    async def test_rejects_negative_index(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
-        resp = await client.put(
-            f"/api/v1/users/upload/{upload_id}/-1",
-            content=b"x",
-        )
+    async def test_rejects_negative_index(self, user_routes: UserRoutes) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        resp = await user_routes.put_chunk(upload_id, -1, b"x")
         assert resp.status_code == 400
 
-    async def test_idempotent_retry(self, client: AsyncClient, tmp_path: Path) -> None:
-        upload_id = await _init(client)
+    async def test_idempotent_retry(
+        self, user_routes: UserRoutes, tmp_path: Path
+    ) -> None:
+        upload_id = await user_routes.start_chunked_upload()
 
-        await _put_chunk(client, upload_id, 0, b"first-attempt")
-        await _put_chunk(client, upload_id, 0, b"retry-attempt")
+        await user_routes.put_chunk_ok(upload_id, 0, b"first-attempt")
+        await user_routes.put_chunk_ok(upload_id, 0, b"retry-attempt")
 
-        complete = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
+        complete = await user_routes.complete_upload_with_extract(
+            upload_id, _users_dir(tmp_path)
+        )
         assert complete.status_code == 200
 
     async def test_client_disconnect_returns_quietly(
-        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+        self, user_routes: UserRoutes, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        upload_id = await _init(client)
+        upload_id = await user_routes.start_chunked_upload()
 
         async def raise_disconnect(*_args: object, **_kwargs: object) -> None:
             raise ClientDisconnect
 
         monkeypatch.setattr(upload_store, "write_chunk_stream", raise_disconnect)
 
-        resp = await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"anything",
-        )
+        resp = await user_routes.put_chunk(upload_id, 0, b"anything")
         assert resp.status_code == 204
 
     async def test_rejects_overflow(
-        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+        self,
+        client: AsyncClient,
+        user_routes: UserRoutes,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(get_settings(), "VITE_MAX_UPLOAD_GB", 0)
         await sign_in(client)
-        init_resp = await client.post("/api/v1/users/upload/init")
+        init_resp = await user_routes.init_upload()
         upload_id = init_resp.json()["upload_id"]
 
-        resp = await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"any data at all",
-        )
+        resp = await user_routes.put_chunk(upload_id, 0, b"any data at all")
         assert resp.status_code == 413
 
 
 class TestCompleteChunkedUpload:
-    async def test_happy_path(self, client: AsyncClient, tmp_path: Path) -> None:
-        upload_id = await _init(client)
+    async def test_happy_path(self, user_routes: UserRoutes, tmp_path: Path) -> None:
+        upload_id = await user_routes.start_chunked_upload()
 
-        await _put_chunk(client, upload_id, 0, b"fake-zip-part1")
-        await _put_chunk(client, upload_id, 1, b"fake-zip-part2")
+        await user_routes.put_chunk_ok(upload_id, 0, b"fake-zip-part1")
+        await user_routes.put_chunk_ok(upload_id, 1, b"fake-zip-part2")
 
-        resp = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
+        resp = await user_routes.complete_upload_with_extract(
+            upload_id, _users_dir(tmp_path)
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert body["user"]["id"] == 999
         assert len(body["trips"]) == 1
 
-    async def test_rejects_unknown_session(self, client: AsyncClient) -> None:
+    async def test_rejects_unknown_session(
+        self, client: AsyncClient, user_routes: UserRoutes
+    ) -> None:
         await sign_in(client)
-        resp = await client.post("/api/v1/users/upload/nonexistent/complete")
+        resp = await user_routes.complete_upload("nonexistent")
         assert resp.status_code == 404
 
-    async def test_rejects_empty_upload(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
-        resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
+    async def test_rejects_empty_upload(self, user_routes: UserRoutes) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        resp = await user_routes.complete_upload(upload_id)
         assert resp.status_code == 400
 
-    async def test_rejects_unauthenticated(self, client: AsyncClient) -> None:
-        resp = await client.post("/api/v1/users/upload/any-id/complete")
+    async def test_rejects_unauthenticated(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.complete_upload("any-id")
         assert resp.status_code == 401
 
-    async def test_bad_zip_returns_406(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
-        await client.put(
-            f"/api/v1/users/upload/{upload_id}/0",
-            content=b"not a zip at all",
-        )
-        resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
+    async def test_bad_zip_returns_406(self, user_routes: UserRoutes) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        await user_routes.put_chunk(upload_id, 0, b"not a zip at all")
+        resp = await user_routes.complete_upload(upload_id)
         assert resp.status_code == 406
 
     @pytest.mark.parametrize("provider", ["google", "microsoft"])
     async def test_both_providers(
-        self, client: AsyncClient, tmp_path: Path, provider: str
+        self, user_routes: UserRoutes, tmp_path: Path, provider: str
     ) -> None:
-        upload_id = await _init(client, provider=provider)
+        upload_id = await user_routes.start_chunked_upload(provider=provider)
 
-        await _put_chunk(client, upload_id, 0)
+        await user_routes.put_chunk_ok(upload_id, 0)
 
-        resp = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
+        resp = await user_routes.complete_upload_with_extract(
+            upload_id, _users_dir(tmp_path)
+        )
         assert resp.status_code == 200
 
     async def test_reupload_via_session_cookie(
-        self, client: AsyncClient, tmp_path: Path
+        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
     ) -> None:
         users_dir = _users_dir(tmp_path)
         await sign_in_and_upload(client, users_dir)
 
-        init_resp = await client.post("/api/v1/users/upload/init")
+        init_resp = await user_routes.init_upload()
         assert init_resp.status_code == 200
         upload_id = init_resp.json()["upload_id"]
 
-        await _put_chunk(client, upload_id, 0)
+        await user_routes.put_chunk_ok(upload_id, 0)
 
-        resp = await _complete_with_extract(client, upload_id, users_dir)
+        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
         assert resp.status_code == 200
         assert resp.json()["user"]["id"] == 999
 
-    async def test_rejects_wrong_owner(self, client: AsyncClient) -> None:
-        upload_id = await _init(client)
-        await _put_chunk(client, upload_id, 0, b"chunk")
+    async def test_rejects_wrong_owner(
+        self, client: AsyncClient, user_routes: UserRoutes
+    ) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        await user_routes.put_chunk_ok(upload_id, 0, b"chunk")
         await sign_in(client, provider="microsoft")
-        resp = await client.post(f"/api/v1/users/upload/{upload_id}/complete")
+        resp = await user_routes.complete_upload(upload_id)
         assert resp.status_code == 403
 
 
 class TestParallelChunkedUpload:
     async def test_parallel_chunks_complete_cleanly(
-        self, client: AsyncClient, tmp_path: Path
+        self, user_routes: UserRoutes, tmp_path: Path
     ) -> None:
-        upload_id = await _init(client)
+        upload_id = await user_routes.start_chunked_upload()
 
         await asyncio.gather(
             *(
-                _put_chunk(client, upload_id, i, p)
+                user_routes.put_chunk_ok(upload_id, i, p)
                 for i, p in enumerate([b"AAAA", b"BBBB", b"CCCC", b"DDDD"])
             )
         )
 
-        resp = await _complete_with_extract(client, upload_id, _users_dir(tmp_path))
+        resp = await user_routes.complete_upload_with_extract(
+            upload_id, _users_dir(tmp_path)
+        )
         assert resp.status_code == 200

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,17 +9,10 @@ from starlette.requests import ClientDisconnect
 from app.core.config import get_settings
 from app.logic.chunked_upload import upload_store
 
-from .factories import sign_in, sign_in_and_upload
 from .helpers.users import UserRoutes
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
-
-
-def _users_dir(tmp_path: Path) -> Path:
-    users_dir = tmp_path / "users"
-    users_dir.mkdir(exist_ok=True)
-    return users_dir
+    from pathlib import Path
 
 
 class TestInitChunkedUpload:
@@ -49,16 +41,14 @@ class TestUploadChunk:
         assert resp.status_code == 400
 
     async def test_idempotent_retry(
-        self, user_routes: UserRoutes, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
         upload_id = await user_routes.start_chunked_upload()
 
         await user_routes.put_chunk_ok(upload_id, 0, b"first-attempt")
         await user_routes.put_chunk_ok(upload_id, 0, b"retry-attempt")
 
-        complete = await user_routes.complete_upload_with_extract(
-            upload_id, _users_dir(tmp_path)
-        )
+        complete = await user_routes.complete_upload_with_extract(upload_id, users_dir)
         assert complete.status_code == 200
 
     async def test_client_disconnect_returns_quietly(
@@ -76,12 +66,11 @@ class TestUploadChunk:
 
     async def test_rejects_overflow(
         self,
-        client: AsyncClient,
         user_routes: UserRoutes,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(get_settings(), "VITE_MAX_UPLOAD_GB", 0)
-        await sign_in(client)
+        await user_routes.sign_in()
         init_resp = await user_routes.init_upload()
         upload_id = init_resp.json()["upload_id"]
 
@@ -90,24 +79,20 @@ class TestUploadChunk:
 
 
 class TestCompleteChunkedUpload:
-    async def test_happy_path(self, user_routes: UserRoutes, tmp_path: Path) -> None:
+    async def test_happy_path(self, user_routes: UserRoutes, users_dir: Path) -> None:
         upload_id = await user_routes.start_chunked_upload()
 
         await user_routes.put_chunk_ok(upload_id, 0, b"fake-zip-part1")
         await user_routes.put_chunk_ok(upload_id, 1, b"fake-zip-part2")
 
-        resp = await user_routes.complete_upload_with_extract(
-            upload_id, _users_dir(tmp_path)
-        )
+        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
         assert resp.status_code == 200
         body = resp.json()
         assert body["user"]["id"] == 999
         assert len(body["trips"]) == 1
 
-    async def test_rejects_unknown_session(
-        self, client: AsyncClient, user_routes: UserRoutes
-    ) -> None:
-        await sign_in(client)
+    async def test_rejects_unknown_session(self, user_routes: UserRoutes) -> None:
+        await user_routes.sign_in()
         resp = await user_routes.complete_upload("nonexistent")
         assert resp.status_code == 404
 
@@ -128,23 +113,19 @@ class TestCompleteChunkedUpload:
 
     @pytest.mark.parametrize("provider", ["google", "microsoft"])
     async def test_both_providers(
-        self, user_routes: UserRoutes, tmp_path: Path, provider: str
+        self, user_routes: UserRoutes, users_dir: Path, provider: str
     ) -> None:
         upload_id = await user_routes.start_chunked_upload(provider=provider)
 
         await user_routes.put_chunk_ok(upload_id, 0)
 
-        resp = await user_routes.complete_upload_with_extract(
-            upload_id, _users_dir(tmp_path)
-        )
+        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
         assert resp.status_code == 200
 
+    @pytest.mark.usefixtures("uploaded_user")
     async def test_reupload_via_session_cookie(
-        self, client: AsyncClient, user_routes: UserRoutes, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
-        users_dir = _users_dir(tmp_path)
-        await sign_in_and_upload(client, users_dir)
-
         init_resp = await user_routes.init_upload()
         assert init_resp.status_code == 200
         upload_id = init_resp.json()["upload_id"]
@@ -155,19 +136,17 @@ class TestCompleteChunkedUpload:
         assert resp.status_code == 200
         assert resp.json()["user"]["id"] == 999
 
-    async def test_rejects_wrong_owner(
-        self, client: AsyncClient, user_routes: UserRoutes
-    ) -> None:
+    async def test_rejects_wrong_owner(self, user_routes: UserRoutes) -> None:
         upload_id = await user_routes.start_chunked_upload()
         await user_routes.put_chunk_ok(upload_id, 0, b"chunk")
-        await sign_in(client, provider="microsoft")
+        await user_routes.sign_in(provider="microsoft")
         resp = await user_routes.complete_upload(upload_id)
         assert resp.status_code == 403
 
 
 class TestParallelChunkedUpload:
     async def test_parallel_chunks_complete_cleanly(
-        self, user_routes: UserRoutes, tmp_path: Path
+        self, user_routes: UserRoutes, users_dir: Path
     ) -> None:
         upload_id = await user_routes.start_chunked_upload()
 
@@ -178,7 +157,5 @@ class TestParallelChunkedUpload:
             )
         )
 
-        resp = await user_routes.complete_upload_with_extract(
-            upload_id, _users_dir(tmp_path)
-        )
+        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
         assert resp.status_code == 200

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -48,8 +48,7 @@ class TestUploadChunk:
         await user_routes.put_chunk_ok(upload_id, 0, b"first-attempt")
         await user_routes.put_chunk_ok(upload_id, 0, b"retry-attempt")
 
-        complete = await user_routes.complete_upload_with_extract(upload_id, users_dir)
-        assert complete.status_code == 200
+        await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)
 
     async def test_client_disconnect_returns_quietly(
         self, user_routes: UserRoutes, monkeypatch: pytest.MonkeyPatch
@@ -85,9 +84,7 @@ class TestCompleteChunkedUpload:
         await user_routes.put_chunk_ok(upload_id, 0, b"fake-zip-part1")
         await user_routes.put_chunk_ok(upload_id, 1, b"fake-zip-part2")
 
-        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
-        assert resp.status_code == 200
-        body = resp.json()
+        body = await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)
         assert body["user"]["id"] == 999
         assert len(body["trips"]) == 1
 
@@ -119,8 +116,7 @@ class TestCompleteChunkedUpload:
 
         await user_routes.put_chunk_ok(upload_id, 0)
 
-        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
-        assert resp.status_code == 200
+        await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)
 
     @pytest.mark.usefixtures("uploaded_user")
     async def test_reupload_via_session_cookie(
@@ -132,9 +128,8 @@ class TestCompleteChunkedUpload:
 
         await user_routes.put_chunk_ok(upload_id, 0)
 
-        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
-        assert resp.status_code == 200
-        assert resp.json()["user"]["id"] == 999
+        body = await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)
+        assert body["user"]["id"] == 999
 
     async def test_rejects_wrong_owner(self, user_routes: UserRoutes) -> None:
         upload_id = await user_routes.start_chunked_upload()
@@ -157,5 +152,4 @@ class TestParallelChunkedUpload:
             )
         )
 
-        resp = await user_routes.complete_upload_with_extract(upload_id, users_dir)
-        assert resp.status_code == 200
+        await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)

--- a/backend/tests/test_demo.py
+++ b/backend/tests/test_demo.py
@@ -3,25 +3,20 @@ from tests.helpers.users import UserRoutes
 
 class TestCreateDemo:
     async def test_creates_demo_user(self, user_routes: UserRoutes) -> None:
-        resp = await user_routes.demo()
-        assert resp.status_code == 200
-        body = resp.json()
+        body = await user_routes.demo_ok()
         assert body["user"]["is_demo"] is True
         assert len(body["trips"]) >= 1
 
     async def test_sets_session_cookie(self, user_routes: UserRoutes) -> None:
-        resp = await user_routes.demo()
-        uid = resp.json()["user"]["id"]
-        user_resp = await user_routes.current()
-        assert user_resp.status_code == 200
-        assert user_resp.json()["id"] == uid
+        demo = await user_routes.demo_ok()
+        user = await user_routes.current_ok()
+        assert user["id"] == demo["user"]["id"]
 
 
 class TestDeleteDemo:
     async def test_deletes_demo_user(self, user_routes: UserRoutes) -> None:
-        await user_routes.demo()
-        resp = await user_routes.delete_demo()
-        assert resp.status_code == 204
+        await user_routes.demo_ok()
+        await user_routes.delete_demo_ok()
         # Session cleared - user endpoint returns 401
         user_resp = await user_routes.current()
         assert user_resp.status_code == 401

--- a/backend/tests/test_demo.py
+++ b/backend/tests/test_demo.py
@@ -1,34 +1,31 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
+from tests.helpers.users import UserRoutes
 
 
 class TestCreateDemo:
-    async def test_creates_demo_user(self, client: AsyncClient) -> None:
-        resp = await client.post("/api/v1/users/demo")
+    async def test_creates_demo_user(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.demo()
         assert resp.status_code == 200
         body = resp.json()
         assert body["user"]["is_demo"] is True
         assert len(body["trips"]) >= 1
 
-    async def test_sets_session_cookie(self, client: AsyncClient) -> None:
-        resp = await client.post("/api/v1/users/demo")
+    async def test_sets_session_cookie(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.demo()
         uid = resp.json()["user"]["id"]
-        user_resp = await client.get("/api/v1/users")
+        user_resp = await user_routes.current()
         assert user_resp.status_code == 200
         assert user_resp.json()["id"] == uid
 
 
 class TestDeleteDemo:
-    async def test_deletes_demo_user(self, client: AsyncClient) -> None:
-        await client.post("/api/v1/users/demo")
-        resp = await client.delete("/api/v1/users/demo")
+    async def test_deletes_demo_user(self, user_routes: UserRoutes) -> None:
+        await user_routes.demo()
+        resp = await user_routes.delete_demo()
         assert resp.status_code == 204
         # Session cleared - user endpoint returns 401
-        user_resp = await client.get("/api/v1/users")
+        user_resp = await user_routes.current()
         assert user_resp.status_code == 401
 
-    async def test_rejects_unauthenticated(self, client: AsyncClient) -> None:
-        resp = await client.delete("/api/v1/users/demo")
+    async def test_rejects_unauthenticated(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.delete_demo()
         assert resp.status_code == 401

--- a/backend/tests/test_demo.py
+++ b/backend/tests/test_demo.py
@@ -16,7 +16,8 @@ class TestCreateDemo:
 class TestDeleteDemo:
     async def test_deletes_demo_user(self, user_routes: UserRoutes) -> None:
         await user_routes.demo_ok()
-        await user_routes.delete_demo_ok()
+        resp = await user_routes.delete_demo()
+        assert resp.status_code == 204
         # Session cleared - user endpoint returns 401
         user_resp = await user_routes.current()
         assert user_resp.status_code == 401

--- a/backend/tests/test_demo_i18n.py
+++ b/backend/tests/test_demo_i18n.py
@@ -9,7 +9,11 @@ from app.logic.demo_i18n import apply_overlay, load_overlay
 from app.models.album import Album
 from app.models.polarsteps import Location
 from app.models.step import Step
-from app.models.weather import Weather, WeatherData
+from tests.factories import (
+    make_album as make_test_album,
+    make_step as make_test_step,
+    make_weather,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -26,7 +30,7 @@ HEBREW_OVERLAY = {
     },
 }
 
-WEATHER = Weather(day=WeatherData(temp=20.0, feels_like=18.0, icon="sun"))
+WEATHER = make_weather()
 LOCATION = Location(
     name="Amsterdam",
     detail="NL",
@@ -37,39 +41,29 @@ LOCATION = Location(
 
 
 def make_album(**kwargs: object) -> Album:
-    defaults: dict[str, object] = {
-        "uid": 1,
-        "id": "trip-1",
-        "title": "Original Title",
-        "subtitle": "Original Subtitle",
-        "hidden_steps": [],
-        "hidden_headers": [],
-        "maps_ranges": [],
-        "front_cover_photo": "",
-        "back_cover_photo": "",
-        "colors": {},
-        "media": [],
-    }
-    return Album(**(defaults | kwargs))
+    overrides = dict(kwargs)
+    aid = overrides.pop("id", overrides.pop("aid", "trip-1"))
+    return make_test_album(
+        aid=aid,
+        title="Original Title",
+        subtitle="Original Subtitle",
+        front_cover_photo="",
+        back_cover_photo="",
+        colors={},
+        **overrides,
+    )
 
 
 def make_step(step_id: int = 1, **kwargs: object) -> Step:
-    defaults: dict[str, object] = {
-        "uid": 1,
-        "aid": "trip-1",
-        "id": step_id,
-        "name": "Original Name",
-        "description": "",
-        "cover": None,
-        "pages": [],
-        "unused": [],
-        "timestamp": 1_700_000_000.0,
-        "timezone_id": "UTC",
-        "location": LOCATION,
-        "elevation": 0,
-        "weather": WEATHER,
-    }
-    return Step(**(defaults | kwargs))
+    return make_test_step(
+        step_id=step_id,
+        name="Original Name",
+        description="",
+        timezone_id="UTC",
+        location=LOCATION,
+        weather=WEATHER,
+        **kwargs,
+    )
 
 
 @pytest.fixture

--- a/backend/tests/test_demo_i18n_integration.py
+++ b/backend/tests/test_demo_i18n_integration.py
@@ -4,6 +4,7 @@ import re
 
 from app.logic.trip_pipeline import _apply_demo_i18n
 from app.models.user import User
+from tests.factories import make_user
 
 from .test_demo_i18n import make_album, make_step
 
@@ -14,12 +15,10 @@ HEBREW_STEP_ID = 149050611  # Pantanal in he.json
 
 
 def _make_demo_user(locale: str = "he") -> User:
-    return User(
-        id=42,
+    return make_user(
+        42,
         first_name="Demo",
         locale=locale,
-        unit_is_km=True,
-        temperature_is_celsius=True,
         album_ids=[DEMO_AID],
         is_demo=True,
     )
@@ -43,12 +42,10 @@ class TestApplyDemoI18n:
     def test_skips_non_demo_user(self) -> None:
         album = make_album(uid=42, id=DEMO_AID)
 
-        user = User(
-            id=42,
+        user = make_user(
+            42,
             first_name="Real",
             locale="he",
-            unit_is_km=True,
-            temperature_is_celsius=True,
             google_sub="g-42",
             album_ids=[DEMO_AID],
             is_demo=False,

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -9,7 +9,7 @@ from app.core.config import get_settings
 from app.logic.eviction import _sizes_by_user, run_eviction
 from app.models.user import User
 
-from .factories import make_async_session_mock
+from .factories import make_async_session_mock, make_user
 
 if TYPE_CHECKING:
     import pytest
@@ -22,13 +22,10 @@ def _make_file(path: Path, size: int) -> Path:
 
 
 def _make_user(uid: int, *, hours_ago: int = 0) -> User:
-    return User(
-        id=uid,
+    return make_user(
+        uid,
         google_sub=f"g-{uid}",
         first_name="U",
-        locale="en-US",
-        unit_is_km=True,
-        temperature_is_celsius=True,
         album_ids=[],
         last_active_at=datetime.now(UTC) - timedelta(hours=hours_ago),
     )

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -34,6 +34,13 @@ def _make_user(uid: int, *, hours_ago: int = 0) -> User:
     )
 
 
+def _configure_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, max_bytes: int
+) -> None:
+    monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
+    monkeypatch.setattr(get_settings(), "MAX_STORAGE_BYTES", max_bytes)
+
+
 class TestSizesByUser:
     def test_sums_per_user(self, tmp_path: Path) -> None:
         _make_file(tmp_path / "1" / "a.txt", 100)
@@ -51,27 +58,23 @@ class TestSizesByUser:
 
 class TestRunEviction:
     async def test_noop_when_under_cap(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
-        monkeypatch.setattr(get_settings(), "MAX_STORAGE_BYTES", 1000)
+        _configure_storage(tmp_path, monkeypatch, 1000)
 
-        users_folder = tmp_path / "users"
-        _make_file(users_folder / "1" / "data.bin", 100)
+        _make_file(users_dir / "1" / "data.bin", 100)
 
         await run_eviction(skip_uid=999)
 
-        assert (users_folder / "1" / "data.bin").exists()
+        assert (users_dir / "1" / "data.bin").exists()
 
     async def test_evicts_lru_user(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
-        monkeypatch.setattr(get_settings(), "MAX_STORAGE_BYTES", 100)
+        _configure_storage(tmp_path, monkeypatch, 100)
 
-        users_folder = tmp_path / "users"
-        _make_file(users_folder / "1" / "data.bin", 80)
-        _make_file(users_folder / "2" / "data.bin", 80)
+        _make_file(users_dir / "1" / "data.bin", 80)
+        _make_file(users_dir / "2" / "data.bin", 80)
 
         old_user = _make_user(1, hours_ago=48)
         recent_user = _make_user(2, hours_ago=1)
@@ -83,18 +86,16 @@ class TestRunEviction:
         with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
             await run_eviction(skip_uid=999)
 
-        assert not (users_folder / "1").exists()
-        assert (users_folder / "2" / "data.bin").exists()
+        assert not (users_dir / "1").exists()
+        assert (users_dir / "2" / "data.bin").exists()
 
     async def test_skips_uploading_user(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
-        monkeypatch.setattr(get_settings(), "MAX_STORAGE_BYTES", 50)
+        _configure_storage(tmp_path, monkeypatch, 50)
 
-        users_folder = tmp_path / "users"
-        _make_file(users_folder / "1" / "data.bin", 80)
-        _make_file(users_folder / "2" / "data.bin", 80)
+        _make_file(users_dir / "1" / "data.bin", 80)
+        _make_file(users_dir / "2" / "data.bin", 80)
 
         oldest_user = _make_user(1, hours_ago=100)
         other_user = _make_user(2, hours_ago=10)
@@ -106,19 +107,17 @@ class TestRunEviction:
         with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
             await run_eviction(skip_uid=1)
 
-        assert (users_folder / "1" / "data.bin").exists()
-        assert not (users_folder / "2").exists()
+        assert (users_dir / "1" / "data.bin").exists()
+        assert not (users_dir / "2").exists()
 
     async def test_stops_when_under_cap(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
-        monkeypatch.setattr(get_settings(), "MAX_STORAGE_BYTES", 120)
+        _configure_storage(tmp_path, monkeypatch, 120)
 
-        users_folder = tmp_path / "users"
-        _make_file(users_folder / "1" / "data.bin", 80)
-        _make_file(users_folder / "2" / "data.bin", 80)
-        _make_file(users_folder / "3" / "data.bin", 80)
+        _make_file(users_dir / "1" / "data.bin", 80)
+        _make_file(users_dir / "2" / "data.bin", 80)
+        _make_file(users_dir / "3" / "data.bin", 80)
 
         users = [
             _make_user(1, hours_ago=72),
@@ -133,6 +132,6 @@ class TestRunEviction:
         with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
             await run_eviction(skip_uid=999)
 
-        assert not (users_folder / "1").exists()
-        assert not (users_folder / "2").exists()
-        assert (users_folder / "3" / "data.bin").exists()
+        assert not (users_dir / "1").exists()
+        assert not (users_dir / "2").exists()
+        assert (users_dir / "3" / "data.bin").exists()

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -41,6 +41,13 @@ def _configure_storage(
     monkeypatch.setattr(get_settings(), "MAX_STORAGE_BYTES", max_bytes)
 
 
+def _mock_eviction_users(*users: User) -> patch:
+    mock_result = MagicMock()
+    mock_result.all.return_value = list(users)
+    mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
+    return patch("app.logic.eviction.AsyncSession", return_value=mock_session)
+
+
 class TestSizesByUser:
     def test_sums_per_user(self, tmp_path: Path) -> None:
         _make_file(tmp_path / "1" / "a.txt", 100)
@@ -79,11 +86,7 @@ class TestRunEviction:
         old_user = _make_user(1, hours_ago=48)
         recent_user = _make_user(2, hours_ago=1)
 
-        mock_result = MagicMock()
-        mock_result.all.return_value = [old_user, recent_user]
-        mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
-
-        with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
+        with _mock_eviction_users(old_user, recent_user):
             await run_eviction(skip_uid=999)
 
         assert not (users_dir / "1").exists()
@@ -100,11 +103,7 @@ class TestRunEviction:
         oldest_user = _make_user(1, hours_ago=100)
         other_user = _make_user(2, hours_ago=10)
 
-        mock_result = MagicMock()
-        mock_result.all.return_value = [oldest_user, other_user]
-        mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
-
-        with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
+        with _mock_eviction_users(oldest_user, other_user):
             await run_eviction(skip_uid=1)
 
         assert (users_dir / "1" / "data.bin").exists()
@@ -125,11 +124,7 @@ class TestRunEviction:
             _make_user(3, hours_ago=24),
         ]
 
-        mock_result = MagicMock()
-        mock_result.all.return_value = users
-        mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
-
-        with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
+        with _mock_eviction_users(*users):
             await run_eviction(skip_uid=999)
 
         assert not (users_dir / "1").exists()

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -9,10 +9,6 @@ from unittest.mock import patch
 import pytest
 
 from app.core.config import get_settings
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
-    from sqlmodel.ext.asyncio.session import AsyncSession
 from app.logic.export import (
     _EXPORT_NAME,
     EXPORT_FILENAME,
@@ -32,6 +28,10 @@ from app.models.step import Step
 from app.models.user import User
 from app.models.weather import Weather, WeatherData
 from tests.factories import collect_async
+from tests.helpers.users import UserRoutes
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 def _export_path(*parts: str) -> str:
@@ -134,6 +134,10 @@ def _zip_names(path: Path) -> list[str]:
 def _read_zip_json(path: Path, member: str) -> Any:
     with zipfile.ZipFile(path) as zf:
         return json.loads(zf.read(member))
+
+
+def _export_download_token(path: Path | None) -> patch:
+    return patch("app.api.v1.routes.users.pop_export_token", return_value=path)
 
 
 class TestTokenManagement:
@@ -277,27 +281,21 @@ class TestExportUserData:
 
 class TestDownloadExport:
     async def test_valid_token_returns_zip(
-        self, client: AsyncClient, tmp_path: Path
+        self, user_routes: UserRoutes, tmp_path: Path
     ) -> None:
         zip_path = tmp_path / "test-export.zip"
         zip_path.write_bytes(b"PK\x03\x04 fake zip")
 
-        with patch(
-            "app.api.v1.routes.users.pop_export_token",
-            return_value=zip_path,
-        ):
-            resp = await client.get("/api/v1/users/export/download/valid-token")
+        with _export_download_token(zip_path):
+            resp = await user_routes.download_export("valid-token")
 
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/zip"
         assert EXPORT_FILENAME in resp.headers.get("content-disposition", "")
         assert resp.content == b"PK\x03\x04 fake zip"
 
-    async def test_invalid_token_returns_404(self, client: AsyncClient) -> None:
-        with patch(
-            "app.api.v1.routes.users.pop_export_token",
-            return_value=None,
-        ):
-            resp = await client.get("/api/v1/users/export/download/bad-token")
+    async def test_invalid_token_returns_404(self, user_routes: UserRoutes) -> None:
+        with _export_download_token(None):
+            resp = await user_routes.download_export("bad-token")
 
         assert resp.status_code == 404

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -20,14 +20,15 @@ from app.logic.export import (
     export_user_data,
     pop_export_token,
 )
-from app.models.album import Album
-from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
-from app.models.polarsteps import Location, Point
-from app.models.segment import Segment
-from app.models.step import Step
 from app.models.user import User
-from app.models.weather import Weather, WeatherData
-from tests.factories import collect_async
+from tests.factories import (
+    AID,
+    collect_async,
+    insert_album,
+    insert_segment,
+    insert_step,
+    make_user,
+)
 from tests.helpers.users import UserRoutes
 
 if TYPE_CHECKING:
@@ -36,79 +37,6 @@ if TYPE_CHECKING:
 
 def _export_path(*parts: str) -> str:
     return str(Path(_EXPORT_NAME, *parts))
-
-
-def _make_user(uid: int, tmp_path: Path, *, album_ids: list[str] | None = None) -> User:
-    user = User(
-        id=uid,
-        google_sub=f"google-{uid}",
-        first_name="Test",
-        locale="en-US",
-        unit_is_km=True,
-        temperature_is_celsius=True,
-        album_ids=album_ids or ["trip-1"],
-    )
-    user.folder.mkdir(parents=True, exist_ok=True)
-    return user
-
-
-_LOCATION = Location(name="Test", detail="Place", country_code="NL", lat=52.0, lon=4.0)
-_WEATHER = Weather(day=WeatherData(temp=20.0, feels_like=18.0, icon="clear_day"))
-
-
-async def _insert_album(session: AsyncSession, uid: int, aid: str) -> Album:
-    album = Album(
-        uid=uid,
-        id=aid,
-        title="Test Album",
-        subtitle="Test Subtitle",
-        hidden_steps=[],
-        front_cover_photo="cover.jpg",
-        back_cover_photo="back.jpg",
-        colors={"NL": "#FF6B35"},
-        font="Assistant",
-        body_font="Frank Ruhl Libre",
-    )
-    session.add(album)
-    await session.flush()
-    return album
-
-
-async def _insert_step(session: AsyncSession, uid: int, aid: str, sid: int) -> Step:
-    step = Step(
-        uid=uid,
-        aid=aid,
-        id=sid,
-        name="Step One",
-        description="A test step",
-        cover_media_name="photo1.jpg",
-        timestamp=1700000000.0,
-        timezone_id="Europe/Amsterdam",
-        location=_LOCATION,
-        elevation=10,
-        weather=_WEATHER,
-    )
-    session.add(step)
-    await session.flush()
-    return step
-
-
-async def _insert_segment(session: AsyncSession, uid: int, aid: str) -> Segment:
-    seg = Segment(
-        uid=uid,
-        aid=aid,
-        start_time=1700000000.0,
-        end_time=1700003600.0,
-        kind="walking",
-        timezone_id="UTC",
-        points=[
-            Point(lat=52.0, lon=4.0, time=1700000000.0),
-            Point(lat=52.1, lon=4.1, time=1700003600.0),
-        ],
-    )
-    session.add(seg)
-    await session.flush()
-    return seg
 
 
 def _done_event(events: list[ExportEvent]) -> ExportDone:
@@ -166,19 +94,17 @@ class TestExportUserData:
         monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
         (tmp_path / "users").mkdir(exist_ok=True)
 
-    async def test_yields_progress_and_done(
-        self, session: AsyncSession, tmp_path: Path
-    ) -> None:
+    async def test_yields_progress_and_done(self, session: AsyncSession) -> None:
         uid = 7001
-        user = _make_user(uid, tmp_path)
+        user = make_user(uid)
 
-        trip_dir = user.trips_folder / "trip-1"
+        trip_dir = user.trips_folder / AID
         trip_dir.mkdir(parents=True)
         (trip_dir / "photo1.jpg").write_bytes(b"\xff\xd8fake jpeg")
 
-        await _insert_album(session, uid, "trip-1")
-        await _insert_step(session, uid, "trip-1", 1)
-        await _insert_segment(session, uid, "trip-1")
+        await insert_album(session, uid)
+        await insert_step(session, uid)
+        await insert_segment(session, uid)
         await session.flush()
 
         events, path = await _export_events_and_path(user, session)
@@ -190,19 +116,17 @@ class TestExportUserData:
         assert progress_events[0].files_total == 5
         assert {
             _export_path("account.json"),
-            _export_path("albums", "trip-1", "album.json"),
-            _export_path("albums", "trip-1", "steps.json"),
-            _export_path("albums", "trip-1", "segments.json"),
-            _export_path("albums", "trip-1", "media", "photo1.jpg"),
+            _export_path("albums", AID, "album.json"),
+            _export_path("albums", AID, "steps.json"),
+            _export_path("albums", AID, "segments.json"),
+            _export_path("albums", AID, "media", "photo1.jpg"),
         }.issubset(_zip_names(path))
 
         path.unlink(missing_ok=True)
 
-    async def test_empty_user_still_produces_zip(
-        self, session: AsyncSession, tmp_path: Path
-    ) -> None:
+    async def test_empty_user_still_produces_zip(self, session: AsyncSession) -> None:
         uid = 7003
-        user = _make_user(uid, tmp_path, album_ids=[])
+        user = make_user(uid, album_ids=[])
 
         _, path = await _export_events_and_path(user, session)
         names = _zip_names(path)
@@ -212,53 +136,25 @@ class TestExportUserData:
         path.unlink(missing_ok=True)
 
     async def test_steps_json_includes_normalized_media_layout(
-        self, session: AsyncSession, tmp_path: Path
+        self, session: AsyncSession
     ) -> None:
         uid = 7005
-        user = _make_user(uid, tmp_path)
-        trip_dir = user.trips_folder / "trip-1"
+        user = make_user(uid)
+        trip_dir = user.trips_folder / AID
         trip_dir.mkdir(parents=True)
 
-        await _insert_album(session, uid, "trip-1")
-        session.add_all(
-            [
-                AlbumMedia(
-                    uid=uid,
-                    aid="trip-1",
-                    name=name,
-                    kind="photo",
-                    width=640,
-                    height=480,
-                    byte_size=10,
-                    upgrade_candidate=True,
-                )
-                for name in ("photo1.jpg", "page.jpg", "unused.jpg")
-            ]
-        )
-        await _insert_step(session, uid, "trip-1", 1)
-        session.add(
-            StepPageMedia(
-                uid=uid,
-                aid="trip-1",
-                step_id=1,
-                page_index=0,
-                position_index=0,
-                media_name="page.jpg",
-            )
-        )
-        session.add(
-            StepUnusedMedia(
-                uid=uid,
-                aid="trip-1",
-                step_id=1,
-                position_index=0,
-                media_name="unused.jpg",
-            )
+        await insert_album(session, uid)
+        await insert_step(
+            session,
+            uid,
+            cover_media_name="photo1.jpg",
+            page_media_name="page.jpg",
+            unused_media_name="unused.jpg",
         )
         await session.flush()
 
         _, path = await _export_events_and_path(user, session)
-        steps = _read_zip_json(path, _export_path("albums", "trip-1", "steps.json"))
+        steps = _read_zip_json(path, _export_path("albums", AID, "steps.json"))
 
         assert steps[0]["cover"] == "photo1.jpg"
         assert steps[0]["pages"] == [["page.jpg"]]
@@ -266,11 +162,9 @@ class TestExportUserData:
         assert "cover_media_name" not in steps[0]
         path.unlink(missing_ok=True)
 
-    async def test_error_on_zip_failure(
-        self, session: AsyncSession, tmp_path: Path
-    ) -> None:
+    async def test_error_on_zip_failure(self, session: AsyncSession) -> None:
         uid = 7004
-        user = _make_user(uid, tmp_path, album_ids=[])
+        user = make_user(uid, album_ids=[])
 
         with patch("app.logic.export._build_zip", side_effect=OSError("disk full")):
             events = await collect_async(export_user_data(user, session))

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -32,6 +32,10 @@ from app.models.step import Step
 from app.models.user import User
 from app.models.weather import Weather, WeatherData
 from tests.factories import collect_async
+
+
+def _export_path(*parts: str) -> str:
+    return str(Path(_EXPORT_NAME, *parts))
 
 
 def _make_user(uid: int, tmp_path: Path, *, album_ids: list[str] | None = None) -> User:
@@ -107,6 +111,31 @@ async def _insert_segment(session: AsyncSession, uid: int, aid: str) -> Segment:
     return seg
 
 
+def _done_event(events: list[ExportEvent]) -> ExportDone:
+    done_events = [e for e in events if isinstance(e, ExportDone)]
+    assert len(done_events) == 1
+    return done_events[0]
+
+
+async def _export_events_and_path(
+    user: User, session: AsyncSession
+) -> tuple[list[ExportEvent], Path]:
+    events: list[ExportEvent] = await collect_async(export_user_data(user, session))
+    path = pop_export_token(_done_event(events).token)
+    assert path is not None
+    return events, path
+
+
+def _zip_names(path: Path) -> list[str]:
+    with zipfile.ZipFile(path) as zf:
+        return zf.namelist()
+
+
+def _read_zip_json(path: Path, member: str) -> Any:
+    with zipfile.ZipFile(path) as zf:
+        return json.loads(zf.read(member))
+
+
 class TestTokenManagement:
     @pytest.fixture(autouse=True)
     def _clean_tokens(self) -> None:
@@ -123,7 +152,6 @@ class TestTokenManagement:
         result = pop_export_token(token)
         assert result == path
 
-        # Second pop returns None
         assert pop_export_token(token) is None
 
 
@@ -140,40 +168,29 @@ class TestExportUserData:
         uid = 7001
         user = _make_user(uid, tmp_path)
 
-        # Set up media on disk
         trip_dir = user.trips_folder / "trip-1"
         trip_dir.mkdir(parents=True)
         (trip_dir / "photo1.jpg").write_bytes(b"\xff\xd8fake jpeg")
 
-        # Insert DB records
         await _insert_album(session, uid, "trip-1")
         await _insert_step(session, uid, "trip-1", 1)
         await _insert_segment(session, uid, "trip-1")
         await session.flush()
 
-        events: list[ExportEvent] = await collect_async(export_user_data(user, session))
+        events, path = await _export_events_and_path(user, session)
 
         progress_events = [e for e in events if isinstance(e, ExportProgress)]
-        done_events = [e for e in events if isinstance(e, ExportDone)]
 
-        assert len(progress_events) >= 2  # initial 0 + at least one update
+        assert len(progress_events) >= 2
         assert progress_events[0].files_done == 0
-        assert (
-            progress_events[0].files_total == 5
-        )  # 1 account + 3 album JSONs + 1 photo
-        assert len(done_events) == 1
-
-        # Verify the ZIP contents
-        path = pop_export_token(done_events[0].token)
-        assert path is not None
-
-        with zipfile.ZipFile(path) as zf:
-            names = zf.namelist()
-            assert f"{_EXPORT_NAME}/account.json" in names
-            assert f"{_EXPORT_NAME}/albums/trip-1/album.json" in names
-            assert f"{_EXPORT_NAME}/albums/trip-1/steps.json" in names
-            assert f"{_EXPORT_NAME}/albums/trip-1/segments.json" in names
-            assert f"{_EXPORT_NAME}/albums/trip-1/media/photo1.jpg" in names
+        assert progress_events[0].files_total == 5
+        assert {
+            _export_path("account.json"),
+            _export_path("albums", "trip-1", "album.json"),
+            _export_path("albums", "trip-1", "steps.json"),
+            _export_path("albums", "trip-1", "segments.json"),
+            _export_path("albums", "trip-1", "media", "photo1.jpg"),
+        }.issubset(_zip_names(path))
 
         path.unlink(missing_ok=True)
 
@@ -183,17 +200,10 @@ class TestExportUserData:
         uid = 7003
         user = _make_user(uid, tmp_path, album_ids=[])
 
-        events = await collect_async(export_user_data(user, session))
-        done_events = [e for e in events if isinstance(e, ExportDone)]
-        assert len(done_events) == 1
-
-        path = pop_export_token(done_events[0].token)
-        assert path is not None
-
-        with zipfile.ZipFile(path) as zf:
-            names = zf.namelist()
-            assert f"{_EXPORT_NAME}/account.json" in names
-            assert len(names) == 1
+        _, path = await _export_events_and_path(user, session)
+        names = _zip_names(path)
+        assert _export_path("account.json") in names
+        assert len(names) == 1
 
         path.unlink(missing_ok=True)
 
@@ -243,13 +253,8 @@ class TestExportUserData:
         )
         await session.flush()
 
-        events = await collect_async(export_user_data(user, session))
-        done = next(e for e in events if isinstance(e, ExportDone))
-        path = pop_export_token(done.token)
-        assert path is not None
-
-        with zipfile.ZipFile(path) as zf:
-            steps = json.loads(zf.read(f"{_EXPORT_NAME}/albums/trip-1/steps.json"))
+        _, path = await _export_events_and_path(user, session)
+        steps = _read_zip_json(path, _export_path("albums", "trip-1", "steps.json"))
 
         assert steps[0]["cover"] == "photo1.jpg"
         assert steps[0]["pages"] == [["page.jpg"]]

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -181,9 +181,8 @@ class TestDownloadExport:
         zip_path.write_bytes(b"PK\x03\x04 fake zip")
 
         with _export_download_token(zip_path):
-            resp = await user_routes.download_export("valid-token")
+            resp = await user_routes.download_export_ok("valid-token")
 
-        assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/zip"
         assert EXPORT_FILENAME in resp.headers.get("content-disposition", "")
         assert resp.content == b"PK\x03\x04 fake zip"

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -181,8 +181,9 @@ class TestDownloadExport:
         zip_path.write_bytes(b"PK\x03\x04 fake zip")
 
         with _export_download_token(zip_path):
-            resp = await user_routes.download_export_ok("valid-token")
+            resp = await user_routes.download_export("valid-token")
 
+        assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/zip"
         assert EXPORT_FILENAME in resp.headers.get("content-disposition", "")
         assert resp.content == b"PK\x03\x04 fake zip"

--- a/backend/tests/test_external_media_models.py
+++ b/backend/tests/test_external_media_models.py
@@ -1,23 +1,20 @@
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
-from app.models.album_media import (
-    AlbumMedia,
-    AlbumMediaUndoSnapshot,
-    StepPageMedia,
-    StepUnusedMedia,
+from tests.factories import (
+    DEFAULT_MEDIA_NAME,
+    make_album_media,
+    make_step_page_media,
+    make_step_unused_media,
+    make_undo_snapshot,
 )
 
 
 def test_album_media_keeps_name_as_identity() -> None:
-    media = AlbumMedia(
-        uid=1,
-        aid="trip-1",
-        name="11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg",
-        kind="photo",
+    media = make_album_media(
+        name=DEFAULT_MEDIA_NAME,
         width=1600,
         height=1200,
         byte_size=123456,
-        upgrade_candidate=True,
     )
 
     dumped = media.model_dump()
@@ -29,11 +26,9 @@ def test_album_media_keeps_name_as_identity() -> None:
 
 
 def test_step_page_media_uses_position_as_identity() -> None:
-    placement = StepPageMedia(
-        uid=1,
-        aid="trip-1",
+    placement = make_step_page_media(
         step_id=7,
-        media_name="11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg",
+        media_name=DEFAULT_MEDIA_NAME,
         page_index=2,
         position_index=3,
     )
@@ -45,11 +40,9 @@ def test_step_page_media_uses_position_as_identity() -> None:
 
 
 def test_step_unused_media_uses_position_as_identity() -> None:
-    placement = StepUnusedMedia(
-        uid=1,
-        aid="trip-1",
+    placement = make_step_unused_media(
         step_id=7,
-        media_name="11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg",
+        media_name=DEFAULT_MEDIA_NAME,
         position_index=0,
     )
 
@@ -59,15 +52,6 @@ def test_step_unused_media_uses_position_as_identity() -> None:
 
 
 def test_undo_snapshot_expires_after_five_minutes() -> None:
-    now = datetime.now(UTC)
-    snap = AlbumMediaUndoSnapshot(
-        uid=1,
-        aid="trip-1",
-        media_name="11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg",
-        snapshot_path=".undo/11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg",
-        upgrade_candidate=True,
-        created_at=now,
-        expires_at=now + timedelta(minutes=5),
-    )
+    snap = make_undo_snapshot()
 
     assert snap.expires_at - snap.created_at == timedelta(minutes=5)

--- a/backend/tests/test_external_media_operations.py
+++ b/backend/tests/test_external_media_operations.py
@@ -96,6 +96,80 @@ def _replacement_video(tmp_path: Path, poster: bytes = b"generated poster") -> P
     return replacement
 
 
+def _saved_input(path: Path) -> SavedInput:
+    return SavedInput(path=path, size=path.stat().st_size)
+
+
+async def _replace_video_with_mocked_processing(
+    session: AsyncSession,
+    album: Album,
+    tmp_path: Path,
+    replacement: Path,
+) -> None:
+    with (
+        patch(
+            "app.logic.external_media.album_media.process_saved_media",
+            AsyncMock(
+                return_value=(
+                    [Media(name=replacement.name, width=1280, height=720)],
+                    [replacement],
+                )
+            ),
+        ),
+        patch("app.logic.external_media.album_media.extract_frame", AsyncMock()),
+    ):
+        await replace_album_media_from_saved(
+            session,
+            album=album,
+            album_dir=tmp_path,
+            media_name=VALID_VIDEO_NAME,
+            saved=_saved_input(replacement),
+        )
+
+
+def _seed_video_undo_files(
+    tmp_path: Path,
+    target: Path,
+    *,
+    snapshot_poster: bytes | None = None,
+) -> Path:
+    target.with_suffix(".jpg").write_bytes(b"replacement poster")
+    undo_dir = tmp_path / ".undo"
+    undo_dir.mkdir()
+    snapshot = undo_dir / VALID_VIDEO_NAME
+    snapshot.write_bytes(b"original video")
+    if snapshot_poster is not None:
+        snapshot.with_suffix(".jpg").write_bytes(snapshot_poster)
+    return target.with_suffix(".jpg")
+
+
+async def _restore_video_undo(
+    session: AsyncSession,
+    album: Album,
+    tmp_path: Path,
+    *,
+    create_frame_patch: bool = False,
+) -> AsyncMock:
+    with (
+        patch(
+            "app.logic.external_media.undo.Media.probe",
+            AsyncMock(return_value=Media(name=VALID_VIDEO_NAME, width=640, height=480)),
+        ),
+        patch(
+            "app.logic.external_media.undo.extract_frame",
+            AsyncMock(),
+            create=create_frame_patch,
+        ) as extract_frame,
+    ):
+        await restore_undo_snapshot(
+            session,
+            album=album,
+            album_dir=tmp_path,
+            media_name=VALID_VIDEO_NAME,
+        )
+    return extract_frame
+
+
 def _add_undo_snapshot(
     session: AsyncSession,
     *,
@@ -147,7 +221,7 @@ async def test_replace_preserves_media_name_and_creates_undo(
         album=album,
         album_dir=album_dir,
         media_name=VALID_NAME,
-        saved=SavedInput(path=replacement, size=replacement.stat().st_size),
+        saved=_saved_input(replacement),
     )
 
     assert result.name == VALID_NAME
@@ -187,7 +261,7 @@ async def test_replace_prunes_expired_undo_snapshots(
         album=album,
         album_dir=album_dir,
         media_name=VALID_NAME,
-        saved=SavedInput(path=replacement, size=replacement.stat().st_size),
+        saved=_saved_input(replacement),
     )
 
     assert not old_snapshot.exists()
@@ -211,7 +285,7 @@ async def test_replace_rejects_photo_video_mismatch(
             album=album,
             album_dir=tmp_path,
             media_name=VALID_NAME,
-            saved=SavedInput(path=replacement, size=replacement.stat().st_size),
+            saved=_saved_input(replacement),
         )
 
 
@@ -223,28 +297,7 @@ async def test_video_replace_removes_generated_temp_poster(
     replacement = _replacement_video(tmp_path)
     await session.commit()
 
-    with (
-        patch(
-            "app.logic.external_media.album_media.process_saved_media",
-            AsyncMock(
-                return_value=(
-                    [Media(name=replacement.name, width=1280, height=720)],
-                    [replacement],
-                )
-            ),
-        ),
-        patch(
-            "app.logic.external_media.album_media.extract_frame",
-            AsyncMock(),
-        ),
-    ):
-        await replace_album_media_from_saved(
-            session,
-            album=album,
-            album_dir=tmp_path,
-            media_name=VALID_VIDEO_NAME,
-            saved=SavedInput(path=replacement, size=replacement.stat().st_size),
-        )
+    await _replace_video_with_mocked_processing(session, album, tmp_path, replacement)
 
     assert (tmp_path / VALID_VIDEO_NAME).read_bytes() == b"new video"
     assert not replacement.with_suffix(".jpg").exists()
@@ -258,25 +311,7 @@ async def test_video_replace_snapshots_custom_poster_for_undo(
     replacement = _replacement_video(tmp_path)
     await session.commit()
 
-    with (
-        patch(
-            "app.logic.external_media.album_media.process_saved_media",
-            AsyncMock(
-                return_value=(
-                    [Media(name=replacement.name, width=1280, height=720)],
-                    [replacement],
-                )
-            ),
-        ),
-        patch("app.logic.external_media.album_media.extract_frame", AsyncMock()),
-    ):
-        await replace_album_media_from_saved(
-            session,
-            album=album,
-            album_dir=tmp_path,
-            media_name=VALID_VIDEO_NAME,
-            saved=SavedInput(path=replacement, size=replacement.stat().st_size),
-        )
+    await _replace_video_with_mocked_processing(session, album, tmp_path, replacement)
 
     snapshot_poster = tmp_path / ".undo" / VALID_VIDEO_POSTER_NAME
     assert snapshot_poster.read_bytes() == b"custom poster"
@@ -290,31 +325,11 @@ async def test_video_undo_restores_snapshot_poster(
     album, target = await _album_with_video(
         session, tmp_path, uid=uid, content=b"replacement video"
     )
-    poster = target.with_suffix(".jpg")
-    poster.write_bytes(b"replacement poster")
-    undo_dir = tmp_path / ".undo"
-    undo_dir.mkdir()
-    snapshot = undo_dir / VALID_VIDEO_NAME
-    snapshot.write_bytes(b"original video")
-    snapshot.with_suffix(".jpg").write_bytes(b"custom poster")
+    poster = _seed_video_undo_files(tmp_path, target, snapshot_poster=b"custom poster")
     _add_undo_snapshot(session, uid=uid)
     await session.commit()
 
-    with (
-        patch(
-            "app.logic.external_media.undo.Media.probe",
-            AsyncMock(return_value=Media(name=VALID_VIDEO_NAME, width=640, height=480)),
-        ),
-        patch(
-            "app.logic.external_media.undo.extract_frame", AsyncMock()
-        ) as extract_frame,
-    ):
-        await restore_undo_snapshot(
-            session,
-            album=album,
-            album_dir=tmp_path,
-            media_name=VALID_VIDEO_NAME,
-        )
+    extract_frame = await _restore_video_undo(session, album, tmp_path)
 
     assert poster.read_bytes() == b"custom poster"
     extract_frame.assert_not_awaited()
@@ -328,30 +343,12 @@ async def test_video_undo_regenerates_restored_poster(
     album, target = await _album_with_video(
         session, tmp_path, uid=uid, content=b"replacement video"
     )
-    target.with_suffix(".jpg").write_bytes(b"replacement poster")
-    undo_dir = tmp_path / ".undo"
-    undo_dir.mkdir()
-    snapshot = undo_dir / VALID_VIDEO_NAME
-    snapshot.write_bytes(b"original video")
+    _seed_video_undo_files(tmp_path, target)
     _add_undo_snapshot(session, uid=uid)
     await session.commit()
 
-    with (
-        patch(
-            "app.logic.external_media.undo.Media.probe",
-            AsyncMock(return_value=Media(name=VALID_VIDEO_NAME, width=640, height=480)),
-        ),
-        patch(
-            "app.logic.external_media.undo.extract_frame",
-            AsyncMock(),
-            create=True,
-        ) as extract_frame,
-    ):
-        await restore_undo_snapshot(
-            session,
-            album=album,
-            album_dir=tmp_path,
-            media_name=VALID_VIDEO_NAME,
-        )
+    extract_frame = await _restore_video_undo(
+        session, album, tmp_path, create_frame_patch=True
+    )
 
     extract_frame.assert_awaited_once_with(target)

--- a/backend/tests/test_external_media_operations.py
+++ b/backend/tests/test_external_media_operations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,24 +16,106 @@ from app.logic.external_media.undo import (
 )
 from app.logic.layout.media import Media
 from app.logic.media_import import SavedInput
+from app.models.album import Album
 from app.models.album_media import AlbumMedia, AlbumMediaUndoSnapshot
 
-from .factories import AID, create_test_jpeg, insert_album, insert_album_media
+from .factories import (
+    AID,
+    DEFAULT_MEDIA_NAME,
+    MISSING_MEDIA_NAME,
+    create_test_jpeg,
+    insert_album,
+    insert_album_media,
+)
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
-VALID_NAME = (
-    "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
-)
+VALID_NAME = DEFAULT_MEDIA_NAME
 VALID_VIDEO_NAME = (
     "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.mp4"
 )
 VALID_VIDEO_POSTER_NAME = VALID_VIDEO_NAME.replace(".mp4", ".jpg")
-OLD_NAME = (
-    "33333333-3333-4333-8333-333333333333_44444444-4444-4444-8444-444444444444.jpg"
-)
+OLD_NAME = MISSING_MEDIA_NAME
+
+
+async def _album_with_photo(
+    session: AsyncSession,
+    tmp_path: Path,
+    *,
+    uid: int = 1,
+    name: str = VALID_NAME,
+    width: int = 640,
+    height: int = 480,
+) -> tuple[Album, AlbumMedia]:
+    album = await insert_album(session, uid)
+    original = create_test_jpeg(tmp_path / name, width, height)
+    media = await insert_album_media(
+        session,
+        uid,
+        name=name,
+        width=width,
+        height=height,
+    )
+    media.byte_size = original.stat().st_size
+    session.add(media)
+    return album, media
+
+
+async def _album_with_video(
+    session: AsyncSession,
+    tmp_path: Path,
+    *,
+    uid: int = 1,
+    content: bytes = b"old video",
+    poster: bytes | None = None,
+) -> tuple[Album, Path]:
+    album = await insert_album(session, uid)
+    target = tmp_path / VALID_VIDEO_NAME
+    target.write_bytes(content)
+    if poster is not None:
+        target.with_suffix(".jpg").write_bytes(poster)
+    media = await insert_album_media(
+        session,
+        uid,
+        name=VALID_VIDEO_NAME,
+        width=640,
+        height=480,
+    )
+    media.kind = "video"
+    media.byte_size = target.stat().st_size
+    session.add(media)
+    return album, target
+
+
+def _replacement_video(tmp_path: Path, poster: bytes = b"generated poster") -> Path:
+    replacement = tmp_path / "replacement.mp4"
+    replacement.write_bytes(b"new video")
+    replacement.with_suffix(".jpg").write_bytes(poster)
+    return replacement
+
+
+def _add_undo_snapshot(
+    session: AsyncSession,
+    *,
+    uid: int = 1,
+    media_name: str = VALID_VIDEO_NAME,
+    created_at: datetime | None = None,
+    expires_at: datetime | None = None,
+) -> None:
+    now = created_at or datetime.now(UTC)
+    session.add(
+        AlbumMediaUndoSnapshot(
+            uid=uid,
+            aid=AID,
+            media_name=media_name,
+            snapshot_path=str(Path(".undo") / media_name),
+            upgrade_candidate=True,
+            created_at=now,
+            expires_at=expires_at or now + timedelta(minutes=5),
+        )
+    )
 
 
 def test_enqueue_undo_snapshot_prune_adds_scheduler_background_task(
@@ -53,18 +137,8 @@ async def test_replace_preserves_media_name_and_creates_undo(
     tmp_path: Path,
 ) -> None:
     uid = 1
-    album = await insert_album(session, uid)
     album_dir = tmp_path
-    original = create_test_jpeg(album_dir / VALID_NAME, 640, 480)
-    media = await insert_album_media(
-        session,
-        uid,
-        name=VALID_NAME,
-        width=640,
-        height=480,
-    )
-    media.byte_size = original.stat().st_size
-    session.add(media)
+    album, _media = await _album_with_photo(session, album_dir, uid=uid)
     replacement = create_test_jpeg(tmp_path / "replacement.jpg", 1600, 1200)
     await session.commit()
 
@@ -90,30 +164,21 @@ async def test_replace_prunes_expired_undo_snapshots(
     tmp_path: Path,
 ) -> None:
     uid = 1
-    album = await insert_album(session, uid)
     album_dir = tmp_path
-    original = create_test_jpeg(album_dir / VALID_NAME, 640, 480)
-    await insert_album_media(session, uid, name=VALID_NAME, width=640, height=480)
+    album, _media = await _album_with_photo(session, album_dir, uid=uid)
     await insert_album_media(session, uid, name=OLD_NAME, width=640, height=480)
     undo_dir = album_dir / ".undo"
     undo_dir.mkdir()
     old_snapshot = undo_dir / OLD_NAME
     old_snapshot.write_bytes(b"expired snapshot")
     now = datetime.now(UTC)
-    session.add(
-        AlbumMediaUndoSnapshot(
-            uid=uid,
-            aid=AID,
-            media_name=OLD_NAME,
-            snapshot_path=str(Path(".undo") / OLD_NAME),
-            upgrade_candidate=True,
-            created_at=now - timedelta(minutes=10),
-            expires_at=now - timedelta(minutes=5),
-        )
+    _add_undo_snapshot(
+        session,
+        uid=uid,
+        media_name=OLD_NAME,
+        created_at=now - timedelta(minutes=10),
+        expires_at=now - timedelta(minutes=5),
     )
-    media = await session.get_one(AlbumMedia, (uid, AID, VALID_NAME))
-    media.byte_size = original.stat().st_size
-    session.add(media)
     replacement = create_test_jpeg(tmp_path / "replacement.jpg", 1600, 1200)
     await session.commit()
 
@@ -134,15 +199,7 @@ async def test_replace_rejects_photo_video_mismatch(
     session: AsyncSession,
     tmp_path: Path,
 ) -> None:
-    uid = 1
-    album = await insert_album(session, uid)
-    media = await insert_album_media(
-        session,
-        uid,
-        name=VALID_NAME,
-        width=640,
-        height=480,
-    )
+    album, media = await _album_with_photo(session, tmp_path)
     media.kind = "video"
     session.add(media)
     replacement = create_test_jpeg(tmp_path / "replacement.jpg", 1600, 1200)
@@ -162,24 +219,8 @@ async def test_video_replace_removes_generated_temp_poster(
     session: AsyncSession,
     tmp_path: Path,
 ) -> None:
-    uid = 1
-    album = await insert_album(session, uid)
-    original = tmp_path / VALID_VIDEO_NAME
-    original.write_bytes(b"old video")
-    media = await insert_album_media(
-        session,
-        uid,
-        name=VALID_VIDEO_NAME,
-        width=640,
-        height=480,
-    )
-    media.kind = "video"
-    media.byte_size = original.stat().st_size
-    session.add(media)
-    replacement = tmp_path / "replacement.mp4"
-    replacement.write_bytes(b"new video")
-    replacement_poster = replacement.with_suffix(".jpg")
-    replacement_poster.write_bytes(b"generated poster")
+    album, _target = await _album_with_video(session, tmp_path)
+    replacement = _replacement_video(tmp_path)
     await session.commit()
 
     with (
@@ -206,31 +247,15 @@ async def test_video_replace_removes_generated_temp_poster(
         )
 
     assert (tmp_path / VALID_VIDEO_NAME).read_bytes() == b"new video"
-    assert not replacement_poster.exists()
+    assert not replacement.with_suffix(".jpg").exists()
 
 
 async def test_video_replace_snapshots_custom_poster_for_undo(
     session: AsyncSession,
     tmp_path: Path,
 ) -> None:
-    uid = 1
-    album = await insert_album(session, uid)
-    original = tmp_path / VALID_VIDEO_NAME
-    original.write_bytes(b"old video")
-    original.with_suffix(".jpg").write_bytes(b"custom poster")
-    media = await insert_album_media(
-        session,
-        uid,
-        name=VALID_VIDEO_NAME,
-        width=640,
-        height=480,
-    )
-    media.kind = "video"
-    media.byte_size = original.stat().st_size
-    session.add(media)
-    replacement = tmp_path / "replacement.mp4"
-    replacement.write_bytes(b"new video")
-    replacement.with_suffix(".jpg").write_bytes(b"generated poster")
+    album, _target = await _album_with_video(session, tmp_path, poster=b"custom poster")
+    replacement = _replacement_video(tmp_path)
     await session.commit()
 
     with (
@@ -262,9 +287,9 @@ async def test_video_undo_restores_snapshot_poster(
     tmp_path: Path,
 ) -> None:
     uid = 1
-    album = await insert_album(session, uid)
-    target = tmp_path / VALID_VIDEO_NAME
-    target.write_bytes(b"replacement video")
+    album, target = await _album_with_video(
+        session, tmp_path, uid=uid, content=b"replacement video"
+    )
     poster = target.with_suffix(".jpg")
     poster.write_bytes(b"replacement poster")
     undo_dir = tmp_path / ".undo"
@@ -272,27 +297,7 @@ async def test_video_undo_restores_snapshot_poster(
     snapshot = undo_dir / VALID_VIDEO_NAME
     snapshot.write_bytes(b"original video")
     snapshot.with_suffix(".jpg").write_bytes(b"custom poster")
-    media = await insert_album_media(
-        session,
-        uid,
-        name=VALID_VIDEO_NAME,
-        width=1280,
-        height=720,
-    )
-    media.kind = "video"
-    media.byte_size = target.stat().st_size
-    now = datetime.now(UTC)
-    session.add(
-        AlbumMediaUndoSnapshot(
-            uid=uid,
-            aid=AID,
-            media_name=VALID_VIDEO_NAME,
-            snapshot_path=str(Path(".undo") / VALID_VIDEO_NAME),
-            upgrade_candidate=True,
-            created_at=now,
-            expires_at=now + timedelta(minutes=5),
-        )
-    )
+    _add_undo_snapshot(session, uid=uid)
     await session.commit()
 
     with (
@@ -320,35 +325,15 @@ async def test_video_undo_regenerates_restored_poster(
     tmp_path: Path,
 ) -> None:
     uid = 1
-    album = await insert_album(session, uid)
-    target = tmp_path / VALID_VIDEO_NAME
-    target.write_bytes(b"replacement video")
+    album, target = await _album_with_video(
+        session, tmp_path, uid=uid, content=b"replacement video"
+    )
     target.with_suffix(".jpg").write_bytes(b"replacement poster")
     undo_dir = tmp_path / ".undo"
     undo_dir.mkdir()
     snapshot = undo_dir / VALID_VIDEO_NAME
     snapshot.write_bytes(b"original video")
-    media = await insert_album_media(
-        session,
-        uid,
-        name=VALID_VIDEO_NAME,
-        width=1280,
-        height=720,
-    )
-    media.kind = "video"
-    media.byte_size = target.stat().st_size
-    now = datetime.now(UTC)
-    session.add(
-        AlbumMediaUndoSnapshot(
-            uid=uid,
-            aid=AID,
-            media_name=VALID_VIDEO_NAME,
-            snapshot_path=str(Path(".undo") / VALID_VIDEO_NAME),
-            upgrade_candidate=True,
-            created_at=now,
-            expires_at=now + timedelta(minutes=5),
-        )
-    )
+    _add_undo_snapshot(session, uid=uid)
     await session.commit()
 
     with (

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -12,7 +12,6 @@ from PIL import Image
 
 from app.api.v1.deps import _get_http_clients
 from app.api.v1.routes.external_media import add_google_media
-from app.core.config import get_settings
 from app.core.http_clients import HttpClients
 from app.main import app
 from app.models.album_media import AlbumMedia, StepUnusedMedia
@@ -22,11 +21,10 @@ from app.models.user import User
 from .conftest import _mock_http_clients
 from .factories import (
     AID,
+    DEFAULT_MEDIA_NAME,
+    MISSING_MEDIA_NAME,
     connect_google_photos,
-    insert_album,
-    insert_album_media,
-    insert_step,
-    sign_in_and_upload,
+    sign_in_with_album_media,
 )
 
 if TYPE_CHECKING:
@@ -46,33 +44,11 @@ def _pin_http_clients() -> HttpClients:
     return http
 
 
-async def _signed_in_album(client: AsyncClient, session: AsyncSession) -> int:
-    user_data = await sign_in_and_upload(
-        client,
-        get_settings().USERS_FOLDER,
-        provider="google",
-    )
-    uid = user_data["id"]
-    await insert_album(session, uid)
-    await insert_album_media(
-        session,
-        uid,
-        name="11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg",
-    )
-    await insert_step(session, uid)
-    (get_settings().USERS_FOLDER / str(uid) / "trip" / AID).mkdir(
-        parents=True,
-        exist_ok=True,
-    )
-    await session.commit()
-    return uid
-
-
 async def test_device_add_to_step_prepends_unused(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
+    scenario = await sign_in_with_album_media(client, session)
 
     resp = await client.post(
         f"/api/v1/albums/{AID}/external-media/add/device",
@@ -84,10 +60,10 @@ async def test_device_add_to_step_prepends_unused(
     imported = resp.json()["names"]
     assert len(imported) == 1
 
-    unused = await session.get_one(StepUnusedMedia, (uid, AID, 1, 0))
+    unused = await session.get_one(StepUnusedMedia, (scenario.uid, AID, 1, 0))
     assert unused.media_name == imported[0]
 
-    row = await session.get_one(AlbumMedia, (uid, AID, imported[0]))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, imported[0]))
     assert row.kind == "photo"
     assert row.upgrade_candidate is False
     assert row.byte_size > 0
@@ -103,7 +79,7 @@ async def test_device_add_to_cover_does_not_select_cover(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
+    scenario = await sign_in_with_album_media(client, session)
 
     resp = await client.post(
         f"/api/v1/albums/{AID}/external-media/add/device",
@@ -113,7 +89,7 @@ async def test_device_add_to_cover_does_not_select_cover(
 
     assert resp.status_code == 200
     imported = resp.json()["names"][0]
-    row = await session.get_one(AlbumMedia, (uid, AID, imported))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, imported))
     assert row.width == 900
     assert row.height == 600
 
@@ -121,23 +97,21 @@ async def test_device_add_to_cover_does_not_select_cover(
 async def test_device_replace_updates_existing_media(
     client: AsyncClient,
     session: AsyncSession,
-    tmp_path: Path,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=True,
     )
-    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
-    Image.new("RGB", (640, 480), color="red").save(album_dir / media_name, "JPEG")
 
     resp = await client.post(
         f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": media_name},
+        data={"media_name": scenario.media_name},
         files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
     )
 
     assert resp.status_code == 200
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 1200
     assert row.height == 800
 
@@ -146,36 +120,36 @@ async def test_device_replace_schedules_undo_snapshot_prune(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=True,
     )
-    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
-    Image.new("RGB", (640, 480), color="red").save(album_dir / media_name, "JPEG")
 
     with patch(
         "app.api.v1.routes.external_media.enqueue_undo_snapshot_prune",
     ) as enqueue_prune:
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/device",
-            data={"media_name": media_name},
+            data={"media_name": scenario.media_name},
             files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
         )
 
     assert resp.status_code == 200
     enqueue_prune.assert_called_once()
     _, scheduled_uid, scheduled_aid, scheduled_dir = enqueue_prune.call_args.args
-    assert (scheduled_uid, scheduled_aid, scheduled_dir) == (uid, AID, album_dir)
+    assert (scheduled_uid, scheduled_aid, scheduled_dir) == (
+        scenario.uid,
+        AID,
+        scenario.album_dir,
+    )
 
 
 async def test_device_replace_oversized_upload_returns_413(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    await _signed_in_album(client, session)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
-    )
+    await sign_in_with_album_media(client, session)
 
     with patch(
         "app.api.v1.routes.external_media.save_uploads",
@@ -183,7 +157,7 @@ async def test_device_replace_oversized_upload_returns_413(
     ):
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/device",
-            data={"media_name": media_name},
+            data={"media_name": DEFAULT_MEDIA_NAME},
             files={"file": ("replacement.jpg", b"too large", "image/jpeg")},
         )
 
@@ -195,18 +169,13 @@ async def test_device_replace_missing_media_returns_404(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    await _signed_in_album(client, session)
+    await sign_in_with_album_media(client, session)
     save_uploads = AsyncMock(side_effect=AssertionError("should not save upload"))
 
     with patch("app.api.v1.routes.external_media.save_uploads", save_uploads):
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/device",
-            data={
-                "media_name": (
-                    "33333333-3333-4333-8333-333333333333_"
-                    "44444444-4444-4444-8444-444444444444.jpg"
-                )
-            },
+            data={"media_name": MISSING_MEDIA_NAME},
             files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
         )
 
@@ -218,28 +187,26 @@ async def test_device_replace_missing_media_returns_404(
 async def test_undo_replacement_restores_previous_dimensions(
     client: AsyncClient,
     session: AsyncSession,
-    tmp_path: Path,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=True,
     )
-    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
-    Image.new("RGB", (640, 480), color="red").save(album_dir / media_name, "JPEG")
 
     replace_resp = await client.post(
         f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": media_name},
+        data={"media_name": scenario.media_name},
         files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
     )
     assert replace_resp.status_code == 200
 
     undo_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
+        f"/api/v1/albums/{AID}/external-media/undo/{scenario.media_name}",
     )
 
     assert undo_resp.status_code == 200
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 640
     assert row.height == 480
 
@@ -247,35 +214,33 @@ async def test_undo_replacement_restores_previous_dimensions(
 async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
     client: AsyncClient,
     session: AsyncSession,
-    tmp_path: Path,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=True,
     )
-    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
-    Image.new("RGB", (640, 480), color="red").save(album_dir / media_name, "JPEG")
 
     first_replace = await client.post(
         f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": media_name},
+        data={"media_name": scenario.media_name},
         files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
     )
     assert first_replace.status_code == 200
 
     second_replace = await client.post(
         f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": media_name},
+        data={"media_name": scenario.media_name},
         files={"file": ("replacement.jpg", _jpeg_bytes(1600, 900), "image/jpeg")},
     )
     assert second_replace.status_code == 200
 
     undo_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
+        f"/api/v1/albums/{AID}/external-media/undo/{scenario.media_name}",
     )
 
     assert undo_resp.status_code == 200
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 1200
     assert row.height == 800
 
@@ -283,34 +248,32 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
 async def test_undo_replacement_restores_previous_upgrade_candidate(
     client: AsyncClient,
     session: AsyncSession,
-    tmp_path: Path,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=True,
     )
-    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
-    Image.new("RGB", (640, 480), color="red").save(album_dir / media_name, "JPEG")
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     row.upgrade_candidate = True
     session.add(row)
     await session.commit()
 
     replace_resp = await client.post(
         f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": media_name},
+        data={"media_name": scenario.media_name},
         files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
     )
     assert replace_resp.status_code == 200
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False
 
     undo_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
+        f"/api/v1/albums/{AID}/external-media/undo/{scenario.media_name}",
     )
 
     assert undo_resp.status_code == 200
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is True
 
 
@@ -318,8 +281,8 @@ async def test_google_replace_requires_one_selected_item(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    await connect_google_photos(session, uid)
+    scenario = await sign_in_with_album_media(client, session)
+    await connect_google_photos(session, scenario.uid)
 
     http = _pin_http_clients()
     http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
@@ -332,13 +295,7 @@ async def test_google_replace_requires_one_selected_item(
     ):
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={
-                "media_name": (
-                    "11111111-1111-4111-8111-111111111111_"
-                    "22222222-2222-4222-8222-222222222222.jpg"
-                ),
-                "session_id": "session-abc",
-            },
+            json={"media_name": DEFAULT_MEDIA_NAME, "session_id": "session-abc"},
         )
 
     assert resp.status_code == 400
@@ -349,8 +306,8 @@ async def test_google_replace_rejects_multiple_items_before_download(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    await connect_google_photos(session, uid)
+    scenario = await sign_in_with_album_media(client, session)
+    await connect_google_photos(session, scenario.uid)
 
     http = _pin_http_clients()
     http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
@@ -395,13 +352,7 @@ async def test_google_replace_rejects_multiple_items_before_download(
     ):
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={
-                "media_name": (
-                    "11111111-1111-4111-8111-111111111111_"
-                    "22222222-2222-4222-8222-222222222222.jpg"
-                ),
-                "session_id": "session-abc",
-            },
+            json={"media_name": DEFAULT_MEDIA_NAME, "session_id": "session-abc"},
         )
 
     assert resp.status_code == 400
@@ -413,8 +364,8 @@ async def test_google_add_validates_step_before_download(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    await connect_google_photos(session, uid)
+    scenario = await sign_in_with_album_media(client, session)
+    await connect_google_photos(session, scenario.uid)
 
     http = _pin_http_clients()
     http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
@@ -449,9 +400,9 @@ async def test_google_add_collapses_lost_token_to_disconnected(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    await connect_google_photos(session, uid)
-    user = await session.get_one(User, uid)
+    scenario = await sign_in_with_album_media(client, session)
+    await connect_google_photos(session, scenario.uid)
+    user = await session.get_one(User, scenario.uid)
     user.google_photos_refresh_token = None
     session.add(user)
     await session.commit()
@@ -474,8 +425,8 @@ async def test_google_replace_validates_media_before_download(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    await connect_google_photos(session, uid)
+    scenario = await sign_in_with_album_media(client, session)
+    await connect_google_photos(session, scenario.uid)
 
     http = _pin_http_clients()
     http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
@@ -495,13 +446,7 @@ async def test_google_replace_validates_media_before_download(
     ):
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={
-                "media_name": (
-                    "33333333-3333-4333-8333-333333333333_"
-                    "44444444-4444-4444-8444-444444444444.jpg"
-                ),
-                "session_id": "session-abc",
-            },
+            json={"media_name": MISSING_MEDIA_NAME, "session_id": "session-abc"},
         )
 
     assert resp.status_code == 404
@@ -512,13 +457,12 @@ async def test_google_replace_marks_media_upgraded(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    uid = await _signed_in_album(client, session)
-    await connect_google_photos(session, uid)
-    media_name = (
-        "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg"
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=True,
     )
-    album_dir = get_settings().USERS_FOLDER / str(uid) / "trip" / AID
-    Image.new("RGB", (640, 480), color="red").save(album_dir / media_name, "JPEG")
+    await connect_google_photos(session, scenario.uid)
 
     http = _pin_http_clients()
     http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
@@ -554,9 +498,9 @@ async def test_google_replace_marks_media_upgraded(
     ):
         resp = await client.post(
             f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={"media_name": media_name, "session_id": "session-abc"},
+            json={"media_name": scenario.media_name, "session_id": "session-abc"},
         )
 
     assert resp.status_code == 200
-    row = await session.get_one(AlbumMedia, (uid, AID, media_name))
+    row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from inspect import signature
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -23,12 +23,13 @@ from .factories import (
     AID,
     DEFAULT_MEDIA_NAME,
     MISSING_MEDIA_NAME,
+    AlbumMediaScenario,
     connect_google_photos,
     sign_in_with_album_media,
 )
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Response
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -42,6 +43,75 @@ def _pin_http_clients() -> HttpClients:
     http = _mock_http_clients()
     app.dependency_overrides[_get_http_clients] = lambda: http
     return http
+
+
+async def _google_connected_album_media(
+    client: AsyncClient,
+    session: AsyncSession,
+    *,
+    write_media: bool = False,
+) -> AlbumMediaScenario:
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        write_media=write_media,
+    )
+    await connect_google_photos(session, scenario.uid)
+    http = _pin_http_clients()
+    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
+        {"access_token": "fresh-token", "expires_in": 3600}
+    )
+    return scenario
+
+
+def _picked_item(
+    item_id: str = "google-1",
+    *,
+    filename: str = "picked.jpg",
+    base_url: str = "https://lh3.googleusercontent.com/test",
+    width: int = 1200,
+    height: int = 800,
+) -> PickedMediaItem:
+    return PickedMediaItem(
+        id=item_id,
+        create_time="2024-01-01T00:00:00Z",
+        type="PHOTO",
+        media_file=GoogleMediaFile(
+            base_url=base_url,
+            mime_type="image/jpeg",
+            filename=filename,
+            width=width,
+            height=height,
+        ),
+    )
+
+
+def _download_guard() -> tuple[
+    Callable[..., AsyncIterator[object]], Callable[[], bool]
+]:
+    downloaded = False
+
+    async def fail_if_downloaded(**_kwargs: object) -> AsyncIterator[object]:
+        nonlocal downloaded
+        downloaded = True
+        for item in ():
+            yield item
+
+    return fail_if_downloaded, lambda: downloaded
+
+
+async def _replace_device(
+    client: AsyncClient,
+    media_name: str,
+    *,
+    width: int = 1200,
+    height: int = 800,
+) -> Response:
+    return await client.post(
+        f"/api/v1/albums/{AID}/external-media/replace/device",
+        data={"media_name": media_name},
+        files={"file": ("replacement.jpg", _jpeg_bytes(width, height), "image/jpeg")},
+    )
 
 
 async def test_device_add_to_step_prepends_unused(
@@ -104,11 +174,7 @@ async def test_device_replace_updates_existing_media(
         write_media=True,
     )
 
-    resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": scenario.media_name},
-        files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
-    )
+    resp = await _replace_device(client, scenario.media_name)
 
     assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -129,11 +195,7 @@ async def test_device_replace_schedules_undo_snapshot_prune(
     with patch(
         "app.api.v1.routes.external_media.enqueue_undo_snapshot_prune",
     ) as enqueue_prune:
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/device",
-            data={"media_name": scenario.media_name},
-            files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
-        )
+        resp = await _replace_device(client, scenario.media_name)
 
     assert resp.status_code == 200
     enqueue_prune.assert_called_once()
@@ -194,11 +256,7 @@ async def test_undo_replacement_restores_previous_dimensions(
         write_media=True,
     )
 
-    replace_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": scenario.media_name},
-        files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
-    )
+    replace_resp = await _replace_device(client, scenario.media_name)
     assert replace_resp.status_code == 200
 
     undo_resp = await client.post(
@@ -221,17 +279,11 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
         write_media=True,
     )
 
-    first_replace = await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": scenario.media_name},
-        files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
-    )
+    first_replace = await _replace_device(client, scenario.media_name)
     assert first_replace.status_code == 200
 
-    second_replace = await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": scenario.media_name},
-        files={"file": ("replacement.jpg", _jpeg_bytes(1600, 900), "image/jpeg")},
+    second_replace = await _replace_device(
+        client, scenario.media_name, width=1600, height=900
     )
     assert second_replace.status_code == 200
 
@@ -259,11 +311,7 @@ async def test_undo_replacement_restores_previous_upgrade_candidate(
     session.add(row)
     await session.commit()
 
-    replace_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": scenario.media_name},
-        files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
-    )
+    replace_resp = await _replace_device(client, scenario.media_name)
     assert replace_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False
@@ -281,13 +329,7 @@ async def test_google_replace_requires_one_selected_item(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
-    await connect_google_photos(session, scenario.uid)
-
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
+    await _google_connected_album_media(client, session)
 
     with patch(
         "app.logic.external_media.operations.get_media_items",
@@ -306,37 +348,13 @@ async def test_google_replace_rejects_multiple_items_before_download(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
-    await connect_google_photos(session, scenario.uid)
-
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
+    await _google_connected_album_media(client, session)
     items = [
-        PickedMediaItem(
-            id="google-1",
-            create_time="2024-01-01T00:00:00Z",
-            type="PHOTO",
-            media_file=GoogleMediaFile(
-                base_url="https://lh3.googleusercontent.com/one",
-                mime_type="image/jpeg",
-                filename="one.jpg",
-                width=1200,
-                height=800,
-            ),
-        ),
-        PickedMediaItem(
-            id="google-2",
-            create_time="2024-01-02T00:00:00Z",
-            type="PHOTO",
-            media_file=GoogleMediaFile(
-                base_url="https://lh3.googleusercontent.com/two",
-                mime_type="image/jpeg",
-                filename="two.jpg",
-                width=1200,
-                height=800,
-            ),
+        _picked_item("google-1", filename="one.jpg"),
+        _picked_item(
+            "google-2",
+            filename="two.jpg",
+            base_url="https://lh3.googleusercontent.com/two",
         ),
     ]
 
@@ -364,20 +382,8 @@ async def test_google_add_validates_step_before_download(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
-    await connect_google_photos(session, scenario.uid)
-
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
-    downloaded = False
-
-    async def fail_if_downloaded(**_kwargs: object) -> AsyncIterator[object]:
-        nonlocal downloaded
-        downloaded = True
-        for item in ():
-            yield item
+    await _google_connected_album_media(client, session)
+    fail_if_downloaded, downloaded = _download_guard()
 
     with (
         patch(
@@ -393,15 +399,14 @@ async def test_google_add_validates_step_before_download(
 
     assert resp.status_code == 200
     assert "Step not found" in resp.text
-    assert not downloaded
+    assert not downloaded()
 
 
 async def test_google_add_collapses_lost_token_to_disconnected(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
-    await connect_google_photos(session, scenario.uid)
+    scenario = await _google_connected_album_media(client, session)
     user = await session.get_one(User, scenario.uid)
     user.google_photos_refresh_token = None
     session.add(user)
@@ -425,20 +430,8 @@ async def test_google_replace_validates_media_before_download(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
-    await connect_google_photos(session, scenario.uid)
-
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
-    downloaded = False
-
-    async def fail_if_downloaded(**_kwargs: object) -> AsyncIterator[object]:
-        nonlocal downloaded
-        downloaded = True
-        for item in ():
-            yield item
+    await _google_connected_album_media(client, session)
+    fail_if_downloaded, downloaded = _download_guard()
 
     with patch(
         "app.api.v1.routes.external_media.download_google_items_to_saved",
@@ -450,35 +443,17 @@ async def test_google_replace_validates_media_before_download(
         )
 
     assert resp.status_code == 404
-    assert not downloaded
+    assert not downloaded()
 
 
 async def test_google_replace_marks_media_upgraded(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(
+    scenario = await _google_connected_album_media(
         client,
         session,
         write_media=True,
-    )
-    await connect_google_photos(session, scenario.uid)
-
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
-    item = PickedMediaItem(
-        id="google-1",
-        create_time="2024-01-01T00:00:00Z",
-        type="PHOTO",
-        media_file=GoogleMediaFile(
-            base_url="https://lh3.googleusercontent.com/test",
-            mime_type="image/jpeg",
-            filename="picked.jpg",
-            width=1200,
-            height=800,
-        ),
     )
 
     async def fake_download(*args: object, **kwargs: object) -> None:
@@ -489,7 +464,7 @@ async def test_google_replace_marks_media_upgraded(
     with (
         patch(
             "app.logic.external_media.operations.get_media_items",
-            AsyncMock(return_value=[item]),
+            AsyncMock(return_value=[_picked_item()]),
         ),
         patch(
             "app.logic.external_media.operations.download_media_to_file",

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -26,6 +26,23 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
+async def _replace_device_ok(
+    external_media: ExternalMediaRoutes,
+    media_name: str,
+    **kwargs: int | bytes | None,
+) -> None:
+    resp = await external_media.replace_device(media_name, **kwargs)
+    assert resp.status_code == 200
+
+
+async def _undo_replacement_ok(
+    external_media: ExternalMediaRoutes,
+    media_name: str,
+) -> None:
+    resp = await external_media.undo_replacement(media_name)
+    assert resp.status_code == 200
+
+
 async def test_device_add_to_step_prepends_unused(
     session: AsyncSession,
     album_media_scenario: AlbumMediaFactory,
@@ -151,12 +168,9 @@ async def test_undo_replacement_restores_previous_dimensions(
 ) -> None:
     scenario = await album_media_scenario(write_media=True)
 
-    replace_resp = await external_media.replace_device(scenario.media_name)
-    assert replace_resp.status_code == 200
+    await _replace_device_ok(external_media, scenario.media_name)
+    await _undo_replacement_ok(external_media, scenario.media_name)
 
-    undo_resp = await external_media.undo_replacement(scenario.media_name)
-
-    assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 640
     assert row.height == 480
@@ -169,17 +183,12 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
 ) -> None:
     scenario = await album_media_scenario(write_media=True)
 
-    first_replace = await external_media.replace_device(scenario.media_name)
-    assert first_replace.status_code == 200
-
-    second_replace = await external_media.replace_device(
-        scenario.media_name, width=1600, height=900
+    await _replace_device_ok(external_media, scenario.media_name)
+    await _replace_device_ok(
+        external_media, scenario.media_name, width=1600, height=900
     )
-    assert second_replace.status_code == 200
+    await _undo_replacement_ok(external_media, scenario.media_name)
 
-    undo_resp = await external_media.undo_replacement(scenario.media_name)
-
-    assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 1200
     assert row.height == 800
@@ -196,14 +205,12 @@ async def test_undo_replacement_restores_previous_upgrade_candidate(
     session.add(row)
     await session.commit()
 
-    replace_resp = await external_media.replace_device(scenario.media_name)
-    assert replace_resp.status_code == 200
+    await _replace_device_ok(external_media, scenario.media_name)
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False
 
-    undo_resp = await external_media.undo_replacement(scenario.media_name)
+    await _undo_replacement_ok(external_media, scenario.media_name)
 
-    assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is True
 

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -114,6 +114,34 @@ async def _replace_device(
     )
 
 
+async def _undo_replacement(client: AsyncClient, media_name: str) -> Response:
+    return await client.post(
+        f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
+    )
+
+
+async def _replace_google(
+    client: AsyncClient,
+    *,
+    media_name: str = DEFAULT_MEDIA_NAME,
+    session_id: str = "session-abc",
+) -> Response:
+    return await client.post(
+        f"/api/v1/albums/{AID}/external-media/replace/google",
+        json={"media_name": media_name, "session_id": session_id},
+    )
+
+
+async def _add_google(
+    client: AsyncClient,
+    **payload: str | int,
+) -> Response:
+    return await client.post(
+        f"/api/v1/albums/{AID}/external-media/add/google",
+        json={"session_id": "session-abc", **payload},
+    )
+
+
 async def test_device_add_to_step_prepends_unused(
     client: AsyncClient,
     session: AsyncSession,
@@ -168,11 +196,7 @@ async def test_device_replace_updates_existing_media(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(
-        client,
-        session,
-        write_media=True,
-    )
+    scenario = await sign_in_with_album_media(client, session, write_media=True)
 
     resp = await _replace_device(client, scenario.media_name)
 
@@ -186,11 +210,7 @@ async def test_device_replace_schedules_undo_snapshot_prune(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(
-        client,
-        session,
-        write_media=True,
-    )
+    scenario = await sign_in_with_album_media(client, session, write_media=True)
 
     with patch(
         "app.api.v1.routes.external_media.enqueue_undo_snapshot_prune",
@@ -250,18 +270,12 @@ async def test_undo_replacement_restores_previous_dimensions(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(
-        client,
-        session,
-        write_media=True,
-    )
+    scenario = await sign_in_with_album_media(client, session, write_media=True)
 
     replace_resp = await _replace_device(client, scenario.media_name)
     assert replace_resp.status_code == 200
 
-    undo_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{scenario.media_name}",
-    )
+    undo_resp = await _undo_replacement(client, scenario.media_name)
 
     assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -273,11 +287,7 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(
-        client,
-        session,
-        write_media=True,
-    )
+    scenario = await sign_in_with_album_media(client, session, write_media=True)
 
     first_replace = await _replace_device(client, scenario.media_name)
     assert first_replace.status_code == 200
@@ -287,9 +297,7 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
     )
     assert second_replace.status_code == 200
 
-    undo_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{scenario.media_name}",
-    )
+    undo_resp = await _undo_replacement(client, scenario.media_name)
 
     assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -301,11 +309,7 @@ async def test_undo_replacement_restores_previous_upgrade_candidate(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await sign_in_with_album_media(
-        client,
-        session,
-        write_media=True,
-    )
+    scenario = await sign_in_with_album_media(client, session, write_media=True)
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     row.upgrade_candidate = True
     session.add(row)
@@ -316,9 +320,7 @@ async def test_undo_replacement_restores_previous_upgrade_candidate(
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False
 
-    undo_resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{scenario.media_name}",
-    )
+    undo_resp = await _undo_replacement(client, scenario.media_name)
 
     assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -335,10 +337,7 @@ async def test_google_replace_requires_one_selected_item(
         "app.logic.external_media.operations.get_media_items",
         AsyncMock(return_value=[]),
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={"media_name": DEFAULT_MEDIA_NAME, "session_id": "session-abc"},
-        )
+        resp = await _replace_google(client)
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Select exactly one replacement"
@@ -368,10 +367,7 @@ async def test_google_replace_rejects_multiple_items_before_download(
             AsyncMock(),
         ) as download,
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={"media_name": DEFAULT_MEDIA_NAME, "session_id": "session-abc"},
-        )
+        resp = await _replace_google(client)
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Select exactly one replacement"
@@ -392,10 +388,7 @@ async def test_google_add_validates_step_before_download(
         ),
         patch("app.api.v1.routes.external_media.get_engine", return_value=session.bind),
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/add/google",
-            json={"context": "step", "step_id": 999, "session_id": "session-abc"},
-        )
+        resp = await _add_google(client, context="step", step_id=999)
 
     assert resp.status_code == 200
     assert "Step not found" in resp.text
@@ -415,10 +408,7 @@ async def test_google_add_collapses_lost_token_to_disconnected(
     with patch(
         "app.api.v1.routes.external_media.get_engine", return_value=session.bind
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/add/google",
-            json={"context": "cover", "session_id": "session-abc"},
-        )
+        resp = await _add_google(client, context="cover")
 
     assert resp.status_code == 400
     assert "Google Photos not connected" in resp.text
@@ -437,10 +427,7 @@ async def test_google_replace_validates_media_before_download(
         "app.api.v1.routes.external_media.download_google_items_to_saved",
         fail_if_downloaded,
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={"media_name": MISSING_MEDIA_NAME, "session_id": "session-abc"},
-        )
+        resp = await _replace_google(client, media_name=MISSING_MEDIA_NAME)
 
     assert resp.status_code == 404
     assert not downloaded()
@@ -450,11 +437,7 @@ async def test_google_replace_marks_media_upgraded(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
-    scenario = await _google_connected_album_media(
-        client,
-        session,
-        write_media=True,
-    )
+    scenario = await _google_connected_album_media(client, session, write_media=True)
 
     async def fake_download(*args: object, **kwargs: object) -> None:
         dest = args[3]
@@ -471,10 +454,7 @@ async def test_google_replace_marks_media_upgraded(
             AsyncMock(side_effect=fake_download),
         ),
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/google",
-            json={"media_name": scenario.media_name, "session_id": "session-abc"},
-        )
+        resp = await _replace_google(client, media_name=scenario.media_name)
 
     assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -254,9 +254,10 @@ async def test_google_add_validates_step_before_download(
         ),
         patch("app.api.v1.routes.external_media.get_engine", return_value=session.bind),
     ):
-        text = await external_media.add_google_ok(context="step", step_id=999)
+        resp = await external_media.add_google(context="step", step_id=999)
 
-    assert "Step not found" in text
+    assert resp.status_code == 200
+    assert "Step not found" in resp.text
     assert not downloaded()
 
 
@@ -322,7 +323,8 @@ async def test_google_replace_marks_media_upgraded(
             AsyncMock(side_effect=fake_download),
         ),
     ):
-        await external_media.replace_google_ok(media_name=scenario.media_name)
+        resp = await external_media.replace_google(media_name=scenario.media_name)
 
+    assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -26,23 +26,6 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
-async def _replace_device_ok(
-    external_media: ExternalMediaRoutes,
-    media_name: str,
-    **kwargs: int | bytes | None,
-) -> None:
-    resp = await external_media.replace_device(media_name, **kwargs)
-    assert resp.status_code == 200
-
-
-async def _undo_replacement_ok(
-    external_media: ExternalMediaRoutes,
-    media_name: str,
-) -> None:
-    resp = await external_media.undo_replacement(media_name)
-    assert resp.status_code == 200
-
-
 async def test_device_add_to_step_prepends_unused(
     session: AsyncSession,
     album_media_scenario: AlbumMediaFactory,
@@ -50,10 +33,7 @@ async def test_device_add_to_step_prepends_unused(
 ) -> None:
     scenario = await album_media_scenario()
 
-    resp = await external_media.add_device(context="step", step_id=1)
-
-    assert resp.status_code == 200
-    imported = resp.json()["names"]
+    imported = (await external_media.add_device_ok(context="step", step_id=1))["names"]
     assert len(imported) == 1
 
     unused = await session.get_one(StepUnusedMedia, (scenario.uid, AID, 1, 0))
@@ -78,12 +58,11 @@ async def test_device_add_to_cover_does_not_select_cover(
 ) -> None:
     scenario = await album_media_scenario()
 
-    resp = await external_media.add_device(
-        context="cover", filename="cover.jpg", width=900, height=600
-    )
-
-    assert resp.status_code == 200
-    imported = resp.json()["names"][0]
+    imported = (
+        await external_media.add_device_ok(
+            context="cover", filename="cover.jpg", width=900, height=600
+        )
+    )["names"][0]
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, imported))
     assert row.width == 900
     assert row.height == 600
@@ -96,9 +75,8 @@ async def test_device_replace_updates_existing_media(
 ) -> None:
     scenario = await album_media_scenario(write_media=True)
 
-    resp = await external_media.replace_device(scenario.media_name)
+    await external_media.replace_device_ok(scenario.media_name)
 
-    assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 1200
     assert row.height == 800
@@ -114,9 +92,8 @@ async def test_device_replace_schedules_undo_snapshot_prune(
     with patch(
         "app.api.v1.routes.external_media.enqueue_undo_snapshot_prune",
     ) as enqueue_prune:
-        resp = await external_media.replace_device(scenario.media_name)
+        await external_media.replace_device_ok(scenario.media_name)
 
-    assert resp.status_code == 200
     enqueue_prune.assert_called_once()
     _, scheduled_uid, scheduled_aid, scheduled_dir = enqueue_prune.call_args.args
     assert (scheduled_uid, scheduled_aid, scheduled_dir) == (
@@ -168,8 +145,8 @@ async def test_undo_replacement_restores_previous_dimensions(
 ) -> None:
     scenario = await album_media_scenario(write_media=True)
 
-    await _replace_device_ok(external_media, scenario.media_name)
-    await _undo_replacement_ok(external_media, scenario.media_name)
+    await external_media.replace_device_ok(scenario.media_name)
+    await external_media.undo_replacement_ok(scenario.media_name)
 
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 640
@@ -183,11 +160,9 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
 ) -> None:
     scenario = await album_media_scenario(write_media=True)
 
-    await _replace_device_ok(external_media, scenario.media_name)
-    await _replace_device_ok(
-        external_media, scenario.media_name, width=1600, height=900
-    )
-    await _undo_replacement_ok(external_media, scenario.media_name)
+    await external_media.replace_device_ok(scenario.media_name)
+    await external_media.replace_device_ok(scenario.media_name, width=1600, height=900)
+    await external_media.undo_replacement_ok(scenario.media_name)
 
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.width == 1200
@@ -205,11 +180,11 @@ async def test_undo_replacement_restores_previous_upgrade_candidate(
     session.add(row)
     await session.commit()
 
-    await _replace_device_ok(external_media, scenario.media_name)
+    await external_media.replace_device_ok(scenario.media_name)
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False
 
-    await _undo_replacement_ok(external_media, scenario.media_name)
+    await external_media.undo_replacement_ok(scenario.media_name)
 
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is True
@@ -279,10 +254,9 @@ async def test_google_add_validates_step_before_download(
         ),
         patch("app.api.v1.routes.external_media.get_engine", return_value=session.bind),
     ):
-        resp = await external_media.add_google(context="step", step_id=999)
+        text = await external_media.add_google_ok(context="step", step_id=999)
 
-    assert resp.status_code == 200
-    assert "Step not found" in resp.text
+    assert "Step not found" in text
     assert not downloaded()
 
 
@@ -348,8 +322,7 @@ async def test_google_replace_marks_media_upgraded(
             AsyncMock(side_effect=fake_download),
         ),
     ):
-        resp = await external_media.replace_google(media_name=scenario.media_name)
+        await external_media.replace_google_ok(media_name=scenario.media_name)
 
-    assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -1,158 +1,41 @@
 from __future__ import annotations
 
-import io
-from collections.abc import AsyncIterator, Callable
 from inspect import signature
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
-from httpx_oauth.oauth2 import OAuth2Token
-from PIL import Image
-
-from app.api.v1.deps import _get_http_clients
 from app.api.v1.routes.external_media import add_google_media
-from app.core.http_clients import HttpClients
-from app.main import app
 from app.models.album_media import AlbumMedia, StepUnusedMedia
-from app.models.google_photos import GoogleMediaFile, PickedMediaItem
 from app.models.user import User
 
-from .conftest import _mock_http_clients
 from .factories import (
     AID,
     DEFAULT_MEDIA_NAME,
     MISSING_MEDIA_NAME,
-    AlbumMediaScenario,
-    connect_google_photos,
-    sign_in_with_album_media,
 )
+from .helpers.external_media import (
+    AlbumMediaFactory,
+    ExternalMediaRoutes,
+    download_guard,
+    jpeg_bytes,
+)
+from .helpers.google_photos import picked_item
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient, Response
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-
-def _jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
-    buf = io.BytesIO()
-    Image.new("RGB", (width, height), color="red").save(buf, "JPEG")
-    return buf.getvalue()
-
-
-def _pin_http_clients() -> HttpClients:
-    http = _mock_http_clients()
-    app.dependency_overrides[_get_http_clients] = lambda: http
-    return http
-
-
-async def _google_connected_album_media(
-    client: AsyncClient,
-    session: AsyncSession,
-    *,
-    write_media: bool = False,
-) -> AlbumMediaScenario:
-    scenario = await sign_in_with_album_media(
-        client,
-        session,
-        write_media=write_media,
-    )
-    await connect_google_photos(session, scenario.uid)
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
-    return scenario
-
-
-def _picked_item(
-    item_id: str = "google-1",
-    *,
-    filename: str = "picked.jpg",
-    base_url: str = "https://lh3.googleusercontent.com/test",
-    width: int = 1200,
-    height: int = 800,
-) -> PickedMediaItem:
-    return PickedMediaItem(
-        id=item_id,
-        create_time="2024-01-01T00:00:00Z",
-        type="PHOTO",
-        media_file=GoogleMediaFile(
-            base_url=base_url,
-            mime_type="image/jpeg",
-            filename=filename,
-            width=width,
-            height=height,
-        ),
-    )
-
-
-def _download_guard() -> tuple[
-    Callable[..., AsyncIterator[object]], Callable[[], bool]
-]:
-    downloaded = False
-
-    async def fail_if_downloaded(**_kwargs: object) -> AsyncIterator[object]:
-        nonlocal downloaded
-        downloaded = True
-        for item in ():
-            yield item
-
-    return fail_if_downloaded, lambda: downloaded
-
-
-async def _replace_device(
-    client: AsyncClient,
-    media_name: str,
-    *,
-    width: int = 1200,
-    height: int = 800,
-) -> Response:
-    return await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/device",
-        data={"media_name": media_name},
-        files={"file": ("replacement.jpg", _jpeg_bytes(width, height), "image/jpeg")},
-    )
-
-
-async def _undo_replacement(client: AsyncClient, media_name: str) -> Response:
-    return await client.post(
-        f"/api/v1/albums/{AID}/external-media/undo/{media_name}",
-    )
-
-
-async def _replace_google(
-    client: AsyncClient,
-    *,
-    media_name: str = DEFAULT_MEDIA_NAME,
-    session_id: str = "session-abc",
-) -> Response:
-    return await client.post(
-        f"/api/v1/albums/{AID}/external-media/replace/google",
-        json={"media_name": media_name, "session_id": session_id},
-    )
-
-
-async def _add_google(
-    client: AsyncClient,
-    **payload: str | int,
-) -> Response:
-    return await client.post(
-        f"/api/v1/albums/{AID}/external-media/add/google",
-        json={"session_id": "session-abc", **payload},
-    )
+pytest_plugins = ("tests.helpers.external_media_fixtures",)
 
 
 async def test_device_add_to_step_prepends_unused(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
+    scenario = await album_media_scenario()
 
-    resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/add/device",
-        data={"context": "step", "step_id": "1"},
-        files=[("files", ("holiday.jpg", _jpeg_bytes(), "image/jpeg"))],
-    )
+    resp = await external_media.add_device(context="step", step_id=1)
 
     assert resp.status_code == 200
     imported = resp.json()["names"]
@@ -174,15 +57,14 @@ def test_google_add_stream_route_does_not_depend_on_request_db_session() -> None
 
 
 async def test_device_add_to_cover_does_not_select_cover(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session)
+    scenario = await album_media_scenario()
 
-    resp = await client.post(
-        f"/api/v1/albums/{AID}/external-media/add/device",
-        data={"context": "cover"},
-        files=[("files", ("cover.jpg", _jpeg_bytes(900, 600), "image/jpeg"))],
+    resp = await external_media.add_device(
+        context="cover", filename="cover.jpg", width=900, height=600
     )
 
     assert resp.status_code == 200
@@ -193,12 +75,13 @@ async def test_device_add_to_cover_does_not_select_cover(
 
 
 async def test_device_replace_updates_existing_media(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session, write_media=True)
+    scenario = await album_media_scenario(write_media=True)
 
-    resp = await _replace_device(client, scenario.media_name)
+    resp = await external_media.replace_device(scenario.media_name)
 
     assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -207,15 +90,16 @@ async def test_device_replace_updates_existing_media(
 
 
 async def test_device_replace_schedules_undo_snapshot_prune(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session, write_media=True)
+    scenario = await album_media_scenario(write_media=True)
 
     with patch(
         "app.api.v1.routes.external_media.enqueue_undo_snapshot_prune",
     ) as enqueue_prune:
-        resp = await _replace_device(client, scenario.media_name)
+        resp = await external_media.replace_device(scenario.media_name)
 
     assert resp.status_code == 200
     enqueue_prune.assert_called_once()
@@ -228,19 +112,18 @@ async def test_device_replace_schedules_undo_snapshot_prune(
 
 
 async def test_device_replace_oversized_upload_returns_413(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    await sign_in_with_album_media(client, session)
+    await album_media_scenario()
 
     with patch(
         "app.api.v1.routes.external_media.save_uploads",
         AsyncMock(side_effect=OverflowError("Import is too large")),
     ):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/device",
-            data={"media_name": DEFAULT_MEDIA_NAME},
-            files={"file": ("replacement.jpg", b"too large", "image/jpeg")},
+        resp = await external_media.replace_device(
+            DEFAULT_MEDIA_NAME, content=b"too large"
         )
 
     assert resp.status_code == 413
@@ -248,18 +131,15 @@ async def test_device_replace_oversized_upload_returns_413(
 
 
 async def test_device_replace_missing_media_returns_404(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    await sign_in_with_album_media(client, session)
+    await album_media_scenario()
     save_uploads = AsyncMock(side_effect=AssertionError("should not save upload"))
 
     with patch("app.api.v1.routes.external_media.save_uploads", save_uploads):
-        resp = await client.post(
-            f"/api/v1/albums/{AID}/external-media/replace/device",
-            data={"media_name": MISSING_MEDIA_NAME},
-            files={"file": ("replacement.jpg", _jpeg_bytes(1200, 800), "image/jpeg")},
-        )
+        resp = await external_media.replace_device(MISSING_MEDIA_NAME)
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Media not found"
@@ -267,15 +147,16 @@ async def test_device_replace_missing_media_returns_404(
 
 
 async def test_undo_replacement_restores_previous_dimensions(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session, write_media=True)
+    scenario = await album_media_scenario(write_media=True)
 
-    replace_resp = await _replace_device(client, scenario.media_name)
+    replace_resp = await external_media.replace_device(scenario.media_name)
     assert replace_resp.status_code == 200
 
-    undo_resp = await _undo_replacement(client, scenario.media_name)
+    undo_resp = await external_media.undo_replacement(scenario.media_name)
 
     assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -284,20 +165,21 @@ async def test_undo_replacement_restores_previous_dimensions(
 
 
 async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session, write_media=True)
+    scenario = await album_media_scenario(write_media=True)
 
-    first_replace = await _replace_device(client, scenario.media_name)
+    first_replace = await external_media.replace_device(scenario.media_name)
     assert first_replace.status_code == 200
 
-    second_replace = await _replace_device(
-        client, scenario.media_name, width=1600, height=900
+    second_replace = await external_media.replace_device(
+        scenario.media_name, width=1600, height=900
     )
     assert second_replace.status_code == 200
 
-    undo_resp = await _undo_replacement(client, scenario.media_name)
+    undo_resp = await external_media.undo_replacement(scenario.media_name)
 
     assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -306,21 +188,22 @@ async def test_undo_after_repeated_replacement_restores_immediate_previous_file(
 
 
 async def test_undo_replacement_restores_previous_upgrade_candidate(
-    client: AsyncClient,
     session: AsyncSession,
+    album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await sign_in_with_album_media(client, session, write_media=True)
+    scenario = await album_media_scenario(write_media=True)
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     row.upgrade_candidate = True
     session.add(row)
     await session.commit()
 
-    replace_resp = await _replace_device(client, scenario.media_name)
+    replace_resp = await external_media.replace_device(scenario.media_name)
     assert replace_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
     assert row.upgrade_candidate is False
 
-    undo_resp = await _undo_replacement(client, scenario.media_name)
+    undo_resp = await external_media.undo_replacement(scenario.media_name)
 
     assert undo_resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))
@@ -328,29 +211,31 @@ async def test_undo_replacement_restores_previous_upgrade_candidate(
 
 
 async def test_google_replace_requires_one_selected_item(
-    client: AsyncClient,
     session: AsyncSession,
+    google_album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    await _google_connected_album_media(client, session)
+    await google_album_media_scenario()
 
     with patch(
         "app.logic.external_media.operations.get_media_items",
         AsyncMock(return_value=[]),
     ):
-        resp = await _replace_google(client)
+        resp = await external_media.replace_google()
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Select exactly one replacement"
 
 
 async def test_google_replace_rejects_multiple_items_before_download(
-    client: AsyncClient,
     session: AsyncSession,
+    google_album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    await _google_connected_album_media(client, session)
+    await google_album_media_scenario()
     items = [
-        _picked_item("google-1", filename="one.jpg"),
-        _picked_item(
+        picked_item("google-1", filename="one.jpg"),
+        picked_item(
             "google-2",
             filename="two.jpg",
             base_url="https://lh3.googleusercontent.com/two",
@@ -367,7 +252,7 @@ async def test_google_replace_rejects_multiple_items_before_download(
             AsyncMock(),
         ) as download,
     ):
-        resp = await _replace_google(client)
+        resp = await external_media.replace_google()
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Select exactly one replacement"
@@ -375,11 +260,12 @@ async def test_google_replace_rejects_multiple_items_before_download(
 
 
 async def test_google_add_validates_step_before_download(
-    client: AsyncClient,
     session: AsyncSession,
+    google_album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    await _google_connected_album_media(client, session)
-    fail_if_downloaded, downloaded = _download_guard()
+    await google_album_media_scenario()
+    fail_if_downloaded, downloaded = download_guard()
 
     with (
         patch(
@@ -388,7 +274,7 @@ async def test_google_add_validates_step_before_download(
         ),
         patch("app.api.v1.routes.external_media.get_engine", return_value=session.bind),
     ):
-        resp = await _add_google(client, context="step", step_id=999)
+        resp = await external_media.add_google(context="step", step_id=999)
 
     assert resp.status_code == 200
     assert "Step not found" in resp.text
@@ -396,10 +282,11 @@ async def test_google_add_validates_step_before_download(
 
 
 async def test_google_add_collapses_lost_token_to_disconnected(
-    client: AsyncClient,
     session: AsyncSession,
+    google_album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await _google_connected_album_media(client, session)
+    scenario = await google_album_media_scenario()
     user = await session.get_one(User, scenario.uid)
     user.google_photos_refresh_token = None
     session.add(user)
@@ -408,7 +295,7 @@ async def test_google_add_collapses_lost_token_to_disconnected(
     with patch(
         "app.api.v1.routes.external_media.get_engine", return_value=session.bind
     ):
-        resp = await _add_google(client, context="cover")
+        resp = await external_media.add_google(context="cover")
 
     assert resp.status_code == 400
     assert "Google Photos not connected" in resp.text
@@ -417,44 +304,46 @@ async def test_google_add_collapses_lost_token_to_disconnected(
 
 
 async def test_google_replace_validates_media_before_download(
-    client: AsyncClient,
     session: AsyncSession,
+    google_album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    await _google_connected_album_media(client, session)
-    fail_if_downloaded, downloaded = _download_guard()
+    await google_album_media_scenario()
+    fail_if_downloaded, downloaded = download_guard()
 
     with patch(
         "app.api.v1.routes.external_media.download_google_items_to_saved",
         fail_if_downloaded,
     ):
-        resp = await _replace_google(client, media_name=MISSING_MEDIA_NAME)
+        resp = await external_media.replace_google(media_name=MISSING_MEDIA_NAME)
 
     assert resp.status_code == 404
     assert not downloaded()
 
 
 async def test_google_replace_marks_media_upgraded(
-    client: AsyncClient,
     session: AsyncSession,
+    google_album_media_scenario: AlbumMediaFactory,
+    external_media: ExternalMediaRoutes,
 ) -> None:
-    scenario = await _google_connected_album_media(client, session, write_media=True)
+    scenario = await google_album_media_scenario(write_media=True)
 
     async def fake_download(*args: object, **kwargs: object) -> None:
         dest = args[3]
         assert isinstance(dest, Path)
-        dest.write_bytes(_jpeg_bytes(1200, 800))
+        dest.write_bytes(jpeg_bytes(1200, 800))
 
     with (
         patch(
             "app.logic.external_media.operations.get_media_items",
-            AsyncMock(return_value=[_picked_item()]),
+            AsyncMock(return_value=[picked_item()]),
         ),
         patch(
             "app.logic.external_media.operations.download_media_to_file",
             AsyncMock(side_effect=fake_download),
         ),
     ):
-        resp = await _replace_google(client, media_name=scenario.media_name)
+        resp = await external_media.replace_google(media_name=scenario.media_name)
 
     assert resp.status_code == 200
     row = await session.get_one(AlbumMedia, (scenario.uid, AID, scenario.media_name))

--- a/backend/tests/test_external_media_routes.py
+++ b/backend/tests/test_external_media_routes.py
@@ -25,8 +25,6 @@ from .helpers.google_photos import picked_item
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-pytest_plugins = ("tests.helpers.external_media_fixtures",)
-
 
 async def test_device_add_to_step_prepends_unused(
     session: AsyncSession,

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -12,30 +12,31 @@ from httpx_oauth.oauth2 import (
     OAuth2Token,
     RefreshTokenError,
 )
-from itsdangerous import URLSafeTimedSerializer
 
-from app.api.v1.deps import _get_http_clients
 from app.api.v1.routes.google_photos import _validate_match_names, match_media
-from app.core.config import get_settings
-from app.core.http_clients import HttpClients
 from app.logic.media_upgrade.phash_matching import MatchResult
 from app.logic.media_upgrade.pipeline import MatchCompleted, _clear_caches
-from app.main import app
 from app.models.polarsteps import Location
 from app.models.step import StepRead
 from app.models.user import User
 from app.models.weather import Weather, WeatherData
 
-from .conftest import _mock_http_clients
 from .factories import (
     sign_in_connected_google_photos,
     sign_in_uploaded_user,
+)
+from .helpers.google_photos import (
+    assert_error_redirect,
+    connected_google_photos_http,
+    oauth_callback,
+    picker_mock,
+    pin_http_clients,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from httpx import AsyncClient, Response
+    from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -43,74 +44,6 @@ if TYPE_CHECKING:
 def _clear_upgrade_caches_between_tests() -> Iterator[None]:
     yield
     _clear_caches()
-
-
-def _pin_http_clients() -> HttpClients:
-    http = _mock_http_clients()
-    app.dependency_overrides[_get_http_clients] = lambda: http
-    return http
-
-
-async def _connected_google_photos_http(
-    client: AsyncClient, session: AsyncSession
-) -> HttpClients:
-    await sign_in_connected_google_photos(client, session)
-    http = _pin_http_clients()
-    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-        {"access_token": "fresh-token", "expires_in": 3600}
-    )
-    return http
-
-
-def _picker_mock() -> AsyncMock:
-    mock_picker = AsyncMock()
-    mock_picker.return_value.id = "session-abc"
-    mock_picker.return_value.picker_uri = "https://photos.google.com/picker/abc"
-    return mock_picker
-
-
-def _build_callback_state(
-    csrf: str = "test-csrf-value",
-    nonce: str = "n-8chars",
-    redirect_uri: str = "http://test/api/v1/google-photos/callback",
-) -> str:
-    return URLSafeTimedSerializer(
-        get_settings().SECRET_KEY, salt="gphotos-oauth-state"
-    ).dumps({"csrf": csrf, "nonce": nonce, "redirect_uri": redirect_uri})
-
-
-def _build_oauth_cookie(
-    csrf: str = "test-csrf-value",
-    verifier: str = "test-verifier-value",
-) -> str:
-    return URLSafeTimedSerializer(
-        get_settings().SECRET_KEY, salt="gphotos-oauth-cookie"
-    ).dumps({"csrf": csrf, "verifier": verifier})
-
-
-async def _oauth_callback(
-    client: AsyncClient,
-    *,
-    csrf: str = "test-csrf-value",
-    cookie_csrf: str | None = "test-csrf-value",
-    verifier: str = "test-verifier-value",
-) -> Response:
-    state = _build_callback_state(csrf=csrf)
-    if cookie_csrf is not None:
-        client.cookies.set(
-            "gphotos_oauth",
-            _build_oauth_cookie(csrf=cookie_csrf, verifier=verifier),
-        )
-    return await client.get(
-        "/api/v1/google-photos/callback",
-        params={"code": "auth-code", "state": state},
-        follow_redirects=False,
-    )
-
-
-def _assert_error_redirect(resp: Response) -> None:
-    assert resp.status_code == 303
-    assert "?error" in resp.headers["location"]
 
 
 class TestRequireGoogleUser:
@@ -132,7 +65,7 @@ class TestDisconnect:
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
         uid = await sign_in_connected_google_photos(client, session)
-        _pin_http_clients()
+        pin_http_clients()
 
         resp = await client.delete("/api/v1/google-photos/connection")
         assert resp.status_code == 204
@@ -147,8 +80,8 @@ class TestPickerSession:
     async def test_create_session_calls_google_api(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        await _connected_google_photos_http(client, session)
-        mock_picker = _picker_mock()
+        await connected_google_photos_http(client, session)
+        mock_picker = picker_mock()
 
         with patch(
             "app.api.v1.routes.google_photos.create_picker_session",
@@ -164,8 +97,8 @@ class TestPickerSession:
     async def test_create_session_passes_picker_item_limit(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        http = await _connected_google_photos_http(client, session)
-        mock_picker = _picker_mock()
+        http = await connected_google_photos_http(client, session)
+        mock_picker = picker_mock()
 
         with patch(
             "app.api.v1.routes.google_photos.create_picker_session",
@@ -243,7 +176,7 @@ class TestMatchMedia:
             pages=[["photo.jpg"]],
             unused=[],
         )
-        http = _mock_http_clients()
+        http = pin_http_clients()
         http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
             {"access_token": "fresh-token", "expires_in": 3600}
         )
@@ -291,12 +224,12 @@ class TestOAuthCallback:
         user_data = await sign_in_uploaded_user(client)
         uid = user_data["id"]
 
-        http = _pin_http_clients()
+        http = pin_http_clients()
         http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
             {"refresh_token": "rt-new-123", "access_token": "at-xyz"}
         )
 
-        resp = await _oauth_callback(client)
+        resp = await oauth_callback(client)
 
         assert resp.status_code == 303
         assert "?error" not in resp.headers["location"]
@@ -321,39 +254,39 @@ class TestOAuthCallback:
     ) -> None:
         await sign_in_uploaded_user(client)
 
-        http = _pin_http_clients()
+        http = pin_http_clients()
         if side_effect is None:
             http.gphotos_oauth.get_access_token.return_value = token
         else:
             http.gphotos_oauth.get_access_token.side_effect = side_effect
 
-        resp = await _oauth_callback(client)
+        resp = await oauth_callback(client)
 
-        _assert_error_redirect(resp)
+        assert_error_redirect(resp)
 
     async def test_state_csrf_mismatch_redirects_with_error(
         self, client: AsyncClient
     ) -> None:
         await sign_in_uploaded_user(client)
 
-        resp = await _oauth_callback(
+        resp = await oauth_callback(
             client, csrf="state-csrf-B", cookie_csrf="cookie-csrf-A"
         )
 
-        _assert_error_redirect(resp)
+        assert_error_redirect(resp)
 
     async def test_passes_pkce_verifier_to_token_exchange(
         self, client: AsyncClient
     ) -> None:
         await sign_in_uploaded_user(client)
 
-        http = _pin_http_clients()
+        http = pin_http_clients()
         http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
             {"refresh_token": "rt-x", "access_token": "at-x"}
         )
 
         verifier = "test-verifier-value"
-        await _oauth_callback(client, verifier=verifier)
+        await oauth_callback(client, verifier=verifier)
 
         http.gphotos_oauth.get_access_token.assert_awaited_once()
         call = http.gphotos_oauth.get_access_token.call_args
@@ -364,7 +297,7 @@ class TestTokenRevocation:
     async def test_expired_token_returns_401(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        http = await _connected_google_photos_http(client, session)
+        http = await connected_google_photos_http(client, session)
         http.gphotos_oauth.refresh_token.side_effect = RefreshTokenError(
             "invalid_grant"
         )

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -97,10 +97,8 @@ class TestPickerSession:
             "app.api.v1.routes.google_photos.create_picker_session",
             mock_picker,
         ):
-            resp = await google_photos_routes.create_session()
+            data = await google_photos_routes.create_session_ok()
 
-        assert resp.status_code == 200
-        data = resp.json()
         assert data["session_id"] == "session-abc"
         assert "picker" in data["picker_uri"]
 
@@ -117,9 +115,8 @@ class TestPickerSession:
             "app.api.v1.routes.google_photos.create_picker_session",
             mock_picker,
         ):
-            resp = await google_photos_routes.create_session(max_item_count=1)
+            await google_photos_routes.create_session_ok(max_item_count=1)
 
-        assert resp.status_code == 200
         mock_picker.assert_awaited_once_with(
             http.gphotos_picker,
             "fresh-token",

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -35,7 +35,7 @@ from .factories import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Response
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -49,6 +49,24 @@ def _pin_http_clients() -> HttpClients:
     http = _mock_http_clients()
     app.dependency_overrides[_get_http_clients] = lambda: http
     return http
+
+
+async def _connected_google_photos_http(
+    client: AsyncClient, session: AsyncSession
+) -> HttpClients:
+    await sign_in_connected_google_photos(client, session)
+    http = _pin_http_clients()
+    http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
+        {"access_token": "fresh-token", "expires_in": 3600}
+    )
+    return http
+
+
+def _picker_mock() -> AsyncMock:
+    mock_picker = AsyncMock()
+    mock_picker.return_value.id = "session-abc"
+    mock_picker.return_value.picker_uri = "https://photos.google.com/picker/abc"
+    return mock_picker
 
 
 def _build_callback_state(
@@ -68,6 +86,31 @@ def _build_oauth_cookie(
     return URLSafeTimedSerializer(
         get_settings().SECRET_KEY, salt="gphotos-oauth-cookie"
     ).dumps({"csrf": csrf, "verifier": verifier})
+
+
+async def _oauth_callback(
+    client: AsyncClient,
+    *,
+    csrf: str = "test-csrf-value",
+    cookie_csrf: str | None = "test-csrf-value",
+    verifier: str = "test-verifier-value",
+) -> Response:
+    state = _build_callback_state(csrf=csrf)
+    if cookie_csrf is not None:
+        client.cookies.set(
+            "gphotos_oauth",
+            _build_oauth_cookie(csrf=cookie_csrf, verifier=verifier),
+        )
+    return await client.get(
+        "/api/v1/google-photos/callback",
+        params={"code": "auth-code", "state": state},
+        follow_redirects=False,
+    )
+
+
+def _assert_error_redirect(resp: Response) -> None:
+    assert resp.status_code == 303
+    assert "?error" in resp.headers["location"]
 
 
 class TestRequireGoogleUser:
@@ -104,14 +147,8 @@ class TestPickerSession:
     async def test_create_session_calls_google_api(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        await sign_in_connected_google_photos(client, session)
-        http = _pin_http_clients()
-        http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-            {"access_token": "fresh-token", "expires_in": 3600}
-        )
-        mock_picker = AsyncMock()
-        mock_picker.return_value.id = "session-abc"
-        mock_picker.return_value.picker_uri = "https://photos.google.com/picker/abc"
+        await _connected_google_photos_http(client, session)
+        mock_picker = _picker_mock()
 
         with patch(
             "app.api.v1.routes.google_photos.create_picker_session",
@@ -127,14 +164,8 @@ class TestPickerSession:
     async def test_create_session_passes_picker_item_limit(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        await sign_in_connected_google_photos(client, session)
-        http = _pin_http_clients()
-        http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
-            {"access_token": "fresh-token", "expires_in": 3600}
-        )
-        mock_picker = AsyncMock()
-        mock_picker.return_value.id = "session-abc"
-        mock_picker.return_value.picker_uri = "https://photos.google.com/picker/abc"
+        http = await _connected_google_photos_http(client, session)
+        mock_picker = _picker_mock()
 
         with patch(
             "app.api.v1.routes.google_photos.create_picker_session",
@@ -155,21 +186,29 @@ class TestValidateMatchNames:
         matches = [MatchResult(local_name="photo1.jpg", google_id="gid-1", distance=0)]
         _validate_match_names(matches, {"photo1.jpg", "photo2.jpg"})
 
-    def test_rejects_unknown_name(self) -> None:
-        matches = [MatchResult(local_name="unknown.jpg", google_id="gid-1", distance=0)]
+    @pytest.mark.parametrize(
+        ("matches", "detail"),
+        [
+            (
+                [MatchResult(local_name="unknown.jpg", google_id="gid-1", distance=0)],
+                "unknown.jpg",
+            ),
+            (
+                [
+                    MatchResult(local_name="photo1.jpg", google_id="gid-1", distance=0),
+                    MatchResult(local_name="evil.jpg", google_id="gid-2", distance=0),
+                ],
+                "evil.jpg",
+            ),
+        ],
+    )
+    def test_rejects_unknown_name(
+        self, matches: list[MatchResult], detail: str
+    ) -> None:
         with pytest.raises(HTTPException) as exc_info:
             _validate_match_names(matches, {"photo1.jpg"})
         assert exc_info.value.status_code == 422
-
-    def test_rejects_if_any_name_invalid(self) -> None:
-        matches = [
-            MatchResult(local_name="photo1.jpg", google_id="gid-1", distance=0),
-            MatchResult(local_name="evil.jpg", google_id="gid-2", distance=0),
-        ]
-        with pytest.raises(HTTPException) as exc_info:
-            _validate_match_names(matches, {"photo1.jpg"})
-        assert exc_info.value.status_code == 422
-        assert "evil.jpg" in str(exc_info.value.detail)
+        assert detail in str(exc_info.value.detail)
 
 
 class TestMatchMedia:
@@ -257,14 +296,7 @@ class TestOAuthCallback:
             {"refresh_token": "rt-new-123", "access_token": "at-xyz"}
         )
 
-        csrf = "test-csrf-value"
-        state = _build_callback_state(csrf=csrf)
-        client.cookies.set("gphotos_oauth", _build_oauth_cookie(csrf=csrf))
-        resp = await client.get(
-            "/api/v1/google-photos/callback",
-            params={"code": "auth-code", "state": state},
-            follow_redirects=False,
-        )
+        resp = await _oauth_callback(client)
 
         assert resp.status_code == 303
         assert "?error" not in resp.headers["location"]
@@ -274,63 +306,41 @@ class TestOAuthCallback:
         assert user.google_photos_refresh_token is not None
         assert user.google_photos_connected_at is not None
 
-    async def test_oauth_error_redirects_with_error(self, client: AsyncClient) -> None:
-        await sign_in_uploaded_user(client)
-
-        http = _pin_http_clients()
-        http.gphotos_oauth.get_access_token.side_effect = GetAccessTokenError(
-            "access_denied"
-        )
-
-        csrf = "test-csrf-value"
-        state = _build_callback_state(csrf=csrf)
-        client.cookies.set("gphotos_oauth", _build_oauth_cookie(csrf=csrf))
-        resp = await client.get(
-            "/api/v1/google-photos/callback",
-            params={"code": "auth-code", "state": state},
-            follow_redirects=False,
-        )
-
-        assert resp.status_code == 303
-        assert "?error" in resp.headers["location"]
-
-    async def test_no_refresh_token_redirects_with_error(
-        self, client: AsyncClient
+    @pytest.mark.parametrize(
+        ("token", "side_effect"),
+        [
+            (None, GetAccessTokenError("access_denied")),
+            (OAuth2Token({"access_token": "at-xyz"}), None),
+        ],
+    )
+    async def test_token_exchange_failure_redirects_with_error(
+        self,
+        client: AsyncClient,
+        token: OAuth2Token | None,
+        side_effect: Exception | None,
     ) -> None:
         await sign_in_uploaded_user(client)
 
         http = _pin_http_clients()
-        http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
-            {"access_token": "at-xyz"}  # no refresh_token
-        )
+        if side_effect is None:
+            http.gphotos_oauth.get_access_token.return_value = token
+        else:
+            http.gphotos_oauth.get_access_token.side_effect = side_effect
 
-        csrf = "test-csrf-value"
-        state = _build_callback_state(csrf=csrf)
-        client.cookies.set("gphotos_oauth", _build_oauth_cookie(csrf=csrf))
-        resp = await client.get(
-            "/api/v1/google-photos/callback",
-            params={"code": "auth-code", "state": state},
-            follow_redirects=False,
-        )
+        resp = await _oauth_callback(client)
 
-        assert resp.status_code == 303
-        assert "?error" in resp.headers["location"]
+        _assert_error_redirect(resp)
 
     async def test_state_csrf_mismatch_redirects_with_error(
         self, client: AsyncClient
     ) -> None:
         await sign_in_uploaded_user(client)
 
-        client.cookies.set("gphotos_oauth", _build_oauth_cookie(csrf="cookie-csrf-A"))
-        state = _build_callback_state(csrf="state-csrf-B")
-        resp = await client.get(
-            "/api/v1/google-photos/callback",
-            params={"code": "auth-code", "state": state},
-            follow_redirects=False,
+        resp = await _oauth_callback(
+            client, csrf="state-csrf-B", cookie_csrf="cookie-csrf-A"
         )
 
-        assert resp.status_code == 303
-        assert "?error" in resp.headers["location"]
+        _assert_error_redirect(resp)
 
     async def test_passes_pkce_verifier_to_token_exchange(
         self, client: AsyncClient
@@ -342,17 +352,8 @@ class TestOAuthCallback:
             {"refresh_token": "rt-x", "access_token": "at-x"}
         )
 
-        csrf = "test-csrf-value"
         verifier = "test-verifier-value"
-        state = _build_callback_state(csrf=csrf)
-        client.cookies.set(
-            "gphotos_oauth", _build_oauth_cookie(csrf=csrf, verifier=verifier)
-        )
-        await client.get(
-            "/api/v1/google-photos/callback",
-            params={"code": "auth-code", "state": state},
-            follow_redirects=False,
-        )
+        await _oauth_callback(client, verifier=verifier)
 
         http.gphotos_oauth.get_access_token.assert_awaited_once()
         call = http.gphotos_oauth.get_access_token.call_args
@@ -363,8 +364,7 @@ class TestTokenRevocation:
     async def test_expired_token_returns_401(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        await sign_in_connected_google_photos(client, session)
-        http = _pin_http_clients()
+        http = await _connected_google_photos_http(client, session)
         http.gphotos_oauth.refresh_token.side_effect = RefreshTokenError(
             "invalid_grant"
         )

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -56,10 +56,10 @@ class TestRequireGoogleUser:
         resp = await google_photos_routes.create_session()
         assert resp.status_code == 403
 
+    @pytest.mark.usefixtures("uploaded_user")
     async def test_google_user_without_connection_gets_400(
-        self, client: AsyncClient, google_photos_routes: GooglePhotosRoutes
+        self, google_photos_routes: GooglePhotosRoutes
     ) -> None:
-        await sign_in_uploaded_user(client)
         resp = await google_photos_routes.create_session()
         assert resp.status_code == 400
 
@@ -232,11 +232,8 @@ class TestMatchMedia:
 
 class TestOAuthCallback:
     async def test_success_stores_refresh_token(
-        self, client: AsyncClient, session: AsyncSession
+        self, client: AsyncClient, session: AsyncSession, uploaded_user: dict
     ) -> None:
-        user_data = await sign_in_uploaded_user(client)
-        uid = user_data["id"]
-
         http = pin_http_clients()
         http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
             {"refresh_token": "rt-new-123", "access_token": "at-xyz"}
@@ -247,11 +244,12 @@ class TestOAuthCallback:
         assert resp.status_code == 303
         assert "?error" not in resp.headers["location"]
 
-        user = await session.get(User, uid)
+        user = await session.get(User, uploaded_user["id"])
         assert user is not None
         assert user.google_photos_refresh_token is not None
         assert user.google_photos_connected_at is not None
 
+    @pytest.mark.usefixtures("uploaded_user")
     @pytest.mark.parametrize(
         ("token", "side_effect"),
         [
@@ -265,8 +263,6 @@ class TestOAuthCallback:
         token: OAuth2Token | None,
         side_effect: Exception | None,
     ) -> None:
-        await sign_in_uploaded_user(client)
-
         http = pin_http_clients()
         if side_effect is None:
             http.gphotos_oauth.get_access_token.return_value = token
@@ -277,22 +273,20 @@ class TestOAuthCallback:
 
         assert_error_redirect(resp)
 
+    @pytest.mark.usefixtures("uploaded_user")
     async def test_state_csrf_mismatch_redirects_with_error(
         self, client: AsyncClient
     ) -> None:
-        await sign_in_uploaded_user(client)
-
         resp = await oauth_callback(
             client, csrf="state-csrf-B", cookie_csrf="cookie-csrf-A"
         )
 
         assert_error_redirect(resp)
 
+    @pytest.mark.usefixtures("uploaded_user")
     async def test_passes_pkce_verifier_to_token_exchange(
         self, client: AsyncClient
     ) -> None:
-        await sign_in_uploaded_user(client)
-
         http = pin_http_clients()
         http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
             {"refresh_token": "rt-x", "access_token": "at-x"}

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -1,10 +1,3 @@
-"""Integration tests for Google Photos routes.
-
-Tests auth gating, disconnect, and edge cases. The full upgrade flow
-requires mocking the Google Picker API extensively, which is best tested
-E2E. The matching algorithm is covered in test_media_upgrade.py.
-"""
-
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
@@ -35,8 +28,8 @@ from app.models.weather import Weather, WeatherData
 
 from .conftest import _mock_http_clients
 from .factories import (
-    connect_google_photos,
-    sign_in_and_upload,
+    sign_in_connected_google_photos,
+    sign_in_uploaded_user,
 )
 
 if TYPE_CHECKING:
@@ -48,18 +41,11 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def _clear_upgrade_caches_between_tests() -> Iterator[None]:
-    """Reset the event-loop-bound semaphore cache between tests."""
     yield
     _clear_caches()
 
 
 def _pin_http_clients() -> HttpClients:
-    """Return (and install) a pinned HttpClients that survives across requests.
-
-    The default conftest override constructs a fresh mock per request, which
-    loses any state the test sets up. Pin one instance so configuring
-    ``http.gphotos_oauth.*`` is visible to the route handler.
-    """
     http = _mock_http_clients()
     app.dependency_overrides[_get_http_clients] = lambda: http
     return http
@@ -86,22 +72,14 @@ def _build_oauth_cookie(
 
 class TestRequireGoogleUser:
     async def test_microsoft_user_gets_403(self, client: AsyncClient) -> None:
-        """Microsoft-authed users cannot access Google Photos endpoints."""
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        await sign_in_and_upload(client, users_dir, provider="microsoft")
+        await sign_in_uploaded_user(client, provider="microsoft")
         resp = await client.post("/api/v1/google-photos/sessions")
         assert resp.status_code == 403
 
     async def test_google_user_without_connection_gets_400(
         self, client: AsyncClient
     ) -> None:
-        """Google user without Photos connected gets 400 on session create."""
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        await sign_in_and_upload(client, users_dir, provider="google")
+        await sign_in_uploaded_user(client)
         resp = await client.post("/api/v1/google-photos/sessions")
         assert resp.status_code == 400
 
@@ -110,14 +88,8 @@ class TestDisconnect:
     async def test_disconnect_clears_tokens(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        user_data = await sign_in_and_upload(client, users_dir, provider="google")
-        uid = user_data["id"]
-
-        await connect_google_photos(session, uid)
-        _pin_http_clients()  # disconnect calls revoke_token on the mock
+        uid = await sign_in_connected_google_photos(client, session)
+        _pin_http_clients()
 
         resp = await client.delete("/api/v1/google-photos/connection")
         assert resp.status_code == 204
@@ -132,13 +104,7 @@ class TestPickerSession:
     async def test_create_session_calls_google_api(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        user_data = await sign_in_and_upload(client, users_dir, provider="google")
-        uid = user_data["id"]
-        await connect_google_photos(session, uid)
-
+        await sign_in_connected_google_photos(client, session)
         http = _pin_http_clients()
         http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
             {"access_token": "fresh-token", "expires_in": 3600}
@@ -161,13 +127,7 @@ class TestPickerSession:
     async def test_create_session_passes_picker_item_limit(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        user_data = await sign_in_and_upload(client, users_dir, provider="google")
-        uid = user_data["id"]
-        await connect_google_photos(session, uid)
-
+        await sign_in_connected_google_photos(client, session)
         http = _pin_http_clients()
         http.gphotos_oauth.refresh_token.return_value = OAuth2Token(
             {"access_token": "fresh-token", "expires_in": 3600}
@@ -289,10 +249,7 @@ class TestOAuthCallback:
     async def test_success_stores_refresh_token(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        user_data = await sign_in_and_upload(client, users_dir, provider="google")
+        user_data = await sign_in_uploaded_user(client)
         uid = user_data["id"]
 
         http = _pin_http_clients()
@@ -318,10 +275,7 @@ class TestOAuthCallback:
         assert user.google_photos_connected_at is not None
 
     async def test_oauth_error_redirects_with_error(self, client: AsyncClient) -> None:
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        await sign_in_and_upload(client, users_dir, provider="google")
+        await sign_in_uploaded_user(client)
 
         http = _pin_http_clients()
         http.gphotos_oauth.get_access_token.side_effect = GetAccessTokenError(
@@ -343,10 +297,7 @@ class TestOAuthCallback:
     async def test_no_refresh_token_redirects_with_error(
         self, client: AsyncClient
     ) -> None:
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        await sign_in_and_upload(client, users_dir, provider="google")
+        await sign_in_uploaded_user(client)
 
         http = _pin_http_clients()
         http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
@@ -368,19 +319,10 @@ class TestOAuthCallback:
     async def test_state_csrf_mismatch_redirects_with_error(
         self, client: AsyncClient
     ) -> None:
-        """Regression: cookie CSRF that disagrees with the signed state is rejected.
-
-        This is the guarantee of the double-submit pattern - catches an
-        attacker who can forge the state query param but cannot plant the
-        matching HttpOnly cookie.
-        """
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        await sign_in_and_upload(client, users_dir, provider="google")
+        await sign_in_uploaded_user(client)
 
         client.cookies.set("gphotos_oauth", _build_oauth_cookie(csrf="cookie-csrf-A"))
-        state = _build_callback_state(csrf="state-csrf-B")  # mismatched
+        state = _build_callback_state(csrf="state-csrf-B")
         resp = await client.get(
             "/api/v1/google-photos/callback",
             params={"code": "auth-code", "state": state},
@@ -393,15 +335,7 @@ class TestOAuthCallback:
     async def test_passes_pkce_verifier_to_token_exchange(
         self, client: AsyncClient
     ) -> None:
-        """Regression: the cookie's PKCE verifier is forwarded to Google.
-
-        Without this, the authorize-side code_challenge has no counterpart
-        at token exchange and Google rejects the flow.
-        """
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        await sign_in_and_upload(client, users_dir, provider="google")
+        await sign_in_uploaded_user(client)
 
         http = _pin_http_clients()
         http.gphotos_oauth.get_access_token.return_value = OAuth2Token(
@@ -429,14 +363,7 @@ class TestTokenRevocation:
     async def test_expired_token_returns_401(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        """User with revoked token gets 401 on session create."""
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        user_data = await sign_in_and_upload(client, users_dir, provider="google")
-        uid = user_data["id"]
-        await connect_google_photos(session, uid)
-
+        await sign_in_connected_google_photos(client, session)
         http = _pin_http_clients()
         http.gphotos_oauth.refresh_token.side_effect = RefreshTokenError(
             "invalid_grant"
@@ -451,18 +378,7 @@ class TestTokenLostSelfHeal:
     async def test_token_lost_collapses_to_disconnected(
         self, client: AsyncClient, session: AsyncSession
     ) -> None:
-        """Regression: connected_at set + refresh_token=None heals to disconnected.
-
-        Happens when SECRET_KEY rotates and EncryptedString can no longer
-        decrypt the stored ciphertext. The self-heal lives in ``_get_user``
-        so any authed request collapses the state at a single point.
-        """
-        users_dir = get_settings().USERS_FOLDER
-        users_dir.mkdir(parents=True, exist_ok=True)
-
-        user_data = await sign_in_and_upload(client, users_dir, provider="google")
-        uid = user_data["id"]
-        await connect_google_photos(session, uid)
+        uid = await sign_in_connected_google_photos(client, session)
 
         user = await session.get(User, uid)
         assert user is not None

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -16,12 +16,12 @@ from httpx_oauth.oauth2 import (
 from app.api.v1.routes.google_photos import _validate_match_names, match_media
 from app.logic.media_upgrade.phash_matching import MatchResult
 from app.logic.media_upgrade.pipeline import MatchCompleted, _clear_caches
-from app.models.polarsteps import Location
-from app.models.step import StepRead
 from app.models.user import User
-from app.models.weather import Weather, WeatherData
 
 from .factories import (
+    make_step_read,
+    make_user,
+    make_weather,
     sign_in_connected_google_photos,
     sign_in_uploaded_user,
 )
@@ -159,35 +159,19 @@ class TestValidateMatchNames:
 
 class TestMatchMedia:
     async def test_keeps_non_candidate_media_in_match_set(self) -> None:
-        user = User(
-            id=1,
-            first_name="Test",
-            locale="en-US",
-            unit_is_km=True,
-            temperature_is_celsius=True,
+        user = make_user(
+            1,
             google_sub="sub",
-            google_photos_refresh_token="refresh-token",  # noqa: S106
-            google_photos_connected_at=datetime.now(UTC),
         )
-        step = StepRead(
-            uid=1,
-            aid="trip-1",
-            id=7,
+        user.google_photos_refresh_token = "refresh-token"  # noqa: S105
+        user.google_photos_connected_at = datetime.now(UTC)
+        step = make_step_read(
+            step_id=7,
             name="Step",
             description="",
-            timestamp=1_700_000_000.0,
             timezone_id="UTC",
-            location=Location(
-                name="Place", detail="", country_code="nl", lat=52.0, lon=4.0
-            ),
-            elevation=0,
-            weather=Weather(
-                day=WeatherData(temp=20.0, feels_like=18.0, icon="clear"),
-                night=None,
-            ),
-            cover=None,
+            weather=make_weather(icon="clear"),
             pages=[["photo.jpg"]],
-            unused=[],
         )
         http = pin_http_clients()
         http.gphotos_oauth.refresh_token.return_value = OAuth2Token(

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -316,9 +316,7 @@ class TestTokenLostSelfHeal:
         session.add(user)
         await session.flush()
 
-        resp = await user_routes.current()
-        assert resp.status_code == 200
-        assert resp.json()["google_photos_connected_at"] is None
+        assert (await user_routes.current_ok())["google_photos_connected_at"] is None
 
         await session.refresh(user)
         assert user.google_photos_connected_at is None

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -26,12 +26,14 @@ from .factories import (
     sign_in_uploaded_user,
 )
 from .helpers.google_photos import (
+    GooglePhotosRoutes,
     assert_error_redirect,
     connected_google_photos_http,
     oauth_callback,
     picker_mock,
     pin_http_clients,
 )
+from .helpers.users import UserRoutes
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -47,27 +49,32 @@ def _clear_upgrade_caches_between_tests() -> Iterator[None]:
 
 
 class TestRequireGoogleUser:
-    async def test_microsoft_user_gets_403(self, client: AsyncClient) -> None:
+    async def test_microsoft_user_gets_403(
+        self, client: AsyncClient, google_photos_routes: GooglePhotosRoutes
+    ) -> None:
         await sign_in_uploaded_user(client, provider="microsoft")
-        resp = await client.post("/api/v1/google-photos/sessions")
+        resp = await google_photos_routes.create_session()
         assert resp.status_code == 403
 
     async def test_google_user_without_connection_gets_400(
-        self, client: AsyncClient
+        self, client: AsyncClient, google_photos_routes: GooglePhotosRoutes
     ) -> None:
         await sign_in_uploaded_user(client)
-        resp = await client.post("/api/v1/google-photos/sessions")
+        resp = await google_photos_routes.create_session()
         assert resp.status_code == 400
 
 
 class TestDisconnect:
     async def test_disconnect_clears_tokens(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        google_photos_routes: GooglePhotosRoutes,
     ) -> None:
         uid = await sign_in_connected_google_photos(client, session)
         pin_http_clients()
 
-        resp = await client.delete("/api/v1/google-photos/connection")
+        resp = await google_photos_routes.disconnect()
         assert resp.status_code == 204
 
         user = await session.get(User, uid)
@@ -78,7 +85,10 @@ class TestDisconnect:
 
 class TestPickerSession:
     async def test_create_session_calls_google_api(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        google_photos_routes: GooglePhotosRoutes,
     ) -> None:
         await connected_google_photos_http(client, session)
         mock_picker = picker_mock()
@@ -87,7 +97,7 @@ class TestPickerSession:
             "app.api.v1.routes.google_photos.create_picker_session",
             mock_picker,
         ):
-            resp = await client.post("/api/v1/google-photos/sessions")
+            resp = await google_photos_routes.create_session()
 
         assert resp.status_code == 200
         data = resp.json()
@@ -95,7 +105,10 @@ class TestPickerSession:
         assert "picker" in data["picker_uri"]
 
     async def test_create_session_passes_picker_item_limit(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        google_photos_routes: GooglePhotosRoutes,
     ) -> None:
         http = await connected_google_photos_http(client, session)
         mock_picker = picker_mock()
@@ -104,7 +117,7 @@ class TestPickerSession:
             "app.api.v1.routes.google_photos.create_picker_session",
             mock_picker,
         ):
-            resp = await client.post("/api/v1/google-photos/sessions?max_item_count=1")
+            resp = await google_photos_routes.create_session(max_item_count=1)
 
         assert resp.status_code == 200
         mock_picker.assert_awaited_once_with(
@@ -295,21 +308,27 @@ class TestOAuthCallback:
 
 class TestTokenRevocation:
     async def test_expired_token_returns_401(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        google_photos_routes: GooglePhotosRoutes,
     ) -> None:
         http = await connected_google_photos_http(client, session)
         http.gphotos_oauth.refresh_token.side_effect = RefreshTokenError(
             "invalid_grant"
         )
 
-        resp = await client.post("/api/v1/google-photos/sessions")
+        resp = await google_photos_routes.create_session()
 
         assert resp.status_code == 401
 
 
 class TestTokenLostSelfHeal:
     async def test_token_lost_collapses_to_disconnected(
-        self, client: AsyncClient, session: AsyncSession
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        user_routes: UserRoutes,
     ) -> None:
         uid = await sign_in_connected_google_photos(client, session)
 
@@ -319,7 +338,7 @@ class TestTokenLostSelfHeal:
         session.add(user)
         await session.flush()
 
-        resp = await client.get("/api/v1/users")
+        resp = await user_routes.current()
         assert resp.status_code == 200
         assert resp.json()["google_photos_connected_at"] is None
 

--- a/backend/tests/test_google_photos_service.py
+++ b/backend/tests/test_google_photos_service.py
@@ -104,10 +104,16 @@ def _json_response(data: dict, status_code: int = 200) -> httpx.Response:
     )
 
 
+def _client_with(**responses: httpx.Response) -> AsyncMock:
+    client = AsyncMock()
+    for method, response in responses.items():
+        getattr(client, method).return_value = response
+    return client
+
+
 class TestCreatePickerSession:
     async def test_maps_response_to_domain_model(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.post.return_value = _json_response(_SESSION_JSON)
+        mock_client = _client_with(post=_json_response(_SESSION_JSON))
 
         session = await create_picker_session(mock_client, "test-token")
 
@@ -117,10 +123,10 @@ class TestCreatePickerSession:
         assert session.polling_interval == "5s"
 
     async def test_propagates_http_error(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.post.return_value = httpx.Response(
+        error = httpx.Response(
             500, request=httpx.Request("POST", "http://test"), content=b"error"
         )
+        mock_client = _client_with(post=error)
 
         with pytest.raises(httpx.HTTPStatusError):
             await create_picker_session(mock_client, "test-token")
@@ -129,9 +135,7 @@ class TestCreatePickerSession:
 class TestGetMediaItems:
     async def test_single_page(self) -> None:
         page_json = {"mediaItems": [_MEDIA_ITEM_JSON]}
-
-        mock_client = AsyncMock()
-        mock_client.get.return_value = _json_response(page_json)
+        mock_client = _client_with(get=_json_response(page_json))
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -160,8 +164,7 @@ class TestGetMediaItems:
         assert second_call_params.get("pageToken") == "page-2"
 
     async def test_empty_response(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.get.return_value = _json_response({})
+        mock_client = _client_with(get=_json_response({}))
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -169,8 +172,7 @@ class TestGetMediaItems:
 
     async def test_video_items_preserved(self) -> None:
         video = {**_MEDIA_ITEM_JSON, "id": "vid-1", "type": "VIDEO"}
-        mock_client = AsyncMock()
-        mock_client.get.return_value = _json_response({"mediaItems": [video]})
+        mock_client = _client_with(get=_json_response({"mediaItems": [video]}))
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -178,9 +180,8 @@ class TestGetMediaItems:
         assert items[0].type == "VIDEO"
 
     async def test_video_processing_status_surfaced(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.get.return_value = _json_response(
-            {"mediaItems": [_VIDEO_ITEM_JSON]}
+        mock_client = _client_with(
+            get=_json_response({"mediaItems": [_VIDEO_ITEM_JSON]})
         )
 
         items = await get_media_items(mock_client, "session-1", "token-1")

--- a/backend/tests/test_google_photos_service.py
+++ b/backend/tests/test_google_photos_service.py
@@ -1,9 +1,3 @@
-"""Tests for app.services.google_photos - Pydantic parsing and pagination.
-
-Tests the API contract boundary: camelCase Google JSON -> domain models.
-Uses real httpx.Response objects so Pydantic parsing runs end-to-end.
-"""
-
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -29,15 +23,11 @@ from app.services.google_photos import (
     get_media_items,
 )
 
-# ---------------------------------------------------------------------------
-# Fixtures: realistic Google API JSON (camelCase, extra fields)
-# ---------------------------------------------------------------------------
-
 _SESSION_JSON = {
     "id": "session-xyz",
     "pickerUri": "https://photos.google.com/picker/abc",
     "pollingConfig": {"pollInterval": "5s"},
-    "expireTime": "2025-01-01T00:00:00Z",  # extra field we don't model
+    "expireTime": "2025-01-01T00:00:00Z",
     "mediaItemsSet": False,
 }
 
@@ -72,11 +62,6 @@ _VIDEO_ITEM_JSON = {
 }
 
 
-# ---------------------------------------------------------------------------
-# Response parsing (Pydantic camelCase -> snake_case)
-# ---------------------------------------------------------------------------
-
-
 class TestResponseParsing:
     def test_session_response_parses_camel_case(self) -> None:
         data = _SessionResponse.model_validate(_SESSION_JSON)
@@ -85,11 +70,6 @@ class TestResponseParsing:
         assert data.polling_config is not None
         assert data.polling_config.poll_interval == "5s"
         assert data.media_items_set is False
-
-    def test_session_response_ignores_extra_fields(self) -> None:
-        """Google may add fields; extra='allow' prevents breakage."""
-        data = _SessionResponse.model_validate(_SESSION_JSON)
-        assert data.id == "session-xyz"  # core fields still parsed
 
     def test_media_items_page_parses_items(self) -> None:
         raw = {"mediaItems": [_MEDIA_ITEM_JSON], "nextPageToken": "tok-2"}
@@ -113,11 +93,6 @@ class TestResponseParsing:
         page = _MediaItemsPage.model_validate({"mediaItems": [raw]})
         item = page.media_items[0]
         assert item.media_file.media_file_metadata is None
-
-
-# ---------------------------------------------------------------------------
-# Service function tests (mock HTTP, test logic + parsing end-to-end)
-# ---------------------------------------------------------------------------
 
 
 _DUMMY_REQUEST = httpx.Request("GET", "http://test")
@@ -181,7 +156,6 @@ class TestGetMediaItems:
         assert len(items) == 2
         assert items[0].id == "media-1"
         assert items[1].id == "media-2"
-        # Verify page token was passed on second call
         second_call_params = mock_client.get.call_args_list[1].kwargs.get("params", {})
         assert second_call_params.get("pageToken") == "page-2"
 
@@ -194,7 +168,6 @@ class TestGetMediaItems:
         assert items == []
 
     async def test_video_items_preserved(self) -> None:
-        """get_media_items returns all types; filtering is done later."""
         video = {**_MEDIA_ITEM_JSON, "id": "vid-1", "type": "VIDEO"}
         mock_client = AsyncMock()
         mock_client.get.return_value = _json_response({"mediaItems": [video]})
@@ -218,14 +191,10 @@ class TestGetMediaItems:
 
 
 class TestVideoMetadataParsing:
-    def test_video_processing_status_parsed(self) -> None:
-        page = _MediaItemsPage.model_validate({"mediaItems": [_VIDEO_ITEM_JSON]})
-        assert page.media_items[0].type == "VIDEO"
-
     def test_video_processing_status_surfaced_on_picked_item(self) -> None:
-        """get_media_items should surface processingStatus on PickedMediaItem."""
         page = _MediaItemsPage.model_validate({"mediaItems": [_VIDEO_ITEM_JSON]})
         raw = page.media_items[0]
+        assert raw.type == "VIDEO"
         assert raw.video_metadata is not None
         assert raw.video_metadata.processing_status == "READY"
 
@@ -233,11 +202,6 @@ class TestVideoMetadataParsing:
         page = _MediaItemsPage.model_validate({"mediaItems": [_MEDIA_ITEM_JSON]})
         raw = page.media_items[0]
         assert raw.video_metadata is None
-
-
-# ---------------------------------------------------------------------------
-# ensure_fresh_token
-# ---------------------------------------------------------------------------
 
 
 def _oauth_mock(refresh_return: OAuth2Token | None = None) -> AsyncMock:
@@ -249,7 +213,6 @@ def _oauth_mock(refresh_return: OAuth2Token | None = None) -> AsyncMock:
 
 class TestEnsureFreshToken:
     async def test_returns_input_when_fresh(self) -> None:
-        """A non-expired token is returned unchanged - no network call."""
         fresh = OAuth2Token({"access_token": "tok-fresh", "expires_in": 3600})
         oauth = _oauth_mock()
         result = await ensure_fresh_token(oauth, "rt-1", fresh)
@@ -257,15 +220,12 @@ class TestEnsureFreshToken:
         oauth.refresh_token.assert_not_called()
 
     async def test_refreshes_when_stale_or_none(self) -> None:
-        """None or near-expiry tokens trigger the refresh grant."""
         new = OAuth2Token({"access_token": "tok-new", "expires_in": 3600})
         oauth = _oauth_mock(refresh_return=new)
 
-        # Case: no prior token.
         result = await ensure_fresh_token(oauth, "rt-1", None)
         assert result is new
 
-        # Case: prior token already expired (expires_in=0 -> past).
         stale = OAuth2Token({"access_token": "tok-stale", "expires_in": 0})
         result = await ensure_fresh_token(oauth, "rt-1", stale)
         assert result is new
@@ -278,10 +238,6 @@ class TestEnsureFreshToken:
             await ensure_fresh_token(oauth, "rt-bad", None)
 
 
-# ---------------------------------------------------------------------------
-# Download size limits and cleanup
-# ---------------------------------------------------------------------------
-
 _BASE_URL = "https://lh3.googleusercontent.com/test"
 _TOKEN = "ya29.test"  # noqa: S105
 
@@ -289,7 +245,6 @@ _TOKEN = "ya29.test"  # noqa: S105
 def _streaming_client(
     chunks: list[bytes], headers: dict[str, str] | None = None
 ) -> AsyncMock:
-    """Build a mock httpx.AsyncClient whose .stream() yields the given chunks."""
     resp = AsyncMock()
     resp.raise_for_status = lambda: None
     resp.headers = headers or {}
@@ -310,14 +265,17 @@ async def _async_iter(items: list[bytes]) -> AsyncIterator[bytes]:
 
 
 class TestDownloadMediaBytes:
-    async def test_rejects_content_length_over_limit(self) -> None:
-        client = _streaming_client([], headers={"content-length": "1000"})
-        with pytest.raises(DownloadTooLargeError):
-            await download_media_bytes(client, _BASE_URL, _TOKEN, max_bytes=500)
-
-    async def test_rejects_stream_exceeding_limit(self) -> None:
-        """Even without content-length, reject if chunks exceed max_bytes."""
-        client = _streaming_client([b"x" * 600])
+    @pytest.mark.parametrize(
+        ("chunks", "headers"),
+        [
+            ([], {"content-length": "1000"}),
+            ([b"x" * 600], None),
+        ],
+    )
+    async def test_rejects_download_over_limit(
+        self, chunks: list[bytes], headers: dict[str, str] | None
+    ) -> None:
+        client = _streaming_client(chunks, headers=headers)
         with pytest.raises(DownloadTooLargeError):
             await download_media_bytes(client, _BASE_URL, _TOKEN, max_bytes=500)
 

--- a/backend/tests/test_google_photos_service.py
+++ b/backend/tests/test_google_photos_service.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -22,6 +21,7 @@ from app.services.google_photos import (
     ensure_fresh_token,
     get_media_items,
 )
+from tests.helpers.http import async_client, json_response
 
 _SESSION_JSON = {
     "id": "session-xyz",
@@ -95,25 +95,9 @@ class TestResponseParsing:
         assert item.media_file.media_file_metadata is None
 
 
-_DUMMY_REQUEST = httpx.Request("GET", "http://test")
-
-
-def _json_response(data: dict, status_code: int = 200) -> httpx.Response:
-    return httpx.Response(
-        status_code, content=json.dumps(data).encode(), request=_DUMMY_REQUEST
-    )
-
-
-def _client_with(**responses: httpx.Response) -> AsyncMock:
-    client = AsyncMock()
-    for method, response in responses.items():
-        getattr(client, method).return_value = response
-    return client
-
-
 class TestCreatePickerSession:
     async def test_maps_response_to_domain_model(self) -> None:
-        mock_client = _client_with(post=_json_response(_SESSION_JSON))
+        mock_client = async_client(post=json_response(_SESSION_JSON))
 
         session = await create_picker_session(mock_client, "test-token")
 
@@ -126,7 +110,7 @@ class TestCreatePickerSession:
         error = httpx.Response(
             500, request=httpx.Request("POST", "http://test"), content=b"error"
         )
-        mock_client = _client_with(post=error)
+        mock_client = async_client(post=error)
 
         with pytest.raises(httpx.HTTPStatusError):
             await create_picker_session(mock_client, "test-token")
@@ -135,7 +119,7 @@ class TestCreatePickerSession:
 class TestGetMediaItems:
     async def test_single_page(self) -> None:
         page_json = {"mediaItems": [_MEDIA_ITEM_JSON]}
-        mock_client = _client_with(get=_json_response(page_json))
+        mock_client = async_client(get=json_response(page_json))
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -147,13 +131,11 @@ class TestGetMediaItems:
 
     async def test_pagination_collects_all_pages(self) -> None:
         item2 = {**_MEDIA_ITEM_JSON, "id": "media-2"}
-        page1 = _json_response(
+        page1 = json_response(
             {"mediaItems": [_MEDIA_ITEM_JSON], "nextPageToken": "page-2"}
         )
-        page2 = _json_response({"mediaItems": [item2]})
-
-        mock_client = AsyncMock()
-        mock_client.get.side_effect = [page1, page2]
+        page2 = json_response({"mediaItems": [item2]})
+        mock_client = async_client(get=[page1, page2])
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -164,7 +146,7 @@ class TestGetMediaItems:
         assert second_call_params.get("pageToken") == "page-2"
 
     async def test_empty_response(self) -> None:
-        mock_client = _client_with(get=_json_response({}))
+        mock_client = async_client(get=json_response({}))
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -172,7 +154,7 @@ class TestGetMediaItems:
 
     async def test_video_items_preserved(self) -> None:
         video = {**_MEDIA_ITEM_JSON, "id": "vid-1", "type": "VIDEO"}
-        mock_client = _client_with(get=_json_response({"mediaItems": [video]}))
+        mock_client = async_client(get=json_response({"mediaItems": [video]}))
 
         items = await get_media_items(mock_client, "session-1", "token-1")
 
@@ -180,8 +162,8 @@ class TestGetMediaItems:
         assert items[0].type == "VIDEO"
 
     async def test_video_processing_status_surfaced(self) -> None:
-        mock_client = _client_with(
-            get=_json_response({"mediaItems": [_VIDEO_ITEM_JSON]})
+        mock_client = async_client(
+            get=json_response({"mediaItems": [_VIDEO_ITEM_JSON]})
         )
 
         items = await get_media_items(mock_client, "session-1", "token-1")

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -1,9 +1,8 @@
-"""Tests for app.services.mapbox - Mapbox Map Matching & Directions API client."""
-
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from app.services.mapbox import (
     _chunked_route,
@@ -14,11 +13,6 @@ from app.services.mapbox import (
 )
 
 type Coords = list[tuple[float, float]]
-
-
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
 
 
 def _matching_json(coords: list[list[float]]) -> bytes:
@@ -43,30 +37,23 @@ def _ok_response(content: bytes) -> MagicMock:
     return resp
 
 
-# ---------------------------------------------------------------------------
-# _fetch_matching - coordinate extraction + stitching logic
-# ---------------------------------------------------------------------------
-
-
 class TestFetchMatching:
-    async def test_api_error_returns_none(self) -> None:
+    @pytest.mark.parametrize(
+        "response",
+        [
+            _error_response(500),
+            _ok_response(b'{"matchings": []}'),
+        ],
+    )
+    async def test_returns_none_without_route(self, response: MagicMock) -> None:
         client = AsyncMock()
-        client.get.return_value = _error_response(500)
-        assert (
-            await _fetch_matching(client, [(4.0, 52.0), (4.1, 52.1)], "driving", "tok")
-            is None
-        )
-
-    async def test_empty_matchings_returns_none(self) -> None:
-        client = AsyncMock()
-        client.get.return_value = _ok_response(b'{"matchings": []}')
+        client.get.return_value = response
         assert (
             await _fetch_matching(client, [(4.0, 52.0), (4.1, 52.1)], "driving", "tok")
             is None
         )
 
     async def test_multiple_matchings_stitched(self) -> None:
-        """First point of subsequent matchings is skipped to avoid duplication."""
         client = AsyncMock()
         content = json.dumps(
             {
@@ -91,36 +78,23 @@ class TestFetchMatching:
         assert result == [(1, 2), (3, 4), (7, 8)]
 
 
-# ---------------------------------------------------------------------------
-# _fetch_directions
-# ---------------------------------------------------------------------------
-
-
 class TestFetchDirections:
-    async def test_api_error_returns_none(self) -> None:
+    @pytest.mark.parametrize(
+        "response",
+        [
+            _error_response(500),
+            _ok_response(b'{"routes": []}'),
+        ],
+    )
+    async def test_returns_none_without_route(self, response: MagicMock) -> None:
         client = AsyncMock()
-        client.get.return_value = _error_response(500)
+        client.get.return_value = response
         assert (
             await _fetch_directions(
                 client, [(4.0, 52.0), (4.1, 52.1)], "walking", "tok"
             )
             is None
         )
-
-    async def test_empty_routes_returns_none(self) -> None:
-        client = AsyncMock()
-        client.get.return_value = _ok_response(b'{"routes": []}')
-        assert (
-            await _fetch_directions(
-                client, [(4.0, 52.0), (4.1, 52.1)], "walking", "tok"
-            )
-            is None
-        )
-
-
-# ---------------------------------------------------------------------------
-# _chunked_route
-# ---------------------------------------------------------------------------
 
 
 class TestChunkedRoute:
@@ -136,7 +110,6 @@ class TestChunkedRoute:
         result = await _chunked_route(coords, chunk_size=4, overlap=1, route_fn=mock_fn)
         assert result is not None
         assert call_count == 3
-        # First point preserved, subsequent chunks skip first point
         assert result[0] == (0.0, 52.001)
 
     async def test_all_chunks_fail(self) -> None:
@@ -149,14 +122,13 @@ class TestChunkedRoute:
         assert result is None
 
     async def test_partial_failure(self) -> None:
-        """If some chunks fail, remaining are still stitched."""
         call_idx = 0
 
         async def partial_fn(chunk: Coords) -> Coords | None:
             nonlocal call_idx
             call_idx += 1
             if call_idx == 2:
-                return None  # second chunk fails
+                return None
             return [(c[0], c[1] + 0.001) for c in chunk]
 
         coords: Coords = [(i * 0.01, 52.0) for i in range(10)]
@@ -165,11 +137,6 @@ class TestChunkedRoute:
         )
         assert result is not None
         assert len(result) >= 2
-
-
-# ---------------------------------------------------------------------------
-# match_segment (integration, mocked HTTP)
-# ---------------------------------------------------------------------------
 
 
 class TestMatchSegment:

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -24,6 +24,14 @@ def _matching_json(coords: list[list[float]]) -> bytes:
     ).encode()
 
 
+def _directions_json(coords: list[list[float]]) -> bytes:
+    return json.dumps(
+        {
+            "routes": [{"geometry": {"type": "LineString", "coordinates": coords}}],
+        }
+    ).encode()
+
+
 class TestFetchMatching:
     @pytest.mark.parametrize(
         "response",
@@ -136,20 +144,7 @@ class TestMatchSegmentsWithStats:
             get=mock_response(_matching_json([[4.0, 52.0], [4.1, 52.1]]))
         )
         directions_client = async_client(
-            get=mock_response(
-                json.dumps(
-                    {
-                        "routes": [
-                            {
-                                "geometry": {
-                                    "type": "LineString",
-                                    "coordinates": [[5.0, 53.0], [5.1, 53.1]],
-                                }
-                            }
-                        ]
-                    }
-                ).encode()
-            )
+            get=mock_response(_directions_json([[5.0, 53.0], [5.1, 53.1]]))
         )
 
         with patch("app.services.mapbox._token", return_value="tok"):

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -24,14 +24,6 @@ def _matching_json(coords: list[list[float]]) -> bytes:
     ).encode()
 
 
-def _directions_json(coords: list[list[float]]) -> bytes:
-    return json.dumps(
-        {
-            "routes": [{"geometry": {"type": "LineString", "coordinates": coords}}],
-        }
-    ).encode()
-
-
 class TestFetchMatching:
     @pytest.mark.parametrize(
         "response",
@@ -144,7 +136,20 @@ class TestMatchSegmentsWithStats:
             get=mock_response(_matching_json([[4.0, 52.0], [4.1, 52.1]]))
         )
         directions_client = async_client(
-            get=mock_response(_directions_json([[5.0, 53.0], [5.1, 53.1]]))
+            get=mock_response(
+                json.dumps(
+                    {
+                        "routes": [
+                            {
+                                "geometry": {
+                                    "type": "LineString",
+                                    "coordinates": [[5.0, 53.0], [5.1, 53.1]],
+                                }
+                            }
+                        ]
+                    }
+                ).encode()
+            )
         )
 
         with patch("app.services.mapbox._token", return_value="tok"):

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -11,6 +11,7 @@ from app.services.mapbox import (
     match_segment,
     match_segments_with_stats,
 )
+from tests.helpers.http import async_client, error_response, mock_response
 
 type Coords = list[tuple[float, float]]
 
@@ -23,38 +24,22 @@ def _matching_json(coords: list[list[float]]) -> bytes:
     ).encode()
 
 
-def _error_response(status: int = 422) -> MagicMock:
-    resp = MagicMock(status_code=status)
-    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-        f"{status}", request=MagicMock(), response=resp
-    )
-    return resp
-
-
-def _ok_response(content: bytes) -> MagicMock:
-    resp = MagicMock(status_code=200)
-    resp.content = content
-    return resp
-
-
 class TestFetchMatching:
     @pytest.mark.parametrize(
         "response",
         [
-            _error_response(500),
-            _ok_response(b'{"matchings": []}'),
+            error_response(500),
+            mock_response(b'{"matchings": []}'),
         ],
     )
     async def test_returns_none_without_route(self, response: MagicMock) -> None:
-        client = AsyncMock()
-        client.get.return_value = response
+        client = async_client(get=response)
         assert (
             await _fetch_matching(client, [(4.0, 52.0), (4.1, 52.1)], "driving", "tok")
             is None
         )
 
     async def test_multiple_matchings_stitched(self) -> None:
-        client = AsyncMock()
         content = json.dumps(
             {
                 "matchings": [
@@ -73,7 +58,7 @@ class TestFetchMatching:
                 ]
             }
         ).encode()
-        client.get.return_value = _ok_response(content)
+        client = async_client(get=mock_response(content))
         result = await _fetch_matching(client, [(1, 2), (7, 8)], "driving", "tok")
         assert result == [(1, 2), (3, 4), (7, 8)]
 
@@ -82,13 +67,12 @@ class TestFetchDirections:
     @pytest.mark.parametrize(
         "response",
         [
-            _error_response(500),
-            _ok_response(b'{"routes": []}'),
+            error_response(500),
+            mock_response(b'{"routes": []}'),
         ],
     )
     async def test_returns_none_without_route(self, response: MagicMock) -> None:
-        client = AsyncMock()
-        client.get.return_value = response
+        client = async_client(get=response)
         assert (
             await _fetch_directions(
                 client, [(4.0, 52.0), (4.1, 52.1)], "walking", "tok"
@@ -148,24 +132,24 @@ class TestMatchSegment:
 
 class TestMatchSegmentsWithStats:
     async def test_counts_matching_and_directions_requests(self) -> None:
-        matching_client = AsyncMock()
-        directions_client = AsyncMock()
-        matching_client.get.return_value = _ok_response(
-            _matching_json([[4.0, 52.0], [4.1, 52.1]])
+        matching_client = async_client(
+            get=mock_response(_matching_json([[4.0, 52.0], [4.1, 52.1]]))
         )
-        directions_client.get.return_value = _ok_response(
-            json.dumps(
-                {
-                    "routes": [
-                        {
-                            "geometry": {
-                                "type": "LineString",
-                                "coordinates": [[5.0, 53.0], [5.1, 53.1]],
+        directions_client = async_client(
+            get=mock_response(
+                json.dumps(
+                    {
+                        "routes": [
+                            {
+                                "geometry": {
+                                    "type": "LineString",
+                                    "coordinates": [[5.0, 53.0], [5.1, 53.1]],
+                                }
                             }
-                        }
-                    ]
-                }
-            ).encode()
+                        ]
+                    }
+                ).encode()
+            )
         )
 
         with patch("app.services.mapbox._token", return_value="tok"):

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -102,6 +102,10 @@ async def _test_token() -> str:
     return "test-token"
 
 
+def _match_dt(hour: int, minute: int = 0) -> datetime:
+    return datetime(2024, 1, 15, hour, minute, tzinfo=UTC)
+
+
 class TestComputePhash:
     def test_orientation_invariant(self, tmp_path: Path) -> None:
         upright = Image.new("RGB", (100, 200), color="white")
@@ -372,14 +376,9 @@ class TestRunMatching:
                 clients=AsyncMock(),
                 album_dir=album_dir,
                 media_by_step={1: ["photo.jpg"]},
-                step_timestamps=[datetime(2024, 1, 15, 10, 0, tzinfo=UTC).timestamp()],
+                step_timestamps=[_match_dt(10).timestamp()],
                 step_ids=[1],
-                google_items=[
-                    _make_item(
-                        "gp-1",
-                        datetime(2024, 1, 15, 10, 5, tzinfo=UTC).isoformat(),
-                    )
-                ],
+                google_items=[_make_item("gp-1", _match_dt(10, 5).isoformat())],
                 tokens=_test_token,
                 upgrade_candidates=set(),
             )
@@ -396,9 +395,9 @@ class TestRunMatching:
         album_dir.mkdir()
 
         step_timestamps = [
-            datetime(2024, 1, 15, 10, 0, tzinfo=UTC).timestamp(),
-            datetime(2024, 1, 15, 14, 0, tzinfo=UTC).timestamp(),
-            datetime(2024, 1, 15, 18, 0, tzinfo=UTC).timestamp(),
+            _match_dt(10).timestamp(),
+            _match_dt(14).timestamp(),
+            _match_dt(18).timestamp(),
         ]
         step_ids = [1, 2, 3]
         names = ["step1.jpg", "step2.jpg", "step3.jpg"]
@@ -419,7 +418,7 @@ class TestRunMatching:
         google_items = [
             _make_item(
                 f"gp-{i}",
-                datetime(2024, 1, 15, 10 + i * 4, 30, tzinfo=UTC).isoformat(),
+                _match_dt(10 + i * 4, 30).isoformat(),
                 base_url=f"https://lh3.googleusercontent.com/{name}",
             )
             for i, name in enumerate(names)

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -1,12 +1,3 @@
-"""Tests for the media upgrade pipeline.
-
-Unit tests are scoped to the algorithmic edge cases that motivated the
-code (Hungarian optimality, overlap-margin boundary, cross-step
-fallback dimension cap) plus the real-I/O photo/video processing. A
-single integration test exercises ``run_matching`` end-to-end against
-fixture JPEGs on disk.
-"""
-
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -53,13 +44,11 @@ from .factories import AID, create_test_jpeg, insert_album, insert_album_media
 
 @pytest.fixture(autouse=True)
 def _clear_upgrade_caches_between_tests() -> Iterator[None]:
-    """Reset the event-loop-bound semaphore cache between tests."""
     yield
     _clear_caches()
 
 
 def _make_hash(value: int) -> imagehash.ImageHash:
-    """Create a deterministic hash for testing."""
     bits = np.array([(value >> i) & 1 for i in range(64)], dtype=bool)
     return imagehash.ImageHash(bits)
 
@@ -97,7 +86,6 @@ def _make_item(
 def _write_jpeg(
     path: Path, width: int, height: int, *, exif: bytes | None = None
 ) -> None:
-    """Write a JPEG image to *path*, optionally with EXIF data."""
     img = Image.new("RGB", (width, height), color=(100, 150, 200))
     kwargs: dict = {"format": "JPEG", "quality": 95}
     if exif is not None:
@@ -106,14 +94,8 @@ def _write_jpeg(
 
 
 def _write_png(path: Path, width: int, height: int) -> None:
-    """Write a PNG image to *path*."""
     img = Image.new("RGBA", (width, height), color=(100, 150, 200, 255))
     img.save(path, format="PNG")
-
-
-# ---------------------------------------------------------------------------
-# Targeted algorithm regression guards
-# ---------------------------------------------------------------------------
 
 
 class TestComputePhash:
@@ -140,26 +122,21 @@ class TestComputePhash:
 
 class TestMatchWithinWindow:
     def test_optimal_assignment_not_greedy(self) -> None:
-        """Hungarian must find the global optimum, not a greedy local one.
-
-        Regression guard: a greedy matcher would pair photo1 with the nearest
-        candidate and leave photo2 worse off; the global optimum swaps them.
-        """
         h_base = _make_hash(0)
 
         bits_p1 = np.array([(0 >> i) & 1 for i in range(64)], dtype=bool)
         bits_p1[0] = True
-        bits_p1[1] = True  # distance 2 from all-zero
+        bits_p1[1] = True
         h_p1 = imagehash.ImageHash(bits_p1)
 
         bits_p2 = np.zeros(64, dtype=bool)
-        bits_p2[0] = True  # distance 1 from all-zero
+        bits_p2[0] = True
         h_p2 = imagehash.ImageHash(bits_p2)
 
         bits_gp2 = np.zeros(64, dtype=bool)
         bits_gp2[0] = True
         bits_gp2[1] = True
-        bits_gp2[2] = True  # distance 3 from p1
+        bits_gp2[2] = True
         h_gp2 = imagehash.ImageHash(bits_gp2)
 
         results = match_within_window(
@@ -173,11 +150,6 @@ class TestMatchWithinWindow:
 
 class TestBucketByWindow:
     def test_overlap_margin_includes_boundary_items(self) -> None:
-        """Items just past a window boundary match via overlap.
-
-        Regression guard: an item 10 min past a step boundary must still be
-        considered for the previous step (30-min overlap).
-        """
         windows = build_step_windows(
             step_timestamps=[1_000_000.0, 1_050_000.0],
             step_ids=[1, 2],
@@ -192,7 +164,6 @@ class TestBucketByWindow:
 
 class TestCrossStepFallback:
     def test_runs_at_exact_dimension_limit(self) -> None:
-        """Fallback still runs when both dimensions are exactly at the limit."""
         h = _make_hash(0)
         n = _FALLBACK_MAX_DIMENSION
         names = [f"photo{i}.jpg" for i in range(n)]
@@ -214,7 +185,6 @@ class TestCrossStepFallback:
         assert len(all_matches) == n
 
     def test_skips_when_exceeding_dimension_limit(self) -> None:
-        """Fallback is skipped when the matrix would be too large."""
         h = _make_hash(0)
         n = _FALLBACK_MAX_DIMENSION + 1
         names = [f"photo{i}.jpg" for i in range(n)]
@@ -236,14 +206,8 @@ class TestCrossStepFallback:
         assert len(all_matches) == 0
 
 
-# ---------------------------------------------------------------------------
-# Photo processing (EXIF strip, resize, JPEG conversion)
-# ---------------------------------------------------------------------------
-
-
 class TestProcessPhoto:
     def test_strips_exif(self, tmp_path: Path) -> None:
-        """EXIF metadata must be removed."""
         img = Image.new("RGB", (800, 600))
         exif = img.getexif()
         exif[ExifBase.Make] = "TestCamera"
@@ -263,38 +227,29 @@ class TestProcessPhoto:
         with Image.open(out) as result:
             assert len(result.getexif()) == 0
 
-    def test_resizes_large_landscape(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        ("source_size", "expected_size"),
+        [
+            ((5000, 3000), (_MAX_LONG_EDGE, 1800)),
+            ((3000, 5000), (1800, _MAX_LONG_EDGE)),
+            ((2000, 1500), (2000, 1500)),
+        ],
+    )
+    def test_resizes_photos(
+        self,
+        tmp_path: Path,
+        source_size: tuple[int, int],
+        expected_size: tuple[int, int],
+    ) -> None:
         raw = tmp_path / "in.jpg"
         out = tmp_path / "out.jpg"
-        _write_jpeg(raw, 5000, 3000)
+        _write_jpeg(raw, *source_size)
 
         w, h = process_photo_sync(raw, out)
 
-        assert (w, h) == (_MAX_LONG_EDGE, 1800)
+        assert (w, h) == expected_size
         with Image.open(out) as result:
-            assert result.size == (_MAX_LONG_EDGE, 1800)
-
-    def test_resizes_large_portrait(self, tmp_path: Path) -> None:
-        raw = tmp_path / "in.jpg"
-        out = tmp_path / "out.jpg"
-        _write_jpeg(raw, 3000, 5000)
-
-        w, h = process_photo_sync(raw, out)
-
-        assert (w, h) == (1800, _MAX_LONG_EDGE)
-        with Image.open(out) as result:
-            assert result.size == (1800, _MAX_LONG_EDGE)
-
-    def test_preserves_small_image(self, tmp_path: Path) -> None:
-        raw = tmp_path / "in.jpg"
-        out = tmp_path / "out.jpg"
-        _write_jpeg(raw, 2000, 1500)
-
-        w, h = process_photo_sync(raw, out)
-
-        assert (w, h) == (2000, 1500)
-        with Image.open(out) as result:
-            assert result.size == (2000, 1500)
+            assert result.size == expected_size
 
     def test_converts_png_to_jpeg(self, tmp_path: Path) -> None:
         raw = tmp_path / "in.png"
@@ -309,10 +264,9 @@ class TestProcessPhoto:
             assert result.size == (800, 600)
 
     def test_handles_orientation_tag(self, tmp_path: Path) -> None:
-        """EXIF orientation 6 (rotated 90 CW) should produce a transposed image."""
-        img = Image.new("RGB", (400, 600))  # portrait source
+        img = Image.new("RGB", (400, 600))
         exif = img.getexif()
-        exif[ExifBase.Orientation] = 6  # 90 CW rotation
+        exif[ExifBase.Orientation] = 6
         exif_bytes = exif.tobytes()
 
         raw = tmp_path / "in.jpg"
@@ -321,7 +275,6 @@ class TestProcessPhoto:
 
         w, h = process_photo_sync(raw, out)
 
-        # After transpose: 600x400 (landscape)
         assert (w, h) == (600, 400)
         with Image.open(out) as result:
             assert result.size == (600, 400)
@@ -351,11 +304,6 @@ class TestProcessVideo:
         monkeypatch.setattr("asyncio.create_subprocess_exec", _fake_exec)
         with pytest.raises(RuntimeError, match="cap"):
             await process_video(source, out)
-
-
-# ---------------------------------------------------------------------------
-# _needs_upgrade
-# ---------------------------------------------------------------------------
 
 
 class TestNeedsUpgrade:
@@ -396,11 +344,6 @@ class TestPersistUpgrade:
 
         assert media.byte_size == target.stat().st_size
         assert media.upgrade_candidate is False
-
-
-# ---------------------------------------------------------------------------
-# run_matching end-to-end
-# ---------------------------------------------------------------------------
 
 
 class TestRunMatching:
@@ -456,14 +399,6 @@ class TestRunMatching:
     async def test_matches_real_images_end_to_end(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Full matching pipeline against real JPEGs on disk.
-
-        Each Google item's base_url points at its own id; the mocked
-        ``download_media_bytes`` returns the matching local file's bytes so
-        candidate hashes equal local hashes. Exercises bucketing, local
-        hashing, candidate hashing, within-window Hungarian, cross-step
-        fallback, and the terminal summary event.
-        """
         album_dir = tmp_path / "album"
         album_dir.mkdir()
 
@@ -475,7 +410,6 @@ class TestRunMatching:
         step_ids = [1, 2, 3]
         names = ["step1.jpg", "step2.jpg", "step3.jpg"]
 
-        # Visually distinct images so each pHash is unique.
         bytes_by_name: dict[str, bytes] = {}
         for i, name in enumerate(names):
             img = Image.new("RGB", (400, 300))
@@ -489,7 +423,6 @@ class TestRunMatching:
             img.save(path, "JPEG", quality=90)
             bytes_by_name[name] = path.read_bytes()
 
-        # Google items: one per step, base_url encodes the local file.
         google_items = [
             _make_item(
                 f"gp-{i}",

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -98,6 +98,10 @@ def _write_png(path: Path, width: int, height: int) -> None:
     img.save(path, format="PNG")
 
 
+async def _test_token() -> str:
+    return "test-token"
+
+
 class TestComputePhash:
     def test_orientation_invariant(self, tmp_path: Path) -> None:
         upright = Image.new("RGB", (100, 200), color="white")
@@ -163,13 +167,21 @@ class TestBucketByWindow:
 
 
 class TestCrossStepFallback:
-    def test_runs_at_exact_dimension_limit(self) -> None:
+    @pytest.mark.parametrize(
+        ("dimension", "expected_matches"),
+        [
+            (_FALLBACK_MAX_DIMENSION, _FALLBACK_MAX_DIMENSION),
+            (_FALLBACK_MAX_DIMENSION + 1, 0),
+        ],
+    )
+    def test_dimension_limit(self, dimension: int, expected_matches: int) -> None:
         h = _make_hash(0)
-        n = _FALLBACK_MAX_DIMENSION
-        names = [f"photo{i}.jpg" for i in range(n)]
+        names = [f"photo{i}.jpg" for i in range(dimension)]
         hashes = dict.fromkeys(names, h)
-        items = [_make_item(f"gp-{i}", "2024-01-15T10:00:00Z") for i in range(n)]
-        candidate_hashes = {f"gp-{i}": h for i in range(n)}
+        items = [
+            _make_item(f"gp-{i}", "2024-01-15T10:00:00Z") for i in range(dimension)
+        ]
+        candidate_hashes = {f"gp-{i}": h for i in range(dimension)}
 
         all_matches: list[MatchResult] = []
         cross_step_fallback(
@@ -182,28 +194,7 @@ class TestCrossStepFallback:
             google_items=items,
         )
 
-        assert len(all_matches) == n
-
-    def test_skips_when_exceeding_dimension_limit(self) -> None:
-        h = _make_hash(0)
-        n = _FALLBACK_MAX_DIMENSION + 1
-        names = [f"photo{i}.jpg" for i in range(n)]
-        hashes = dict.fromkeys(names, h)
-        items = [_make_item(f"gp-{i}", "2024-01-15T10:00:00Z") for i in range(n)]
-        candidate_hashes = {f"gp-{i}": h for i in range(n)}
-
-        all_matches: list[MatchResult] = []
-        cross_step_fallback(
-            all_matches,
-            matched_locals=set(),
-            matched_candidates=set(),
-            media_names=names,
-            local_hashes=hashes,
-            candidate_hashes=candidate_hashes,
-            google_items=items,
-        )
-
-        assert len(all_matches) == 0
+        assert len(all_matches) == expected_matches
 
 
 class TestProcessPhoto:
@@ -307,13 +298,18 @@ class TestProcessVideo:
 
 
 class TestNeedsUpgrade:
-    def test_candidate_needs_upgrade(self) -> None:
+    @pytest.mark.parametrize(
+        ("upgrade_candidates", "expected"),
+        [
+            ({"photo.jpg"}, True),
+            (set(), False),
+        ],
+    )
+    def test_needs_upgrade(
+        self, upgrade_candidates: set[str], *, expected: bool
+    ) -> None:
         match = MatchResult(local_name="photo.jpg", google_id="gid-A", distance=0)
-        assert _needs_upgrade(match, {"photo.jpg"}) is True
-
-    def test_non_candidate_skips(self) -> None:
-        match = MatchResult(local_name="photo.jpg", google_id="gid-A", distance=0)
-        assert _needs_upgrade(match, set()) is False
+        assert _needs_upgrade(match, upgrade_candidates) is expected
 
 
 class TestPersistUpgrade:
@@ -370,9 +366,6 @@ class TestRunMatching:
             "app.logic.media_upgrade.pipeline._hash_candidate_one", fake_candidate
         )
 
-        async def fake_token() -> str:
-            return "test-token"
-
         events = [
             event
             async for event in run_matching(
@@ -387,7 +380,7 @@ class TestRunMatching:
                         datetime(2024, 1, 15, 10, 5, tzinfo=UTC).isoformat(),
                     )
                 ],
-                tokens=fake_token,
+                tokens=_test_token,
                 upgrade_candidates=set(),
             )
         ]
@@ -450,9 +443,6 @@ class TestRunMatching:
             "app.logic.media_upgrade.pipeline.download_media_bytes", fake_download
         )
 
-        async def fake_token() -> str:
-            return "test-token"
-
         clients = AsyncMock()
         events = [
             event
@@ -465,7 +455,7 @@ class TestRunMatching:
                 step_timestamps=step_timestamps,
                 step_ids=step_ids,
                 google_items=google_items,
-                tokens=fake_token,
+                tokens=_test_token,
             )
         ]
 

--- a/backend/tests/test_open_meteo.py
+++ b/backend/tests/test_open_meteo.py
@@ -1,9 +1,7 @@
 import datetime as _dt_mod
-import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -17,6 +15,7 @@ from app.services.open_meteo import (
     elevations,
 )
 from tests.factories import collect_async
+from tests.helpers.http import async_client, error_response, json_response
 
 
 @dataclass
@@ -75,13 +74,7 @@ class TestElevations:
     async def test_http_error_propagates(self) -> None:
         locs = [_Loc(0, 0)]
 
-        resp = MagicMock()
-        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "500", request=MagicMock(), response=MagicMock()
-        )
-
-        client = MagicMock(spec=httpx.AsyncClient)
-        client.get = AsyncMock(return_value=resp)
+        client = async_client(get=error_response())
         with pytest.raises(httpx.HTTPStatusError):
             await collect_async(elevations(client, locs))
 
@@ -141,11 +134,7 @@ class TestBuildWeathers:
             feels_min=[-5.0],
             wmo_daily=[71],
         )
-        mock_response = MagicMock(status_code=200)
-        mock_response.content = json.dumps(resp_data).encode()
-
-        client = MagicMock(spec=httpx.AsyncClient)
-        client.get = AsyncMock(return_value=mock_response)
+        client = async_client(get=json_response(resp_data))
         result = [w async for w in build_weathers(client, [step])]
 
         assert len(result) == 1
@@ -158,8 +147,7 @@ class TestBuildWeathers:
 
     async def test_http_error_raises(self) -> None:
         step = _make_step(0, 0, 1704067200.0)
-        client = MagicMock(spec=httpx.AsyncClient)
-        client.get = AsyncMock(side_effect=httpx.HTTPError("fail"))
+        client = async_client(get=httpx.HTTPError("fail"))
         with pytest.raises(RuntimeError, match="Weather API"):
             async for _ in build_weathers(client, [step]):
                 pass

--- a/backend/tests/test_open_meteo.py
+++ b/backend/tests/test_open_meteo.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from app.core.http_clients import _open_meteo_weight
+from app.models.weather import Weather
 from app.services.open_meteo import (
     _LocationResult,
     _weather_from_result,
@@ -70,6 +71,31 @@ def _om_response(dates: list[str], **overrides: list) -> dict:
     return {"daily": daily}
 
 
+def _assert_weather(
+    weather: Weather,
+    *,
+    day_temp: float,
+    day_feels: float | None = None,
+    day_icon: str | None = None,
+    night_temp: float | None = None,
+    night_feels: float | None = None,
+    night_icon: str | None = None,
+) -> None:
+    assert weather.day.temp == day_temp
+    if day_feels is not None:
+        assert weather.day.feels_like == day_feels
+    if day_icon is not None:
+        assert weather.day.icon == day_icon
+    if night_temp is None:
+        return
+    assert weather.night is not None
+    assert weather.night.temp == night_temp
+    if night_feels is not None:
+        assert weather.night.feels_like == night_feels
+    if night_icon is not None:
+        assert weather.night.icon == night_icon
+
+
 class TestElevations:
     async def test_http_error_propagates(self) -> None:
         locs = [_Loc(0, 0)]
@@ -108,13 +134,15 @@ class TestWeatherFromResult:
         weather = _weather_from_result(step, loc)
 
         assert weather is not None
-        assert weather.day.temp == 30.0
-        assert weather.day.feels_like == 32.0
-        assert weather.day.icon == "rain"
-        assert weather.night is not None
-        assert weather.night.temp == 18.0
-        assert weather.night.feels_like == 16.0
-        assert weather.night.icon == "rain"
+        _assert_weather(
+            weather,
+            day_temp=30.0,
+            day_feels=32.0,
+            day_icon="rain",
+            night_temp=18.0,
+            night_feels=16.0,
+            night_icon="rain",
+        )
 
     def test_missing_date_returns_none(self) -> None:
         raw = _om_response(["2024-01-01"])
@@ -140,10 +168,12 @@ class TestBuildWeathers:
         assert len(result) == 1
         idx, w = result[0]
         assert idx == 0
-        assert w.day.temp == 5.0
-        assert w.day.icon == "partly-cloudy-day-snow"
-        assert w.night is not None
-        assert w.night.temp == -2.0
+        _assert_weather(
+            w,
+            day_temp=5.0,
+            day_icon="partly-cloudy-day-snow",
+            night_temp=-2.0,
+        )
 
     async def test_http_error_raises(self) -> None:
         step = _make_step(0, 0, 1704067200.0)

--- a/backend/tests/test_open_meteo.py
+++ b/backend/tests/test_open_meteo.py
@@ -1,5 +1,3 @@
-"""Tests for app.services.open_meteo - elevation lookups and weather fetching."""
-
 import datetime as _dt_mod
 import json
 from dataclasses import dataclass
@@ -19,10 +17,6 @@ from app.services.open_meteo import (
     elevations,
 )
 from tests.factories import collect_async
-
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -48,10 +42,6 @@ class _Step:
 def _make_step(lat: float, lon: float, ts: float, **kw: Any) -> _Step:
     return _Step(location=_Loc(lat, lon), timestamp=ts, **kw)
 
-
-# ---------------------------------------------------------------------------
-# Weather helpers
-# ---------------------------------------------------------------------------
 
 _DAILY_FIELD_MAP = {
     "temp_max": "temperature_2m_max",
@@ -81,11 +71,6 @@ def _om_response(dates: list[str], **overrides: list) -> dict:
     return {"daily": daily}
 
 
-# ---------------------------------------------------------------------------
-# Elevation tests
-# ---------------------------------------------------------------------------
-
-
 class TestElevations:
     async def test_http_error_propagates(self) -> None:
         locs = [_Loc(0, 0)]
@@ -101,23 +86,18 @@ class TestElevations:
             await collect_async(elevations(client, locs))
 
 
-# ---------------------------------------------------------------------------
-# Weather tests
-# ---------------------------------------------------------------------------
-
-
 class TestWmoIcon:
-    def test_clear_day(self) -> None:
-        assert _wmo_icon(0) == "clear-day"
-
-    def test_clear_night(self) -> None:
-        assert _wmo_icon(0, night=True) == "clear-night"
-
-    def test_fog_day(self) -> None:
-        assert _wmo_icon(45) == "fog-day"
-
-    def test_unknown_code(self) -> None:
-        assert _wmo_icon(999) == "not-available"
+    @pytest.mark.parametrize(
+        ("code", "night", "expected"),
+        [
+            (0, False, "clear-day"),
+            (0, True, "clear-night"),
+            (45, False, "fog-day"),
+            (999, False, "not-available"),
+        ],
+    )
+    def test_icon(self, code: int, *, night: bool, expected: str) -> None:
+        assert _wmo_icon(code, night=night) == expected
 
 
 class TestWeatherFromResult:
@@ -185,46 +165,36 @@ class TestBuildWeathers:
                 pass
 
 
-# ---------------------------------------------------------------------------
-# Rate-limit weight
-# ---------------------------------------------------------------------------
-
-
 class TestOpenMeteoWeight:
-    def test_elevation_single_coord(self) -> None:
-        req = httpx.Request(
-            "GET", "https://api.open-meteo.com/v1/elevation?latitude=1.0&longitude=2.0"
-        )
-        assert _open_meteo_weight(req) == 1
-
-    def test_elevation_batched_coords(self) -> None:
-        req = httpx.Request(
-            "GET",
-            "https://api.open-meteo.com/v1/elevation?latitude=1,2,3,4&longitude=5,6,7,8",
-        )
-        assert _open_meteo_weight(req) == 4
-
-    def test_archive_counts_daily_variables(self) -> None:
-        req = httpx.Request(
-            "GET",
-            "https://archive-api.open-meteo.com/v1/archive"
-            "?latitude=1&longitude=2&start_date=2024-01-01&end_date=2024-01-01"
-            "&daily=temperature_2m_max,temperature_2m_min,"
-            "apparent_temperature_max,apparent_temperature_min,weather_code",
-        )
-        assert _open_meteo_weight(req) == 5
-
-    def test_archive_single_variable(self) -> None:
-        req = httpx.Request(
-            "GET",
-            "https://archive-api.open-meteo.com/v1/archive"
-            "?latitude=1&longitude=2&daily=temperature_2m_max",
-        )
-        assert _open_meteo_weight(req) == 1
-
-    def test_archive_without_daily_param(self) -> None:
-        req = httpx.Request(
-            "GET",
-            "https://archive-api.open-meteo.com/v1/archive?latitude=1&longitude=2",
-        )
-        assert _open_meteo_weight(req) == 1
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            (
+                "https://api.open-meteo.com/v1/elevation?latitude=1.0&longitude=2.0",
+                1,
+            ),
+            (
+                "https://api.open-meteo.com/v1/elevation"
+                "?latitude=1,2,3,4&longitude=5,6,7,8",
+                4,
+            ),
+            (
+                "https://archive-api.open-meteo.com/v1/archive"
+                "?latitude=1&longitude=2&start_date=2024-01-01&end_date=2024-01-01"
+                "&daily=temperature_2m_max,temperature_2m_min,"
+                "apparent_temperature_max,apparent_temperature_min,weather_code",
+                5,
+            ),
+            (
+                "https://archive-api.open-meteo.com/v1/archive"
+                "?latitude=1&longitude=2&daily=temperature_2m_max",
+                1,
+            ),
+            (
+                "https://archive-api.open-meteo.com/v1/archive?latitude=1&longitude=2",
+                1,
+            ),
+        ],
+    )
+    def test_weight(self, url: str, expected: int) -> None:
+        assert _open_meteo_weight(httpx.Request("GET", url)) == expected

--- a/backend/tests/test_peaks.py
+++ b/backend/tests/test_peaks.py
@@ -1,6 +1,5 @@
 import json
 from dataclasses import dataclass
-from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -12,6 +11,7 @@ from app.logic.spatial.peaks import (
     _parse_ele,
     correct_peaks,
 )
+from tests.helpers.http import async_client, mock_response
 
 
 @dataclass
@@ -29,11 +29,7 @@ def _overpass_json(peaks: list[tuple[float, str]]) -> bytes:
 
 
 def _mock_overpass_client(peaks: list[tuple[float, str]]) -> httpx.AsyncClient:
-    mock_response = MagicMock(status_code=200)
-    mock_response.content = _overpass_json(peaks)
-    client = MagicMock(spec=httpx.AsyncClient)
-    client.post = AsyncMock(return_value=mock_response)
-    return client
+    return async_client(post=mock_response(_overpass_json(peaks)))
 
 
 class TestParseEle:
@@ -115,8 +111,7 @@ class TestCorrectPeaks:
         locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]
         elevs = [500.0, 5236.0, 500.0]
 
-        client = MagicMock(spec=httpx.AsyncClient)
-        client.post = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+        client = async_client(post=httpx.HTTPError("timeout"))
         result = await correct_peaks(client, locs, elevs)
 
         assert list(result) == elevs

--- a/backend/tests/test_peaks.py
+++ b/backend/tests/test_peaks.py
@@ -32,6 +32,10 @@ def _mock_overpass_client(peaks: list[tuple[float, str]]) -> httpx.AsyncClient:
     return async_client(post=mock_response(_overpass_json(peaks)))
 
 
+def _peak_profile(middle: float) -> tuple[list[_Loc], list[float]]:
+    return [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)], [500.0, middle, 500.0]
+
+
 class TestParseEle:
     def test_plain_string(self) -> None:
         assert _parse_ele("5327") == 5327.0
@@ -99,8 +103,7 @@ class TestCorrectPeaks:
     async def test_peak_correction_cases(
         self, middle: float, peaks: list[tuple[float, str]], expected: float
     ) -> None:
-        locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]
-        elevs = [500.0, middle, 500.0]
+        locs, elevs = _peak_profile(middle)
 
         client = _mock_overpass_client(peaks)
         result = await correct_peaks(client, locs, elevs)
@@ -108,8 +111,7 @@ class TestCorrectPeaks:
         assert result == [500.0, expected, 500.0]
 
     async def test_overpass_failure_returns_original(self) -> None:
-        locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]
-        elevs = [500.0, 5236.0, 500.0]
+        locs, elevs = _peak_profile(5236.0)
 
         client = async_client(post=httpx.HTTPError("timeout"))
         result = await correct_peaks(client, locs, elevs)

--- a/backend/tests/test_peaks.py
+++ b/backend/tests/test_peaks.py
@@ -1,5 +1,3 @@
-"""Tests for app.logic.spatial.peaks."""
-
 import json
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
@@ -77,51 +75,41 @@ class TestLocalPeaks:
 
 
 class TestCorrectPeaks:
-    async def test_corrects_summit(self) -> None:
-        locs = [_Loc(0, 0), _Loc(-16.19, -68.26), _Loc(0, 0)]
-        elevs = [500.0, 5236.0, 500.0]
-
-        client = _mock_overpass_client([(5327, "Pico Austria")])
-        result = await correct_peaks(client, locs, elevs)
-
-        assert result[0] == 500.0  # unchanged
-        assert result[1] == 5327.0  # corrected
-        assert result[2] == 500.0  # unchanged
-
-    async def test_does_not_lower_elevation(self) -> None:
+    @pytest.mark.parametrize(
+        ("middle", "peaks", "expected"),
+        [
+            pytest.param(
+                5236.0, [(5327, "Pico Austria")], 5327.0, id="corrects-summit"
+            ),
+            pytest.param(5400.0, [(5327, "Pico Austria")], 5400.0, id="does-not-lower"),
+            pytest.param(
+                5000.0,
+                [(5000.0 * (1 + PEAK_MAX_DEVIATION), "Boundary Peak")],
+                5000.0 * (1 + PEAK_MAX_DEVIATION),
+                id="threshold",
+            ),
+            pytest.param(
+                5236.0,
+                [
+                    (6088, "Huayna Potosi"),
+                    (5327, "Pico Austria"),
+                    (5648, "Condoriri"),
+                ],
+                5327.0,
+                id="closest",
+            ),
+        ],
+    )
+    async def test_peak_correction_cases(
+        self, middle: float, peaks: list[tuple[float, str]], expected: float
+    ) -> None:
         locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]
-        elevs = [500.0, 5400.0, 500.0]
+        elevs = [500.0, middle, 500.0]
 
-        client = _mock_overpass_client([(5327, "Pico Austria")])
+        client = _mock_overpass_client(peaks)
         result = await correct_peaks(client, locs, elevs)
 
-        assert result[1] == 5400.0  # unchanged - OSM peak is lower
-
-    async def test_deviation_exactly_at_threshold(self) -> None:
-        locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]
-        dem_val = 5000.0
-        osm_val = dem_val * (1 + PEAK_MAX_DEVIATION)  # exactly 10%
-        elevs = [500.0, dem_val, 500.0]
-
-        client = _mock_overpass_client([(osm_val, "Boundary Peak")])
-        result = await correct_peaks(client, locs, elevs)
-
-        assert result[1] == osm_val  # corrected
-
-    async def test_picks_closest_in_elevation(self) -> None:
-        locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]
-        elevs = [500.0, 5236.0, 500.0]
-
-        client = _mock_overpass_client(
-            [
-                (6088, "Huayna Potosi"),
-                (5327, "Pico Austria"),
-                (5648, "Condoriri"),
-            ]
-        )
-        result = await correct_peaks(client, locs, elevs)
-
-        assert result[1] == 5327.0  # closest to 5236
+        assert result == [500.0, expected, 500.0]
 
     async def test_overpass_failure_returns_original(self) -> None:
         locs = [_Loc(0, 0), _Loc(0, 0), _Loc(0, 0)]

--- a/backend/tests/test_reconcile.py
+++ b/backend/tests/test_reconcile.py
@@ -89,6 +89,17 @@ def _album(
     )
 
 
+def _user() -> User:
+    return User(
+        id=_UID,
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        google_sub="test",
+    )
+
+
 class TestScanStepMedia:
     def test_finds_photos_and_videos(self, tmp_path: Path) -> None:
         ps = _ps_step(1, slug="naples")
@@ -232,7 +243,6 @@ _LOC_B = Location(name="B", detail="", country_code="nl", lat=52.5, lon=5.0)
 
 
 def _build_trip_dir(tmp_path: Path, ps_steps: list[PSStep]) -> Path:
-    """Create a minimal trip directory with trip.json and locations.json."""
     trip_dir = tmp_path / _RECONCILE_AID
     trip_dir.mkdir()
     trip_json = {
@@ -245,7 +255,6 @@ def _build_trip_dir(tmp_path: Path, ps_steps: list[PSStep]) -> Path:
         "all_steps": [s.model_dump(by_alias=True) for s in ps_steps],
     }
     (trip_dir / "trip.json").write_text(json.dumps(trip_json))
-    # Dense GPS points between the two steps (simulates a driving track)
     gps_points = [
         {"lat": 52.0 + i * 0.05, "lon": 4.0 + i * 0.1, "time": 1_000_000.0 + i * 360}
         for i in range(11)
@@ -254,14 +263,50 @@ def _build_trip_dir(tmp_path: Path, ps_steps: list[PSStep]) -> Path:
     return trip_dir
 
 
+def _existing_step(step_id: int, **kwargs: object) -> StepRead:
+    step = _step(step_id, **kwargs)
+    step.uid = _UID
+    step.aid = _RECONCILE_AID
+    return step
+
+
+def _existing_album(
+    *,
+    front_cover_photo: str = "front.jpg",
+    back_cover_photo: str = "back.jpg",
+) -> Album:
+    album = _album(
+        front_cover_photo=front_cover_photo,
+        back_cover_photo=back_cover_photo,
+    )
+    album.uid = _UID
+    album.id = _RECONCILE_AID
+    return album
+
+
+async def _collect_reconcile(
+    trip_dir: Path,
+    album: Album,
+    existing_steps: list[StepRead],
+    *,
+    existing_media_rows: list[AlbumMedia] | None = None,
+) -> tuple[list, list]:
+    db_out: list = []
+    events = await collect_async(
+        reconcile_trip(
+            _MOCK_HTTP,
+            _user(),
+            trip_dir,
+            album,
+            existing_steps,
+            db_out,
+            existing_media_rows=existing_media_rows,
+        )
+    )
+    return events, db_out
+
+
 class TestReconcileTripRebuildsSegments:
-    """Regression: reconcile_trip must rebuild segments from GPS data.
-
-    Previously, reconcile_trip never called build_segments, so after
-    _save_reupload deleted old segments the table stayed empty - route
-    lines disappeared from trip maps.
-    """
-
     async def test_segments_included_in_db_out(self, tmp_path: Path) -> None:
         ps_steps = [
             _ps_step(1, slug="start"),
@@ -270,29 +315,11 @@ class TestReconcileTripRebuildsSegments:
         trip_dir = _build_trip_dir(tmp_path, ps_steps)
 
         existing_steps = [
-            _step(1, name="Start"),
-            _step(2, name="End"),
+            _existing_step(1, name="Start"),
+            _existing_step(2, name="End"),
         ]
-        for s in existing_steps:
-            s.uid = _UID
-            s.aid = _RECONCILE_AID
-
-        album = _album()
-        album.uid = _UID
-        album.id = _RECONCILE_AID
-
-        user = User(
-            id=_UID,
-            first_name="Test",
-            locale="en-US",
-            unit_is_km=True,
-            temperature_is_celsius=True,
-            google_sub="test",
-        )
-
-        db_out: list = []
-        events = await collect_async(
-            reconcile_trip(_MOCK_HTTP, user, trip_dir, album, existing_steps, db_out)
+        events, db_out = await _collect_reconcile(
+            trip_dir, _existing_album(), existing_steps
         )
 
         segments = [obj for obj in db_out if isinstance(obj, Segment)]
@@ -314,7 +341,7 @@ class TestReconcileTripRebuildsSegments:
             for event in events
         )
         assert len(segments) > 0, (
-            "reconcile_trip must rebuild segments from GPS data; "
+            "reconcile_trip must rebuild segments from GPS data, "
             "got 0 segments in db_out (route lines would be missing)"
         )
         for seg in segments:
@@ -333,22 +360,7 @@ class TestReconcileTripRebuildsSegments:
         )
         (trip_dir / media_name).write_bytes(b"\xff\xd8")
 
-        existing_steps = [_step(1, pages=[[media_name]], cover=media_name)]
-        for step in existing_steps:
-            step.uid = _UID
-            step.aid = _RECONCILE_AID
-
-        album = _album(front_cover_photo=media_name, back_cover_photo=media_name)
-        album.uid = _UID
-        album.id = _RECONCILE_AID
-        user = User(
-            id=_UID,
-            first_name="Test",
-            locale="en-US",
-            unit_is_km=True,
-            temperature_is_celsius=True,
-            google_sub="test",
-        )
+        existing_steps = [_existing_step(1, pages=[[media_name]], cover=media_name)]
         existing_media = AlbumMedia(
             uid=_UID,
             aid=_RECONCILE_AID,
@@ -360,17 +372,11 @@ class TestReconcileTripRebuildsSegments:
             upgrade_candidate=False,
         )
 
-        db_out: list = []
-        await collect_async(
-            reconcile_trip(
-                _MOCK_HTTP,
-                user,
-                trip_dir,
-                album,
-                existing_steps,
-                db_out,
-                existing_media_rows=[existing_media],
-            )
+        _, db_out = await _collect_reconcile(
+            trip_dir,
+            _existing_album(front_cover_photo=media_name, back_cover_photo=media_name),
+            existing_steps,
+            existing_media_rows=[existing_media],
         )
 
         media_rows = [obj for obj in db_out if isinstance(obj, AlbumMedia)]

--- a/backend/tests/test_reconcile.py
+++ b/backend/tests/test_reconcile.py
@@ -18,17 +18,21 @@ from app.models.polarsteps import Location, PSStep
 from app.models.segment import Segment
 from app.models.step import StepRead
 from app.models.user import User
-from app.models.weather import Weather, WeatherData
-from tests.factories import collect_async
+from tests.factories import (
+    collect_async,
+    make_album,
+    make_album_media,
+    make_step_read,
+    make_user,
+    make_weather,
+)
 
 _MOCK_HTTP = MagicMock(spec=HttpClients)
 _UID = 1
 
 _LOC = Location(name="Place", detail="", country_code="nl", lat=52.0, lon=4.0)
 _LOC2 = Location(name="Updated", detail="center", country_code="de", lat=48.0, lon=11.0)
-_WEATHER = Weather(
-    day=WeatherData(temp=20.0, feels_like=18.0, icon="clear"), night=None
-)
+_WEATHER = make_weather(icon="clear")
 
 
 def _ps_step(step_id: int, slug: str = "step", *, location: Location = _LOC) -> PSStep:
@@ -52,20 +56,16 @@ def _step(
     name: str = "Old Name",
     description: str = "Old desc",
 ) -> StepRead:
-    return StepRead(
-        uid=1,
-        aid="trip-1",
-        id=step_id,
+    return make_step_read(
+        step_id=step_id,
         name=name,
         description=description,
-        timestamp=1_700_000_000.0,
         timezone_id="Europe/Amsterdam",
         location=_LOC,
-        elevation=0,
         weather=_WEATHER,
         cover=cover,
-        pages=pages or [],
-        unused=unused or [],
+        pages=pages,
+        unused=unused,
     )
 
 
@@ -74,30 +74,17 @@ def _album(
     front_cover_photo: str = "front.jpg",
     back_cover_photo: str = "back.jpg",
 ) -> Album:
-    return Album(
-        uid=1,
-        id="trip-1",
+    return make_album(
         title="Trip",
         subtitle="Sub",
         front_cover_photo=front_cover_photo,
         back_cover_photo=back_cover_photo,
         colors={},
-        hidden_steps=[],
-        maps_ranges=[],
-        font="Assistant",
-        body_font="Frank Ruhl Libre",
     )
 
 
 def _user() -> User:
-    return User(
-        id=_UID,
-        first_name="Test",
-        locale="en-US",
-        unit_is_km=True,
-        temperature_is_celsius=True,
-        google_sub="test",
-    )
+    return make_user(_UID, google_sub="test")
 
 
 class TestScanStepMedia:
@@ -361,9 +348,9 @@ class TestReconcileTripRebuildsSegments:
         (trip_dir / media_name).write_bytes(b"\xff\xd8")
 
         existing_steps = [_existing_step(1, pages=[[media_name]], cover=media_name)]
-        existing_media = AlbumMedia(
-            uid=_UID,
-            aid=_RECONCILE_AID,
+        existing_media = make_album_media(
+            _UID,
+            _RECONCILE_AID,
             name=media_name,
             kind="photo",
             width=640,

--- a/backend/tests/test_segment.py
+++ b/backend/tests/test_segment.py
@@ -2,19 +2,18 @@
 
 import pytest
 
-from app.models.polarsteps import Point
 from app.models.segment import Segment, SegmentKind, split_segments
+from tests.factories import make_points_from_tuples, make_segment
 
 
 def _seg(kind: str, points: list[tuple[float, float, float]]) -> Segment:
-    pts = [Point(lat=lat, lon=lon, time=t) for lat, lon, t in points]
-    return Segment(
-        uid=1,
-        aid="test",
+    pts = make_points_from_tuples(points)
+    return make_segment(
+        1,
+        "test",
         start_time=pts[0].time,
         end_time=pts[-1].time,
         kind=SegmentKind(kind),
-        timezone_id="UTC",
         points=pts,
     )
 

--- a/backend/tests/test_segment_routes.py
+++ b/backend/tests/test_segment_routes.py
@@ -20,6 +20,9 @@ from .factories import AID, insert_album, insert_segment
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
+type Route = list[tuple[float, float]]
+type SegmentSeed = tuple[float, float, SegmentKind]
+
 
 @asynccontextmanager
 async def _lock(*, acquired: bool = True) -> AsyncIterator[bool]:
@@ -28,6 +31,65 @@ async def _lock(*, acquired: bool = True) -> AsyncIterator[bool]:
 
 def _http() -> SimpleNamespace:
     return SimpleNamespace(mapbox_matching=object(), mapbox_directions=object())
+
+
+def _stats(
+    *, requests: int = 1, matching_requests: int = 1, directions_requests: int = 0
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        requests=requests,
+        matching_requests=matching_requests,
+        directions_requests=directions_requests,
+    )
+
+
+async def _seed_segments(engine: AsyncEngine, uid: int, *segments: SegmentSeed) -> None:
+    async with AsyncSession(engine) as session:
+        await insert_album(session, uid)
+        for start_time, end_time, kind in segments:
+            await insert_segment(
+                session,
+                uid,
+                start_time=start_time,
+                end_time=end_time,
+                kind=kind,
+            )
+        await session.commit()
+
+
+async def _run_route_enrichment(
+    engine: AsyncEngine,
+    uid: int,
+    *,
+    http: SimpleNamespace | None = None,
+    lock_acquired: bool = True,
+    route_result: tuple[list[Route | None], SimpleNamespace] | None = None,
+    side_effect: object | None = None,
+) -> SimpleNamespace:
+    http = http or _http()
+    match_segments = AsyncMock(
+        side_effect=side_effect,
+        return_value=route_result or ([], _stats(requests=0, matching_requests=0)),
+    )
+
+    with (
+        patch("app.logic.segment_routes.get_engine", return_value=engine) as get_engine,
+        patch(
+            "app.logic.segment_routes.try_advisory_lock",
+            return_value=_lock(acquired=lock_acquired),
+        ),
+        patch(
+            "app.logic.segment_routes.match_segments_with_stats",
+            new=match_segments,
+        ),
+    ):
+        await match_album_segment_routes(http, uid, AID)
+
+    return SimpleNamespace(
+        get_engine=get_engine,
+        match_segments=match_segments,
+        http=http,
+    )
 
 
 def test_enqueue_album_route_enrichment_adds_background_task() -> None:
@@ -62,43 +124,21 @@ async def test_unmatched_driving_and_walking_segments_get_routes(
     uid = 3001
     driving_route = [(4.0, 52.0), (4.1, 52.1)]
     walking_route = [(5.0, 53.0), (5.1, 53.1)]
-    async with AsyncSession(engine) as session:
-        await insert_album(session, uid)
-        await insert_segment(
-            session,
-            uid,
-            start_time=100.0,
-            end_time=200.0,
-            kind=SegmentKind.driving,
-        )
-        await insert_segment(
-            session,
-            uid,
-            start_time=300.0,
-            end_time=400.0,
-            kind=SegmentKind.walking,
-        )
-        await session.commit()
+    await _seed_segments(
+        engine,
+        uid,
+        (100.0, 200.0, SegmentKind.driving),
+        (300.0, 400.0, SegmentKind.walking),
+    )
 
-    http = _http()
-    with (
-        patch("app.logic.segment_routes.get_engine", return_value=engine),
-        patch("app.logic.segment_routes.try_advisory_lock", return_value=_lock()),
-        patch(
-            "app.logic.segment_routes.match_segments_with_stats",
-            new=AsyncMock(
-                return_value=(
-                    [driving_route, walking_route],
-                    SimpleNamespace(
-                        requests=2,
-                        matching_requests=1,
-                        directions_requests=1,
-                    ),
-                )
-            ),
-        ) as match_segments,
-    ):
-        await match_album_segment_routes(http, uid, AID)
+    result = await _run_route_enrichment(
+        engine,
+        uid,
+        route_result=(
+            [driving_route, walking_route],
+            _stats(requests=2, matching_requests=1, directions_requests=1),
+        ),
+    )
 
     assert (
         await _route_for(engine, uid, start_time=100.0, end_time=200.0) == driving_route
@@ -106,10 +146,11 @@ async def test_unmatched_driving_and_walking_segments_get_routes(
     assert (
         await _route_for(engine, uid, start_time=300.0, end_time=400.0) == walking_route
     )
+    match_segments = result.match_segments
     match_segments.assert_awaited_once()
     assert match_segments.await_args.args[:2] == (
-        http.mapbox_matching,
-        http.mapbox_directions,
+        result.http.mapbox_matching,
+        result.http.mapbox_directions,
     )
     assert [profile for _, profile in match_segments.await_args.args[2]] == [
         "driving",
@@ -119,34 +160,15 @@ async def test_unmatched_driving_and_walking_segments_get_routes(
 
 async def test_hike_and_flight_segments_are_skipped(engine: AsyncEngine) -> None:
     uid = 3002
-    async with AsyncSession(engine) as session:
-        await insert_album(session, uid)
-        await insert_segment(
-            session,
-            uid,
-            start_time=100.0,
-            end_time=200.0,
-            kind=SegmentKind.hike,
-        )
-        await insert_segment(
-            session,
-            uid,
-            start_time=300.0,
-            end_time=400.0,
-            kind=SegmentKind.flight,
-        )
-        await session.commit()
+    await _seed_segments(
+        engine,
+        uid,
+        (100.0, 200.0, SegmentKind.hike),
+        (300.0, 400.0, SegmentKind.flight),
+    )
 
-    with (
-        patch("app.logic.segment_routes.get_engine", return_value=engine),
-        patch("app.logic.segment_routes.try_advisory_lock", return_value=_lock()),
-        patch(
-            "app.logic.segment_routes.match_segments_with_stats", new=AsyncMock()
-        ) as match_segments,
-    ):
-        await match_album_segment_routes(_http(), uid, AID)
-
-    match_segments.assert_not_awaited()
+    result = await _run_route_enrichment(engine, uid)
+    result.match_segments.assert_not_awaited()
     assert await _route_for(engine, uid, start_time=100.0, end_time=200.0) is None
     assert await _route_for(engine, uid, start_time=300.0, end_time=400.0) is None
 
@@ -154,16 +176,7 @@ async def test_hike_and_flight_segments_are_skipped(engine: AsyncEngine) -> None
 async def test_rows_deleted_before_write_are_skipped(engine: AsyncEngine) -> None:
     uid = 3003
     route = [(4.0, 52.0), (4.1, 52.1)]
-    async with AsyncSession(engine) as session:
-        await insert_album(session, uid)
-        await insert_segment(
-            session,
-            uid,
-            start_time=100.0,
-            end_time=200.0,
-            kind=SegmentKind.driving,
-        )
-        await session.commit()
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
 
     async def delete_then_match(
         *_args: object,
@@ -179,15 +192,7 @@ async def test_rows_deleted_before_write_are_skipped(engine: AsyncEngine) -> Non
             directions_requests=0,
         )
 
-    with (
-        patch("app.logic.segment_routes.get_engine", return_value=engine),
-        patch("app.logic.segment_routes.try_advisory_lock", return_value=_lock()),
-        patch(
-            "app.logic.segment_routes.match_segments_with_stats",
-            new=AsyncMock(side_effect=delete_then_match),
-        ),
-    ):
-        await match_album_segment_routes(_http(), uid, AID)
+    await _run_route_enrichment(engine, uid, side_effect=delete_then_match)
 
     async with AsyncSession(engine) as session:
         assert await session.get(Segment, (uid, AID, 100.0, 200.0)) is None
@@ -195,58 +200,21 @@ async def test_rows_deleted_before_write_are_skipped(engine: AsyncEngine) -> Non
 
 async def test_none_route_leaves_row_unchanged(engine: AsyncEngine) -> None:
     uid = 3004
-    async with AsyncSession(engine) as session:
-        await insert_album(session, uid)
-        await insert_segment(
-            session,
-            uid,
-            start_time=100.0,
-            end_time=200.0,
-            kind=SegmentKind.driving,
-        )
-        await session.commit()
-
-    with (
-        patch("app.logic.segment_routes.get_engine", return_value=engine),
-        patch("app.logic.segment_routes.try_advisory_lock", return_value=_lock()),
-        patch(
-            "app.logic.segment_routes.match_segments_with_stats",
-            new=AsyncMock(
-                return_value=(
-                    [None],
-                    SimpleNamespace(
-                        requests=1,
-                        matching_requests=1,
-                        directions_requests=0,
-                    ),
-                )
-            ),
-        ),
-    ):
-        await match_album_segment_routes(_http(), uid, AID)
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+    await _run_route_enrichment(
+        engine,
+        uid,
+        route_result=([None], _stats()),
+    )
 
     assert await _route_for(engine, uid) is None
 
 
 async def test_advisory_lock_already_held_skips_run(engine: AsyncEngine) -> None:
     uid = 3005
-    async with AsyncSession(engine) as session:
-        await insert_album(session, uid)
-        await insert_segment(session, uid, start_time=100.0, end_time=200.0)
-        await session.commit()
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+    result = await _run_route_enrichment(engine, uid, lock_acquired=False)
 
-    with (
-        patch("app.logic.segment_routes.get_engine", return_value=engine) as get_engine,
-        patch(
-            "app.logic.segment_routes.try_advisory_lock",
-            return_value=_lock(acquired=False),
-        ),
-        patch(
-            "app.logic.segment_routes.match_segments_with_stats", new=AsyncMock()
-        ) as match_segments,
-    ):
-        await match_album_segment_routes(_http(), uid, AID)
-
-    get_engine.assert_not_called()
-    match_segments.assert_not_awaited()
+    result.get_engine.assert_not_called()
+    result.match_segments.assert_not_awaited()
     assert await _route_for(engine, uid) is None

--- a/backend/tests/test_segments.py
+++ b/backend/tests/test_segments.py
@@ -13,6 +13,7 @@ from app.logic.spatial.segments import (
 from app.logic.trip_processing import multi_day_hike_ranges, segment_timezone
 from app.models.polarsteps import Point, PSLocations, PSTrip
 from app.models.segment import Segment, SegmentData, SegmentKind
+from tests.factories import make_segment
 
 _BASE_TS = datetime(2024, 1, 1, tzinfo=UTC).timestamp()
 
@@ -476,9 +477,9 @@ def _multi_day_seg(
         lat += km / _KM_PER_DEG_LAT
         points.append(Point(lat=lat, lon=0.0, time=t_end))
 
-    return Segment(
-        uid=1,
-        aid="trip1",
+    return make_segment(
+        1,
+        "trip1",
         start_time=points[0].time,
         end_time=points[-1].time,
         kind=SegmentKind.hike,
@@ -493,9 +494,9 @@ def _minimal_seg(
     end: float,
     tz: str = "America/Santiago",
 ) -> Segment:
-    return Segment(
-        uid=1,
-        aid="trip1",
+    return make_segment(
+        1,
+        "trip1",
         start_time=start,
         end_time=end,
         kind=kind,
@@ -516,9 +517,9 @@ class TestMultiDayHikeRanges:
         zone = ZoneInfo("America/Santiago")
         t1 = datetime(2024, 12, 8, 8, 0, tzinfo=zone).timestamp()
         t2 = datetime(2024, 12, 8, 23, 30, tzinfo=zone).timestamp()
-        seg = Segment(
-            uid=1,
-            aid="trip1",
+        seg = make_segment(
+            1,
+            "trip1",
             start_time=t1,
             end_time=t2,
             kind=SegmentKind.hike,
@@ -598,9 +599,9 @@ class TestMultiDayHikeRanges:
         t1 = datetime(d1.year, d1.month, d1.day, 18, 0, tzinfo=zone).timestamp()
         t2 = datetime(d1.year, d1.month, d1.day, 23, 59, tzinfo=zone).timestamp()
         t3 = datetime(d2.year, d2.month, d2.day, 6, 0, tzinfo=zone).timestamp()
-        seg = Segment(
-            uid=1,
-            aid="trip1",
+        seg = make_segment(
+            1,
+            "trip1",
             start_time=t1,
             end_time=t3,
             kind=SegmentKind.hike,
@@ -620,9 +621,9 @@ class TestMultiDayHikeRanges:
         t1 = datetime(d1.year, d1.month, d1.day, 14, 0, tzinfo=zone).timestamp()
         t_mid = datetime(d1.year, d1.month, d1.day, 23, 30, tzinfo=zone).timestamp()
         t2 = datetime(d2.year, d2.month, d2.day, 10, 0, tzinfo=zone).timestamp()
-        seg = Segment(
-            uid=1,
-            aid="trip1",
+        seg = make_segment(
+            1,
+            "trip1",
             start_time=t1,
             end_time=t2,
             kind=SegmentKind.hike,
@@ -660,9 +661,9 @@ class TestMultiDayHikeRangesIntegration:
     ) -> list[Segment]:
         steps = sa_trip.all_steps
         return [
-            Segment(
-                uid=1,
-                aid="sa2024",
+            make_segment(
+                1,
+                "sa2024",
                 start_time=seg.points[0].time,
                 end_time=seg.points[-1].time,
                 kind=seg.kind,

--- a/backend/tests/test_segments.py
+++ b/backend/tests/test_segments.py
@@ -1,19 +1,3 @@
-"""Unit, regression, and integration tests for the segmentation pipeline.
-
-Unit tests use synthetic GPS data to cover:
-  - GPS noise removal (teleport + spike filters, step waypoint preservation)
-  - Segment classification (walking, driving, flight, hike)
-  - Hike validation thresholds (min duration, min distance, min displacement)
-  - Hike segments retain all densified points (no RDP simplification)
-  - Structural invariants (≥2 points, contiguous boundaries)
-  - Robustness (empty steps, no GPS, single step, minimal input)
-
-Integration tests use the South America 2024-2025 trip to verify segmentation
-against known ground truth (hike times, structural invariants).  All integration
-tests build segments from the full trip (all steps + all GPS points), matching
-how segments are pre-computed at user creation time.
-"""
-
 import datetime as _dt_mod
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -30,19 +14,14 @@ from app.logic.trip_processing import multi_day_hike_ranges, segment_timezone
 from app.models.polarsteps import Point, PSLocations, PSTrip
 from app.models.segment import Segment, SegmentData, SegmentKind
 
-# Helpers
-
-# All synthetic tests use 2024-01-01 UTC as the base date.
 _BASE_TS = datetime(2024, 1, 1, tzinfo=UTC).timestamp()
 
 
 def _ts(hours: float) -> float:
-    """Unix timestamp at base-date midnight + ``hours``."""
     return _BASE_TS + hours * 3600.0
 
 
 def _dt(hours: float) -> datetime:
-    """Aware UTC datetime at base-date midnight + ``hours``."""
     return datetime.fromtimestamp(_ts(hours), tz=UTC)
 
 
@@ -54,8 +33,6 @@ class _Loc:
 
 @dataclass
 class _Step:
-    """Minimal StepLike for tests - mirrors the protocol in segments.py."""
-
     location: _Loc
     _hours: float
 
@@ -81,7 +58,6 @@ def _track(
     h1: float,
     n: int = 20,
 ) -> list[Point]:
-    """Linearly-interpolated GPS track with ``n+1`` equally spaced points."""
     return [
         _pt(
             lat0 + (lat1 - lat0) * i / n,
@@ -93,10 +69,6 @@ def _track(
 
 
 def _noise_df(rows: list[tuple]) -> pl.DataFrame:
-    """Build a DataFrame for ``_remove_gps_noise``.
-
-    Each row is ``(lat, lon, unix_time_seconds, is_step?)``.
-    """
     return pl.DataFrame(
         {
             "lat": [float(r[0]) for r in rows],
@@ -115,35 +87,29 @@ def _hikes(steps: list[_Step], gps: list[Point]) -> list[SegmentData]:
     return [s for s in build_segments(steps, gps) if s.kind == SegmentKind.hike]
 
 
-# GPS noise removal
-
-
 class TestNoiseRemoval:
     def test_teleport_removed(self) -> None:
-        """A GPS point that jumps at unrealistic speed is removed."""
         rows = [
             (0.0, 0.0, _ts(10.0), False),
-            (50.0, 0.0, _ts(10.0) + 10, False),  # teleport: 50° in 10s
+            (50.0, 0.0, _ts(10.0) + 10, False),
             (0.01, 0.0, _ts(12.0), False),
         ]
         df = _remove_gps_noise(_noise_df(rows))
         assert 50.0 not in df["lat"].to_list()
 
     def test_teleport_kept_when_step(self) -> None:
-        """A step waypoint survives even when it looks like a teleport."""
         rows = [
             (0.0, 0.0, _ts(10.0), False),
-            (50.0, 0.0, _ts(10.0) + 10, True),  # same jump, but is_step
+            (50.0, 0.0, _ts(10.0) + 10, True),
             (0.01, 0.0, _ts(12.0), False),
         ]
         df = _remove_gps_noise(_noise_df(rows))
         assert 50.0 in df["lat"].to_list()
 
     def test_spike_removed(self) -> None:
-        """A GPS detour that backtracks to the same position is removed."""
         rows = [
             (0.0, 0.0, _ts(10.0), False),
-            (0.0, 0.1, _ts(10.5), False),  # spike: 0.1° off path
+            (0.0, 0.1, _ts(10.5), False),
             (0.0, 0.005, _ts(11.0), False),
         ]
         df = _remove_gps_noise(_noise_df(rows))
@@ -151,22 +117,17 @@ class TestNoiseRemoval:
         assert 0.1 not in df["lon"].to_list()
 
     def test_spike_kept_when_step(self) -> None:
-        """A step waypoint survives even when it looks like a spike."""
         rows = [
             (0.0, 0.0, _ts(10.0), False),
-            (0.0, 0.1, _ts(10.5), True),  # same detour, but is_step
+            (0.0, 0.1, _ts(10.5), True),
             (0.0, 0.005, _ts(11.0), False),
         ]
         df = _remove_gps_noise(_noise_df(rows))
         assert 0.1 in df["lon"].to_list()
 
 
-# Segment classification
-
-
 class TestClassification:
     def test_no_other_kind_in_output(self) -> None:
-        """The internal 'other' label is always resolved to walking or driving."""
         gps = (
             _track(0.0, 0.0, 0.0, 0.01, h0=8.0, h1=9.0, n=10)
             + _track(0.0, 0.01, 0.0, 1.0, h0=9.5, h1=10.0, n=5)
@@ -176,46 +137,30 @@ class TestClassification:
         assert all(k.value != "other" for k in kinds)
 
     def test_slow_short_movement_is_walking(self) -> None:
-        """A short slow segment (below hike thresholds) -> walking."""
         gps = _track(0.0, 0.0, 0.0, 0.005, h0=9.0, h1=9.5, n=10)
         kinds = _segment_kinds([_step(0.0, 0.005, 9.5)], gps)
         assert SegmentKind.walking in kinds
         assert SegmentKind.hike not in kinds
 
     def test_fast_movement_is_driving(self) -> None:
-        """Movement well above hike speed -> driving."""
         gps = _track(0.0, 0.0, 0.0, 0.5, h0=9.0, h1=9.5, n=5)
         kinds = _segment_kinds([_step(0.0, 0.5, 9.5)], gps)
         assert SegmentKind.driving in kinds
         assert SegmentKind.hike not in kinds
 
     def test_flight_speed_is_flight(self) -> None:
-        """Movement above flight speed over flight distance -> flight."""
         gps = [
             _pt(0.0, 0.0, hours=10.0),
-            _pt(0.0, 5.0, hours=12.0),  # ~278 km/h over ~555 km
+            _pt(0.0, 5.0, hours=12.0),
         ]
         steps = [_step(0.0, 0.0, 9.0), _step(0.0, 5.0, 12.0)]
         assert SegmentKind.flight in _segment_kinds(steps, gps)
 
     def test_pre_first_step_flight_not_dropped(self) -> None:
-        """A flight before the first step must not be silently dropped.
-
-        Simulates: fly from city A to layover city B (no step there), walk
-        around B, fly to destination city C (first step).  Both flights
-        occur before the first step's timestamp.
-
-        Regression: _emit_segments skipped pre-first-step flights, which
-        caused the stitch logic to merge the layover walking + second
-        flight into one giant "walking" segment rendered as a thick
-        dashed line across the ocean.
-        """
-        # City A (h0) -> fly -> City B (h3-h8 walking) -> fly -> City C (h22+)
         gps_a = [_pt(32.0, 35.0, hours=0.0)]
         gps_b = _track(25.0, 55.0, 25.01, 55.01, h0=3.5, h1=8.0, n=20)
         gps_c = _track(-34.6, -58.4, -34.61, -58.41, h0=22.0, h1=26.0, n=20)
 
-        # Only step is in city C (the destination)
         steps = [_step(-34.6, -58.4, 22.0)]
 
         segments = list(build_segments(steps, gps_a + gps_b + gps_c))
@@ -223,7 +168,6 @@ class TestClassification:
         assert kinds.count(SegmentKind.flight) >= 2, (
             f"Expected ≥2 flights in {kinds} - pre-first-step flights were dropped"
         )
-        # No walking segment should span continents (> 5° lat/lon)
         for seg in segments:
             if seg.kind == SegmentKind.walking:
                 p0, p1 = seg.points[0], seg.points[-1]
@@ -235,22 +179,12 @@ class TestClassification:
                 assert abs(p0.lon - p1.lon) < 5, msg
 
     def test_valid_hike_detected(self) -> None:
-        """A clear multi-hour walk at hike speed -> hike."""
         gps = _track(0.0, 0.0, 0.0, 0.2, h0=8.0, h1=14.0, n=50)
         assert _hikes([_step(0.0, 0.2, 14.0)], gps)
 
     def test_brief_transfer_between_hikes_absorbed(self) -> None:
-        """A short fast gap (taxi between trailheads) between two hikes -> one hike.
-
-        Regression: a 5-min drive at 17 km/h between two hike days produced
-        two separate hike segments, breaking the single-hike-segment
-        assumption in the frontend's HikeMapPage.
-        """
-        # Hike day 1: 3h, ~6 km at ~2 km/h
         hike1 = _track(0.0, 0.0, 0.0, 0.05, h0=8.0, h1=11.0, n=30)
-        # 10 min taxi at ~20 km/h (0.03° ≈ 3.3 km in 10 min)
         taxi = [_pt(0.0, 0.05, hours=11.0), _pt(0.0, 0.08, hours=11.17)]
-        # Hike day 2: 3h, ~6 km
         hike2 = _track(0.0, 0.08, 0.0, 0.13, h0=11.17, h1=14.17, n=30)
 
         steps = [_step(0.0, 0.0, 8.0), _step(0.0, 0.13, 14.17)]
@@ -260,22 +194,14 @@ class TestClassification:
         )
 
 
-# Hike validation thresholds
-
-
 class TestHikeValidation:
     def test_below_min_duration_is_not_hike(self) -> None:
-        """A hike-speed track shorter than MIN_HIKE_H -> walking."""
         gps = _track(0.0, 0.0, 0.0, 0.01, h0=9.0, h1=10.0, n=15)
         assert not _hikes([_step(0.0, 0.01, 10.0)], gps)
 
     def test_below_min_distance_is_not_hike(self) -> None:
-        """A hike-speed track shorter than MIN_HIKE_KM -> walking."""
         gps = _track(0.0, 0.0, 0.0, 0.009, h0=9.0, h1=12.0, n=30)
         assert not _hikes([_step(0.0, 0.009, 12.0)], gps)
-
-
-# Step location preservation
 
 
 def _point_near(
@@ -286,10 +212,6 @@ def _point_near(
 
 class TestStepPreservation:
     def test_step_in_out_and_back_hike(self) -> None:
-        """Step at turnaround of out-and-back hike appears in output.
-
-        Regression: RDP collapsed the path to two endpoints.
-        """
         gps = _track(0.0, 0.0, 0.0, 0.09, h0=8.0, h1=11.0, n=20) + _track(
             0.0, 0.09, 0.0, 0.0, h0=13.0, h1=16.0, n=20
         )
@@ -298,30 +220,19 @@ class TestStepPreservation:
         assert _point_near(hikes[0].points, 0.0, 0.15)
 
     def test_step_included_when_edge_speed_above_hike_max(self) -> None:
-        """Step is kept even when the GPS->step edge exceeds hike speed.
-
-        Regression: step-adjacent edges only had gap tolerance, not speed exemption.
-        """
         gps = _track(0.0, 0.0, 0.0, 0.05, h0=8.0, h1=13.0, n=30)
         hikes = _hikes([_step(0.0, 0.15, 13.5)], gps)
         assert hikes
         assert _point_near(hikes[0].points, 0.0, 0.15)
 
 
-# Hike point retention
-
-
 class TestHikePoints:
     def test_non_hike_segments_are_rdp_simplified(self) -> None:
-        """Non-hike segments (driving) are RDP-simplified."""
         gps = _track(0.0, 0.0, 0.0, 0.5, h0=9.0, h1=9.5, n=50)
         segments = list(build_segments([_step(0.0, 0.5, 9.5)], gps))
         for seg in segments:
             if seg.kind != SegmentKind.hike:
                 assert len(seg.points) <= 10
-
-
-# Structural invariants
 
 
 class TestStructure:
@@ -351,9 +262,6 @@ class TestStructure:
             )
 
 
-# Robustness
-
-
 class TestRobustness:
     def test_no_gps_does_not_crash(self) -> None:
         steps = [_step(0.0, 0.0, 9.0), _step(0.0, 0.1, 14.0)]
@@ -361,23 +269,16 @@ class TestRobustness:
         assert all(len(s.points) >= 2 for s in segments)
 
 
-# ---------------------------------------------------------------------------
-# Integration tests (real Polarsteps trip data)
-# ---------------------------------------------------------------------------
-
-# Tolerance for hike start/end times: GPS can be sparse so allow ±30 min.
 _TOL_S = 30 * 60
 
 
 def _cmp(ts: float, dt_str: str, tz: ZoneInfo) -> float:
-    """Return signed error (seconds) vs expected 'YYYY-MM-DD HH:MM' in tz."""
     ref = datetime.strptime(dt_str, "%Y-%m-%d %H:%M").replace(tzinfo=tz)
     return ts - ref.timestamp()
 
 
 @pytest.fixture(scope="module")
 def all_segments(sa_trip: PSTrip, sa_locations: PSLocations) -> list[SegmentData]:
-    """Build segments once from the full trip (all steps + GPS)."""
     steps = sorted(sa_trip.all_steps, key=lambda s: s.timestamp)
     return list(build_segments(steps, sa_locations.locations))
 
@@ -388,7 +289,6 @@ def _hikes_in_window(
     start: int,
     end: int,
 ) -> list[SegmentData]:
-    """Return hike segments whose midpoint falls within the step range's day window."""
     t0 = (
         steps[start]
         .datetime.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -408,13 +308,6 @@ def _hikes_in_window(
 
 
 class TestKnownHikes:
-    """Verify detected hikes match known ground truth times.
-
-    Segments are built once from the full trip.  For each test case the hikes
-    whose midpoint falls inside the step range's day window are checked against
-    expected ground truth start/end times.
-    """
-
     @pytest.mark.parametrize(
         ("start", "end", "expected_hikes"),
         [
@@ -499,8 +392,6 @@ class TestKnownHikes:
 
 
 class TestFullTripInvariants:
-    """Structural invariants verified against the full trip."""
-
     def test_min_points_per_segment(self, all_segments: list[SegmentData]) -> None:
         for i, seg in enumerate(all_segments):
             expected_min = (
@@ -522,7 +413,6 @@ class TestFullTripInvariants:
             )
 
     def test_hikes_are_simplified(self, all_segments: list[SegmentData]) -> None:
-        """Hike segments are RDP-simplified but retain at least 2 points."""
         hikes = [s for s in all_segments if s.kind == SegmentKind.hike]
         assert hikes
         for i, h in enumerate(hikes):
@@ -533,10 +423,6 @@ class TestStepLocationInHike:
     def test_step9_location_in_output(
         self, sa_trip: PSTrip, all_segments: list[SegmentData]
     ) -> None:
-        """Step 9 (Ushuaia viewpoint) must appear in the hike output.
-
-        Regression: RDP collapsed out-and-back paths to two endpoints.
-        """
         step9 = sa_trip.all_steps[9]
         hikes = [s for s in all_segments if s.kind == SegmentKind.hike]
 
@@ -552,8 +438,6 @@ class TestStepLocationInHike:
         )
 
 
-# -- Multi-day hike range detection ------------------------------------------
-
 _KM_PER_DEG_LAT = 111.32  # at equator
 
 
@@ -562,12 +446,6 @@ def _multi_day_seg(
     start_date: date,
     tz: str = "America/Santiago",
 ) -> Segment:
-    """Create a hike segment with specified GPS distance per calendar day.
-
-    Each day gets two points (08:00 and 17:00 local), spaced along latitude
-    at the equator so haversine distance ≈ the requested km.  Overnight gaps
-    have zero displacement (camping).
-    """
     zone = ZoneInfo(tz)
     points: list[Point] = []
     lat = 0.0
@@ -598,7 +476,6 @@ def _minimal_seg(
     end: float,
     tz: str = "America/Santiago",
 ) -> Segment:
-    """Segment with only start/end endpoints (no per-day detail)."""
     return Segment(
         uid=1,
         aid="trip1",
@@ -614,30 +491,13 @@ def _minimal_seg(
 
 
 class TestMultiDayHikeRanges:
-    """Tests for multi_day_hike_ranges (per-day distance analysis)."""
-
-    # -- Basic behaviour --
-
-    def test_multi_day_hike_produces_range(self) -> None:
-        seg = _multi_day_seg([14, 14, 14, 14], date(2024, 12, 8))
-        ranges = multi_day_hike_ranges([seg])
-        assert ranges == [(date(2024, 12, 8), date(2024, 12, 11))]
-
-    def test_single_day_hike_excluded(self) -> None:
-        # 6-hour same-day hike - only 1 point pair, 1 calendar day
-        seg = _multi_day_seg([8.0], date(2024, 12, 8))
-        assert multi_day_hike_ranges([seg]) == []
-
     def test_non_hike_segments_excluded(self) -> None:
         seg = _minimal_seg(SegmentKind.driving, 1e9, 1e9 + 4 * 86400)
         assert multi_day_hike_ranges([seg]) == []
 
     def test_uses_local_timezone_for_date(self) -> None:
-        """Late evening in Santiago (23:30 local) is still the same local date."""
         zone = ZoneInfo("America/Santiago")
-        # Dec 8 08:00 Santiago
         t1 = datetime(2024, 12, 8, 8, 0, tzinfo=zone).timestamp()
-        # Dec 8 23:30 Santiago - next day in UTC but same day local
         t2 = datetime(2024, 12, 8, 23, 30, tzinfo=zone).timestamp()
         seg = Segment(
             uid=1,
@@ -648,43 +508,73 @@ class TestMultiDayHikeRanges:
             timezone_id="America/Santiago",
             points=[
                 Point(lat=0.0, lon=0.0, time=t1),
-                Point(lat=0.072, lon=0.0, time=t2),  # ~8 km
+                Point(lat=0.072, lon=0.0, time=t2),
             ],
         )
         assert multi_day_hike_ranges([seg]) == []
 
+    @pytest.mark.parametrize(
+        ("daily_km", "start", "expected", "tz"),
+        [
+            (
+                [14, 14, 14, 14],
+                date(2024, 12, 8),
+                [(date(2024, 12, 8), date(2024, 12, 11))],
+                "America/Santiago",
+            ),
+            ([8.0], date(2024, 12, 8), [], "America/Santiago"),
+            (
+                [15, 14, 13, 14],
+                date(2024, 12, 1),
+                [(date(2024, 12, 1), date(2024, 12, 4))],
+                "America/Santiago",
+            ),
+            (
+                [2.5, 2.3],
+                date(2025, 6, 10),
+                [(date(2025, 6, 10), date(2025, 6, 11))],
+                "America/Lima",
+            ),
+            (
+                [12, 10, 11, 9, 10, 11, 10, 8],
+                date(2025, 8, 10),
+                [(date(2025, 8, 10), date(2025, 8, 17))],
+                "America/Santiago",
+            ),
+            ([10.0, 1.5], date(2024, 12, 24), [], "America/Santiago"),
+            (
+                [6.0, 5.0],
+                date(2025, 5, 14),
+                [(date(2025, 5, 14), date(2025, 5, 15))],
+                "America/Santiago",
+            ),
+            (
+                [0.3, 0.4, 5.0, 0.2, 0.3, 0.3, 0.4, 0.3],
+                date(2025, 1, 26),
+                [],
+                "America/Santiago",
+            ),
+        ],
+    )
+    def test_daily_distance_cases(
+        self,
+        daily_km: list[float],
+        start: date,
+        expected: list[tuple[date, date]],
+        tz: str,
+    ) -> None:
+        assert multi_day_hike_ranges([_multi_day_seg(daily_km, start, tz)]) == expected
+
     def test_multiple_hikes(self) -> None:
-        seg1 = _multi_day_seg([14, 14, 14, 14], date(2024, 12, 8))
-        seg2 = _multi_day_seg([10, 10, 10, 10], date(2025, 1, 7))
-        ranges = multi_day_hike_ranges([seg1, seg2])
+        ranges = multi_day_hike_ranges(
+            [
+                _multi_day_seg([14, 14, 14, 14], date(2024, 12, 8)),
+                _multi_day_seg([10, 10, 10, 10], date(2025, 1, 7)),
+            ]
+        )
         assert len(ranges) == 2
 
-    # -- True positives (confirmed good multi-day hikes) --
-
-    def test_patagonia_4day_trek(self) -> None:
-        seg = _multi_day_seg([15, 14, 13, 14], date(2024, 12, 1))
-        ranges = multi_day_hike_ranges([seg])
-        assert ranges == [(date(2024, 12, 1), date(2024, 12, 4))]
-
-    def test_2day_hike_low_daily_distance(self) -> None:
-        """Weakest true positive: models Jun 10-11 (4.8 km total, ~2.4 km/day)."""
-        seg = _multi_day_seg([2.5, 2.3], date(2025, 6, 10), "America/Lima")
-        ranges = multi_day_hike_ranges([seg])
-        assert ranges == [(date(2025, 6, 10), date(2025, 6, 11))]
-
-    def test_week_long_trek(self) -> None:
-        """Models Aug 10-17: 81.6 km over 8 days."""
-        seg = _multi_day_seg([12, 10, 11, 9, 10, 11, 10, 8], date(2025, 8, 10))
-        ranges = multi_day_hike_ranges([seg])
-        assert ranges == [(date(2025, 8, 10), date(2025, 8, 17))]
-
-    # -- False positives: not multi-day (real hike, single active day) --
-
     def test_midnight_crossing_single_day_hike(self) -> None:
-        """Nov 15-16: single hike on the 15th crossing midnight.
-
-        ~8 km day 1, ~1 km day 2.
-        """
         zone = ZoneInfo("America/Santiago")
         d1 = date(2024, 11, 15)
         d2 = d1 + timedelta(days=1)
@@ -700,31 +590,13 @@ class TestMultiDayHikeRanges:
             timezone_id="America/Santiago",
             points=[
                 Point(lat=0.0, lon=0.0, time=t1),
-                Point(lat=0.072, lon=0.0, time=t2),  # ~8 km
-                Point(lat=0.081, lon=0.0, time=t3),  # ~1 km more
+                Point(lat=0.072, lon=0.0, time=t2),
+                Point(lat=0.081, lon=0.0, time=t3),
             ],
         )
         assert multi_day_hike_ranges([seg]) == []
 
-    def test_single_day_hike_other_day_below_threshold(self) -> None:
-        """Dec 24-25: only the 24th had a hike.  Day 2 has < 2 km."""
-        seg = _multi_day_seg([10.0, 1.5], date(2024, 12, 24))
-        assert multi_day_hike_ranges([seg]) == []
-
-    def test_two_separate_day_hikes_included(self) -> None:
-        """May 14-15: two separate day hikes absorbed into one segment.
-
-        Each day has significant distance - the per-day check correctly
-        includes it.  The frontend shows a map covering both, which is useful.
-        """
-        seg = _multi_day_seg([6.0, 5.0], date(2025, 5, 14))
-        ranges = multi_day_hike_ranges([seg])
-        assert ranges == [(date(2025, 5, 14), date(2025, 5, 15))]
-
-    # -- False positives: GPS drift (not hikes at all) --
-
     def test_gps_drift_crosses_midnight(self) -> None:
-        """Dec 15-16: GPS drift, ~1.5 km total across 2 days."""
         zone = ZoneInfo("America/Santiago")
         d1 = date(2024, 12, 15)
         d2 = d1 + timedelta(days=1)
@@ -740,33 +612,19 @@ class TestMultiDayHikeRanges:
             timezone_id="America/Santiago",
             points=[
                 Point(lat=0.0, lon=0.0, time=t1),
-                Point(lat=0.009, lon=0.0, time=t_mid),  # ~1 km
-                Point(lat=0.0135, lon=0.0, time=t2),  # ~0.5 km more
+                Point(lat=0.009, lon=0.0, time=t_mid),
+                Point(lat=0.0135, lon=0.0, time=t2),
             ],
         )
         assert multi_day_hike_ranges([seg]) == []
 
-    def test_overmerged_camping_one_active_day(self) -> None:
-        """Jan 26-Feb 2: 171 h segment but only one day has real hiking."""
-        seg = _multi_day_seg(
-            [0.3, 0.4, 5.0, 0.2, 0.3, 0.3, 0.4, 0.3],
-            date(2025, 1, 26),
-        )
-        assert multi_day_hike_ranges([seg]) == []
-
-    # -- Merge --
-
     def test_adjacent_ranges_merged(self) -> None:
-        """May 25-26 + May 26-27 → single range May 25-27."""
         seg1 = _multi_day_seg([6.0, 4.0], date(2025, 5, 25))
         seg2 = _multi_day_seg([3.0, 5.0], date(2025, 5, 26))
         ranges = multi_day_hike_ranges([seg1, seg2])
         assert ranges == [(date(2025, 5, 25), date(2025, 5, 27))]
 
-    # -- Edge cases --
-
     def test_non_overlapping_ranges_stay_separate(self) -> None:
-        """Two multi-day hikes a week apart stay as separate ranges."""
         seg1 = _multi_day_seg([10, 10], date(2025, 4, 1))
         seg2 = _multi_day_seg([10, 10], date(2025, 4, 10))
         ranges = multi_day_hike_ranges([seg1, seg2])
@@ -777,14 +635,6 @@ class TestMultiDayHikeRanges:
 
 
 class TestMultiDayHikeRangesIntegration:
-    """Verify multi_day_hike_ranges against real South America 2024-2025 data.
-
-    Builds Segment objects from the full trip's pipeline output, exactly as
-    build_trip_objects() does, then checks that the per-day distance analysis
-    produces the expected ranges - eliminating false positives while keeping
-    all confirmed multi-day hikes.
-    """
-
     @pytest.fixture(scope="class")
     def real_segments(
         self,
@@ -812,10 +662,9 @@ class TestMultiDayHikeRangesIntegration:
     def test_confirmed_multiday_hikes_present(
         self, real_ranges: list[tuple[date, date]]
     ) -> None:
-        """All user-confirmed multi-day hikes must appear."""
         expected_good = [
-            (date(2024, 12, 1), date(2024, 12, 4)),  # Patagonia trek 1
-            (date(2024, 12, 8), date(2024, 12, 11)),  # Patagonia trek 2
+            (date(2024, 12, 1), date(2024, 12, 4)),
+            (date(2024, 12, 8), date(2024, 12, 11)),
         ]
         for start, end in expected_good:
             assert any(s <= start and end <= e for s, e in real_ranges), (
@@ -825,24 +674,23 @@ class TestMultiDayHikeRangesIntegration:
     def test_false_positives_eliminated(
         self, real_ranges: list[tuple[date, date]]
     ) -> None:
-        """Ranges that the old naive check produced but aren't real multi-day hikes."""
         should_not_appear = [
-            (date(2024, 11, 15), date(2024, 11, 16)),  # single hike on 15th
-            (date(2024, 12, 15), date(2024, 12, 16)),  # GPS drift
-            (date(2024, 12, 16), date(2024, 12, 17)),  # same drift, second hit
-            (date(2024, 12, 21), date(2024, 12, 22)),  # not a hike
-            (date(2025, 1, 4), date(2025, 1, 5)),  # not a hike
-            (date(2025, 2, 9), date(2025, 2, 10)),  # GPS drift
-            (date(2025, 2, 11), date(2025, 2, 12)),  # GPS drift
-            (date(2025, 5, 29), date(2025, 5, 30)),  # not a hike
-            (date(2025, 6, 7), date(2025, 6, 8)),  # not a hike
-            (date(2025, 6, 22), date(2025, 6, 23)),  # not a hike
-            (date(2025, 7, 6), date(2025, 7, 7)),  # not a hike
-            (date(2025, 7, 10), date(2025, 7, 11)),  # not multiday
-            (date(2025, 7, 15), date(2025, 7, 16)),  # not a hike
-            (date(2025, 8, 29), date(2025, 8, 30)),  # not a hike
-            (date(2025, 8, 30), date(2025, 8, 31)),  # not a hike
-            (date(2025, 9, 1), date(2025, 9, 2)),  # not a hike
+            (date(2024, 11, 15), date(2024, 11, 16)),
+            (date(2024, 12, 15), date(2024, 12, 16)),
+            (date(2024, 12, 16), date(2024, 12, 17)),
+            (date(2024, 12, 21), date(2024, 12, 22)),
+            (date(2025, 1, 4), date(2025, 1, 5)),
+            (date(2025, 2, 9), date(2025, 2, 10)),
+            (date(2025, 2, 11), date(2025, 2, 12)),
+            (date(2025, 5, 29), date(2025, 5, 30)),
+            (date(2025, 6, 7), date(2025, 6, 8)),
+            (date(2025, 6, 22), date(2025, 6, 23)),
+            (date(2025, 7, 6), date(2025, 7, 7)),
+            (date(2025, 7, 10), date(2025, 7, 11)),
+            (date(2025, 7, 15), date(2025, 7, 16)),
+            (date(2025, 8, 29), date(2025, 8, 30)),
+            (date(2025, 8, 30), date(2025, 8, 31)),
+            (date(2025, 9, 1), date(2025, 9, 2)),
         ]
         for start, end in should_not_appear:
             assert (start, end) not in real_ranges, (
@@ -850,15 +698,11 @@ class TestMultiDayHikeRangesIntegration:
             )
 
     def test_split_hike_merged(self, real_ranges: list[tuple[date, date]]) -> None:
-        """May 25-26 + May 26-27 should merge into a single range."""
         assert (date(2025, 5, 25), date(2025, 5, 26)) not in real_ranges
         assert (date(2025, 5, 26), date(2025, 5, 27)) not in real_ranges
-        # Merged range should exist
         assert any(
             s <= date(2025, 5, 25) and date(2025, 5, 27) <= e for s, e in real_ranges
         ), "May 25-27 merged range missing"
 
     def test_range_count_reduced(self, real_ranges: list[tuple[date, date]]) -> None:
-        """Fewer ranges than the old naive date-crossing check."""
-        # Old naive check produced 40 ranges; new should be ~22
         assert len(real_ranges) < 30, f"Too many ranges: {len(real_ranges)}"

--- a/backend/tests/test_segments.py
+++ b/backend/tests/test_segments.py
@@ -79,6 +79,33 @@ def _noise_df(rows: list[tuple]) -> pl.DataFrame:
     )
 
 
+def _teleport_rows(*, is_step: bool) -> list[tuple[float, float, float, bool]]:
+    return [
+        (0.0, 0.0, _ts(10.0), False),
+        (50.0, 0.0, _ts(10.0) + 10, is_step),
+        (0.01, 0.0, _ts(12.0), False),
+    ]
+
+
+def _spike_rows(*, is_step: bool) -> list[tuple[float, float, float, bool]]:
+    return [
+        (0.0, 0.0, _ts(10.0), False),
+        (0.0, 0.1, _ts(10.5), is_step),
+        (0.0, 0.005, _ts(11.0), False),
+    ]
+
+
+def _assert_noise_value(
+    rows: list[tuple[float, float, float, bool]],
+    column: str,
+    value: float,
+    *,
+    kept: bool,
+) -> None:
+    values = _remove_gps_noise(_noise_df(rows))[column].to_list()
+    assert (value in values) is kept
+
+
 def _segment_kinds(steps: list[_Step], gps: list[Point]) -> set[SegmentKind]:
     return {s.kind for s in build_segments(steps, gps)}
 
@@ -87,43 +114,30 @@ def _hikes(steps: list[_Step], gps: list[Point]) -> list[SegmentData]:
     return [s for s in build_segments(steps, gps) if s.kind == SegmentKind.hike]
 
 
+def _assert_segment_kind(
+    steps: list[_Step],
+    gps: list[Point],
+    expected: SegmentKind,
+    unexpected: SegmentKind | None = None,
+) -> None:
+    kinds = _segment_kinds(steps, gps)
+    assert expected in kinds
+    if unexpected is not None:
+        assert unexpected not in kinds
+
+
 class TestNoiseRemoval:
     def test_teleport_removed(self) -> None:
-        rows = [
-            (0.0, 0.0, _ts(10.0), False),
-            (50.0, 0.0, _ts(10.0) + 10, False),
-            (0.01, 0.0, _ts(12.0), False),
-        ]
-        df = _remove_gps_noise(_noise_df(rows))
-        assert 50.0 not in df["lat"].to_list()
+        _assert_noise_value(_teleport_rows(is_step=False), "lat", 50.0, kept=False)
 
     def test_teleport_kept_when_step(self) -> None:
-        rows = [
-            (0.0, 0.0, _ts(10.0), False),
-            (50.0, 0.0, _ts(10.0) + 10, True),
-            (0.01, 0.0, _ts(12.0), False),
-        ]
-        df = _remove_gps_noise(_noise_df(rows))
-        assert 50.0 in df["lat"].to_list()
+        _assert_noise_value(_teleport_rows(is_step=True), "lat", 50.0, kept=True)
 
     def test_spike_removed(self) -> None:
-        rows = [
-            (0.0, 0.0, _ts(10.0), False),
-            (0.0, 0.1, _ts(10.5), False),
-            (0.0, 0.005, _ts(11.0), False),
-        ]
-        df = _remove_gps_noise(_noise_df(rows))
-        assert df.height == 2
-        assert 0.1 not in df["lon"].to_list()
+        _assert_noise_value(_spike_rows(is_step=False), "lon", 0.1, kept=False)
 
     def test_spike_kept_when_step(self) -> None:
-        rows = [
-            (0.0, 0.0, _ts(10.0), False),
-            (0.0, 0.1, _ts(10.5), True),
-            (0.0, 0.005, _ts(11.0), False),
-        ]
-        df = _remove_gps_noise(_noise_df(rows))
-        assert 0.1 in df["lon"].to_list()
+        _assert_noise_value(_spike_rows(is_step=True), "lon", 0.1, kept=True)
 
 
 class TestClassification:
@@ -137,24 +151,27 @@ class TestClassification:
         assert all(k.value != "other" for k in kinds)
 
     def test_slow_short_movement_is_walking(self) -> None:
-        gps = _track(0.0, 0.0, 0.0, 0.005, h0=9.0, h1=9.5, n=10)
-        kinds = _segment_kinds([_step(0.0, 0.005, 9.5)], gps)
-        assert SegmentKind.walking in kinds
-        assert SegmentKind.hike not in kinds
+        _assert_segment_kind(
+            [_step(0.0, 0.005, 9.5)],
+            _track(0.0, 0.0, 0.0, 0.005, h0=9.0, h1=9.5, n=10),
+            SegmentKind.walking,
+            SegmentKind.hike,
+        )
 
     def test_fast_movement_is_driving(self) -> None:
-        gps = _track(0.0, 0.0, 0.0, 0.5, h0=9.0, h1=9.5, n=5)
-        kinds = _segment_kinds([_step(0.0, 0.5, 9.5)], gps)
-        assert SegmentKind.driving in kinds
-        assert SegmentKind.hike not in kinds
+        _assert_segment_kind(
+            [_step(0.0, 0.5, 9.5)],
+            _track(0.0, 0.0, 0.0, 0.5, h0=9.0, h1=9.5, n=5),
+            SegmentKind.driving,
+            SegmentKind.hike,
+        )
 
     def test_flight_speed_is_flight(self) -> None:
-        gps = [
-            _pt(0.0, 0.0, hours=10.0),
-            _pt(0.0, 5.0, hours=12.0),
-        ]
-        steps = [_step(0.0, 0.0, 9.0), _step(0.0, 5.0, 12.0)]
-        assert SegmentKind.flight in _segment_kinds(steps, gps)
+        _assert_segment_kind(
+            [_step(0.0, 0.0, 9.0), _step(0.0, 5.0, 12.0)],
+            [_pt(0.0, 0.0, hours=10.0), _pt(0.0, 5.0, hours=12.0)],
+            SegmentKind.flight,
+        )
 
     def test_pre_first_step_flight_not_dropped(self) -> None:
         gps_a = [_pt(32.0, 35.0, hours=0.0)]

--- a/backend/tests/test_segments.py
+++ b/backend/tests/test_segments.py
@@ -459,6 +459,18 @@ class TestStepLocationInHike:
 _KM_PER_DEG_LAT = 111.32  # at equator
 
 
+def _hike_seg(points: list[Point], tz: str = "America/Santiago") -> Segment:
+    return make_segment(
+        1,
+        "trip1",
+        start_time=points[0].time,
+        end_time=points[-1].time,
+        kind=SegmentKind.hike,
+        timezone_id=tz,
+        points=points,
+    )
+
+
 def _multi_day_seg(
     daily_km: list[float],
     start_date: date,
@@ -477,15 +489,7 @@ def _multi_day_seg(
         lat += km / _KM_PER_DEG_LAT
         points.append(Point(lat=lat, lon=0.0, time=t_end))
 
-    return make_segment(
-        1,
-        "trip1",
-        start_time=points[0].time,
-        end_time=points[-1].time,
-        kind=SegmentKind.hike,
-        timezone_id=tz,
-        points=points,
-    )
+    return _hike_seg(points, tz)
 
 
 def _minimal_seg(
@@ -517,17 +521,11 @@ class TestMultiDayHikeRanges:
         zone = ZoneInfo("America/Santiago")
         t1 = datetime(2024, 12, 8, 8, 0, tzinfo=zone).timestamp()
         t2 = datetime(2024, 12, 8, 23, 30, tzinfo=zone).timestamp()
-        seg = make_segment(
-            1,
-            "trip1",
-            start_time=t1,
-            end_time=t2,
-            kind=SegmentKind.hike,
-            timezone_id="America/Santiago",
-            points=[
+        seg = _hike_seg(
+            [
                 Point(lat=0.0, lon=0.0, time=t1),
                 Point(lat=0.072, lon=0.0, time=t2),
-            ],
+            ]
         )
         assert multi_day_hike_ranges([seg]) == []
 
@@ -599,18 +597,12 @@ class TestMultiDayHikeRanges:
         t1 = datetime(d1.year, d1.month, d1.day, 18, 0, tzinfo=zone).timestamp()
         t2 = datetime(d1.year, d1.month, d1.day, 23, 59, tzinfo=zone).timestamp()
         t3 = datetime(d2.year, d2.month, d2.day, 6, 0, tzinfo=zone).timestamp()
-        seg = make_segment(
-            1,
-            "trip1",
-            start_time=t1,
-            end_time=t3,
-            kind=SegmentKind.hike,
-            timezone_id="America/Santiago",
-            points=[
+        seg = _hike_seg(
+            [
                 Point(lat=0.0, lon=0.0, time=t1),
                 Point(lat=0.072, lon=0.0, time=t2),
                 Point(lat=0.081, lon=0.0, time=t3),
-            ],
+            ]
         )
         assert multi_day_hike_ranges([seg]) == []
 
@@ -621,18 +613,12 @@ class TestMultiDayHikeRanges:
         t1 = datetime(d1.year, d1.month, d1.day, 14, 0, tzinfo=zone).timestamp()
         t_mid = datetime(d1.year, d1.month, d1.day, 23, 30, tzinfo=zone).timestamp()
         t2 = datetime(d2.year, d2.month, d2.day, 10, 0, tzinfo=zone).timestamp()
-        seg = make_segment(
-            1,
-            "trip1",
-            start_time=t1,
-            end_time=t2,
-            kind=SegmentKind.hike,
-            timezone_id="America/Santiago",
-            points=[
+        seg = _hike_seg(
+            [
                 Point(lat=0.0, lon=0.0, time=t1),
                 Point(lat=0.009, lon=0.0, time=t_mid),
                 Point(lat=0.0135, lon=0.0, time=t2),
-            ],
+            ]
         )
         assert multi_day_hike_ranges([seg]) == []
 

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,6 +30,43 @@ def _mock_user(uid: int = 1) -> User:
     return user
 
 
+def _processing_events(
+    *events: ProcessingEvent,
+) -> Callable[[HttpClients, User], AsyncIterator[ProcessingEvent]]:
+    async def fake_processing(
+        _http: HttpClients, _user: User
+    ) -> AsyncIterator[ProcessingEvent]:
+        for event in events:
+            yield event
+
+    return fake_processing
+
+
+def _gated_processing(
+    gate: asyncio.Event,
+    *,
+    before: list[ProcessingEvent],
+    after: list[ProcessingEvent],
+) -> Callable[[HttpClients, User], AsyncIterator[ProcessingEvent]]:
+    async def fake_processing(
+        _http: HttpClients, _user: User
+    ) -> AsyncIterator[ProcessingEvent]:
+        for event in before:
+            yield event
+        await gate.wait()
+        for event in after:
+            yield event
+
+    return fake_processing
+
+
+def _scheduled_album_calls(uid: int) -> list[tuple[HttpClients, int, str]]:
+    return [
+        (_MOCK_HTTP, uid, "trip-1"),
+        (_MOCK_HTTP, uid, "trip-2"),
+    ]
+
+
 class TestProcessingSession:
     async def test_replay_past_events_on_late_subscribe(self) -> None:
         events = [
@@ -37,18 +74,10 @@ class TestProcessingSession:
             PhaseUpdate(phase="layouts", done=5, total=5),
         ]
 
-        async def fake_processing(
-            _http: HttpClients, _user: User
-        ) -> AsyncIterator[ProcessingEvent]:
-            for e in events:
-                yield e
-
-        with patch("app.logic.session.run_processing", fake_processing):
+        with patch("app.logic.session.run_processing", _processing_events(*events)):
             session = ProcessingSession(_MOCK_HTTP, _mock_user())
-            # Wait for processing to finish
             await session._task
             assert session.is_done
-            # Late subscriber still gets everything
             result = await collect_async(session.subscribe())
 
         assert result == events
@@ -56,34 +85,25 @@ class TestProcessingSession:
     async def test_enqueues_route_enrichment_after_successful_processing(
         self,
     ) -> None:
-        async def fake_processing(
-            _http: HttpClients, _user: User
-        ) -> AsyncIterator[ProcessingEvent]:
-            yield PhaseUpdate(phase="layouts", done=1, total=1)
-
         user = _mock_user(uid=42)
         with (
-            patch("app.logic.session.run_processing", fake_processing),
+            patch(
+                "app.logic.session.run_processing",
+                _processing_events(PhaseUpdate(phase="layouts", done=1, total=1)),
+            ),
             patch("app.logic.session.schedule_album_route_enrichment") as schedule,
         ):
             session = ProcessingSession(_MOCK_HTTP, user)
             await session._task
 
-        assert [call.args for call in schedule.call_args_list] == [
-            (_MOCK_HTTP, 42, "trip-1"),
-            (_MOCK_HTTP, 42, "trip-2"),
-        ]
+        calls = [call.args for call in schedule.call_args_list]
+        assert calls == _scheduled_album_calls(42)
 
     async def test_does_not_enqueue_route_enrichment_after_processing_error(
         self,
     ) -> None:
-        async def fake_processing(
-            _http: HttpClients, _user: User
-        ) -> AsyncIterator[ProcessingEvent]:
-            yield ErrorData()
-
         with (
-            patch("app.logic.session.run_processing", fake_processing),
+            patch("app.logic.session.run_processing", _processing_events(ErrorData())),
             patch("app.logic.session.schedule_album_route_enrichment") as schedule,
         ):
             session = ProcessingSession(_MOCK_HTTP, _mock_user())
@@ -104,30 +124,20 @@ class TestProcessStream:
         events_before_gate = [TripStart(trip_index=0)]
         events_after_gate = [PhaseUpdate(phase="elevations", done=1, total=5)]
 
-        async def fake_processing(
-            _http: HttpClients, _user: User
-        ) -> AsyncIterator[ProcessingEvent]:
-            for e in events_before_gate:
-                yield e
-            await gate.wait()
-            for e in events_after_gate:
-                yield e
-
         user = _mock_user(uid=99)
-        with patch("app.logic.session.run_processing", fake_processing):
-            # Start first subscriber - it will block at gate
+        with patch(
+            "app.logic.session.run_processing",
+            _gated_processing(gate, before=events_before_gate, after=events_after_gate),
+        ):
             session = ProcessingSession(_MOCK_HTTP, user)
             _sessions[user.id] = session
 
-            # Wait for first event to be produced
             await session._notify.wait()
 
-            # Second subscriber (reconnect) should get replayed events
             collected: list[ProcessingEvent] = []
             async for event in process_stream(_MOCK_HTTP, user):
                 collected.append(event)
                 if isinstance(event, TripStart):
-                    # After replay, release the gate
                     gate.set()
 
             assert collected == events_before_gate + events_after_gate
@@ -186,13 +196,11 @@ class TestProcessStream:
 
         user = _mock_user(uid=5)
         with patch("app.logic.session.run_processing", fake_processing):
-            # Start first stream
             session = ProcessingSession(_MOCK_HTTP, user)
             _sessions[user.id] = session
 
             await session._notify.wait()
 
-            # Start second stream (should reconnect, not create new)
             async def second_stream() -> list[ProcessingEvent]:
                 return await collect_async(process_stream(_MOCK_HTTP, user))
 
@@ -202,22 +210,22 @@ class TestProcessStream:
 
             result = await task
 
-        assert call_count == 1  # Only one processing run
+        assert call_count == 1
         assert result[0] == TripStart(trip_index=0)
 
     async def test_route_enrichment_survives_subscriber_disconnect(self) -> None:
         gate = asyncio.Event()
 
-        async def fake_processing(
-            _http: HttpClients, _user: User
-        ) -> AsyncIterator[ProcessingEvent]:
-            yield TripStart(trip_index=0)
-            await gate.wait()
-            yield PhaseUpdate(phase="layouts", done=1, total=1)
-
         user = _mock_user(uid=22)
         with (
-            patch("app.logic.session.run_processing", fake_processing),
+            patch(
+                "app.logic.session.run_processing",
+                _gated_processing(
+                    gate,
+                    before=[TripStart(trip_index=0)],
+                    after=[PhaseUpdate(phase="layouts", done=1, total=1)],
+                ),
+            ),
             patch("app.logic.session.schedule_album_route_enrichment") as schedule,
         ):
             stream = process_stream(_MOCK_HTTP, user)
@@ -229,7 +237,5 @@ class TestProcessStream:
             await session._task
 
         assert first == TripStart(trip_index=0)
-        assert [call.args for call in schedule.call_args_list] == [
-            (_MOCK_HTTP, 22, "trip-1"),
-            (_MOCK_HTTP, 22, "trip-2"),
-        ]
+        calls = [call.args for call in schedule.call_args_list]
+        assert calls == _scheduled_album_calls(22)

--- a/backend/tests/test_trip_pipeline.py
+++ b/backend/tests/test_trip_pipeline.py
@@ -17,8 +17,15 @@ from app.models.polarsteps import Location
 from app.models.segment import Segment, SegmentKind
 from app.models.step import Step
 from app.models.user import User
-from app.models.weather import Weather, WeatherData
-from tests.factories import collect_async, make_points
+from tests.factories import (
+    collect_async,
+    make_album,
+    make_album_media,
+    make_segment,
+    make_step,
+    make_user,
+    make_weather,
+)
 
 AID = "test-trip"
 UID = 1
@@ -48,14 +55,7 @@ async def _create_schema(engine: AsyncEngine) -> None:
 
 
 def _user() -> User:
-    return User(
-        id=UID,
-        first_name="Test",
-        locale="en-US",
-        unit_is_km=True,
-        temperature_is_celsius=True,
-        google_sub="test-sub",
-    )
+    return make_user(UID, google_sub="test-sub")
 
 
 def _album(
@@ -65,21 +65,16 @@ def _album(
     back_cover_photo: str = "b.jpg",
     font: str | None = "Assistant",
 ) -> Album:
-    values = {
-        "uid": UID,
-        "id": AID,
-        "title": title,
-        "subtitle": "",
-        "hidden_steps": [],
-        "maps_ranges": [],
-        "front_cover_photo": front_cover_photo,
-        "back_cover_photo": back_cover_photo,
-        "colors": {},
-        "body_font": "Frank Ruhl Libre",
-    }
-    if font is not None:
-        values["font"] = font
-    return Album(**values)
+    return make_album(
+        UID,
+        AID,
+        title=title,
+        subtitle="",
+        front_cover_photo=front_cover_photo,
+        back_cover_photo=back_cover_photo,
+        colors={},
+        font=font,
+    )
 
 
 def _step(
@@ -92,21 +87,18 @@ def _step(
     feels_like: float = 18.0,
     weather_icon: str = "sun",
 ) -> Step:
-    return Step(
-        uid=UID,
-        aid=AID,
-        id=step_id,
+    return make_step(
+        UID,
+        AID,
+        step_id=step_id,
         name=name,
         description="",
-        cover_media_name=cover_media_name,
         timestamp=timestamp,
         timezone_id="UTC",
         location=None,
         elevation=0,
-        weather=Weather(
-            day=WeatherData(temp=temp, feels_like=feels_like, icon=weather_icon),
-            night=None,
-        ),
+        weather=make_weather(temp=temp, feels_like=feels_like, icon=weather_icon),
+        cover_media_name=cover_media_name,
     )
 
 
@@ -131,27 +123,24 @@ def _reuploaded_step() -> Step:
 
 
 def _segment() -> Segment:
-    return Segment(
-        uid=UID,
-        aid=AID,
+    return make_segment(
+        UID,
+        AID,
         start_time=100.0,
         end_time=500.0,
         kind=SegmentKind.driving,
-        timezone_id="UTC",
-        points=make_points([100.0, 300.0, 500.0]),
     )
 
 
 def _cover_media() -> AlbumMedia:
-    return AlbumMedia(
-        uid=UID,
-        aid=AID,
+    return make_album_media(
+        UID,
+        AID,
         name="cover.jpg",
         kind="photo",
         width=640,
         height=480,
         byte_size=10,
-        upgrade_candidate=True,
     )
 
 
@@ -200,32 +189,21 @@ class TestProcessTripSegmentEvents:
             step_count=1,
             all_steps=[SimpleNamespace(location=location)],
         )
-        user = User(
-            id=UID,
-            first_name="Test",
-            locale="en-US",
-            unit_is_km=True,
-            temperature_is_celsius=True,
-            google_sub="test-sub",
-        )
+        user = _user()
         segments = [
-            Segment(
-                uid=UID,
-                aid=AID,
+            make_segment(
+                UID,
+                AID,
                 start_time=100.0,
                 end_time=200.0,
                 kind=SegmentKind.driving,
-                timezone_id="UTC",
-                points=make_points([100.0, 200.0]),
             ),
-            Segment(
-                uid=UID,
-                aid=AID,
+            make_segment(
+                UID,
+                AID,
                 start_time=300.0,
                 end_time=400.0,
                 kind=SegmentKind.walking,
-                timezone_id="UTC",
-                points=make_points([300.0, 400.0]),
             ),
         ]
         db_out: list = []

--- a/backend/tests/test_trip_pipeline.py
+++ b/backend/tests/test_trip_pipeline.py
@@ -1,11 +1,9 @@
-"""Regression tests for the processing pipeline."""
-
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sqlalchemy import event
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -25,6 +23,165 @@ from tests.factories import collect_async, make_points
 AID = "test-trip"
 UID = 1
 _MOCK_HTTP = MagicMock(spec=HttpClients)
+
+
+def _sqlite_engine(*, foreign_keys: bool = False) -> AsyncEngine:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    if foreign_keys:
+        event.listen(
+            engine.sync_engine,
+            "connect",
+            lambda dbapi_connection, _connection_record: dbapi_connection.execute(
+                "PRAGMA foreign_keys=ON"
+            ),
+        )
+    return engine
+
+
+async def _create_schema(engine: AsyncEngine) -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+
+def _user() -> User:
+    return User(
+        id=UID,
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        google_sub="test-sub",
+    )
+
+
+def _album(
+    *,
+    title: str = "Old Trip",
+    front_cover_photo: str = "a.jpg",
+    back_cover_photo: str = "b.jpg",
+    font: str | None = "Assistant",
+) -> Album:
+    values = {
+        "uid": UID,
+        "id": AID,
+        "title": title,
+        "subtitle": "",
+        "hidden_steps": [],
+        "maps_ranges": [],
+        "front_cover_photo": front_cover_photo,
+        "back_cover_photo": back_cover_photo,
+        "colors": {},
+        "body_font": "Frank Ruhl Libre",
+    }
+    if font is not None:
+        values["font"] = font
+    return Album(**values)
+
+
+def _step(
+    *,
+    step_id: int = 1,
+    name: str = "Old Step",
+    cover_media_name: str | None = None,
+    timestamp: float = 1_000_000.0,
+    temp: float = 20.0,
+    feels_like: float = 18.0,
+    weather_icon: str = "sun",
+) -> Step:
+    return Step(
+        uid=UID,
+        aid=AID,
+        id=step_id,
+        name=name,
+        description="",
+        cover_media_name=cover_media_name,
+        timestamp=timestamp,
+        timezone_id="UTC",
+        location=None,
+        elevation=0,
+        weather=Weather(
+            day=WeatherData(temp=temp, feels_like=feels_like, icon=weather_icon),
+            night=None,
+        ),
+    )
+
+
+def _reuploaded_album() -> Album:
+    return _album(
+        title="Reconciled Trip",
+        front_cover_photo="c.jpg",
+        back_cover_photo="d.jpg",
+        font=None,
+    )
+
+
+def _reuploaded_step() -> Step:
+    return _step(
+        step_id=2,
+        name="New Step",
+        timestamp=2_000_000.0,
+        temp=25.0,
+        feels_like=23.0,
+        weather_icon="cloud",
+    )
+
+
+def _segment() -> Segment:
+    return Segment(
+        uid=UID,
+        aid=AID,
+        start_time=100.0,
+        end_time=500.0,
+        kind=SegmentKind.driving,
+        timezone_id="UTC",
+        points=make_points([100.0, 300.0, 500.0]),
+    )
+
+
+def _cover_media() -> AlbumMedia:
+    return AlbumMedia(
+        uid=UID,
+        aid=AID,
+        name="cover.jpg",
+        kind="photo",
+        width=640,
+        height=480,
+        byte_size=10,
+        upgrade_candidate=True,
+    )
+
+
+async def _seed_album_state(engine: AsyncEngine, *objects: object) -> None:
+    async with AsyncSession(engine) as session:
+        session.add(_user())
+        await session.flush()
+        for obj in objects:
+            session.add(obj)
+            await session.flush()
+        await session.commit()
+
+
+async def _save_reuploaded_objects(
+    engine: AsyncEngine,
+    tmp_path: Path,
+    existing_album: Album,
+    *objects: object,
+) -> None:
+    trip_dir = tmp_path / AID
+    trip_dir.mkdir()
+
+    with patch("app.logic.trip_pipeline.get_engine", return_value=engine):
+        await _save_reupload(
+            uid=UID,
+            objects=list(objects),
+            reconciled_aids={AID},
+            existing_albums={AID: existing_album},
+            trip_dirs=[trip_dir],
+        )
 
 
 class TestProcessTripSegmentEvents:
@@ -107,121 +264,21 @@ class TestProcessTripSegmentEvents:
 
 
 class TestSaveReuploadDeletesSegments:
-    """Regression for stale Segments on reupload.
-
-    _save_reupload deleted Steps for reconciled albums but left stale Segments
-    in the DB.  Segments FK-cascade from Album, not Step, so deleting Steps
-    alone had no effect on Segments.
-    """
-
     async def test_reconciled_album_segments_are_deleted(self, tmp_path: Path) -> None:
-        engine = create_async_engine(
-            "sqlite+aiosqlite://",
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
-        async with engine.begin() as conn:
-            await conn.run_sync(SQLModel.metadata.create_all)
+        engine = _sqlite_engine()
+        await _create_schema(engine)
 
-        # Seed: user, album, step, and segment.
-        async with AsyncSession(engine) as session:
-            user = User(
-                id=UID,
-                first_name="Test",
-                locale="en-US",
-                unit_is_km=True,
-                temperature_is_celsius=True,
-                google_sub="test-sub",
-            )
-            session.add(user)
-            album = Album(
-                uid=UID,
-                id=AID,
-                title="Old Trip",
-                subtitle="",
-                hidden_steps=[],
-                maps_ranges=[],
-                front_cover_photo="a.jpg",
-                back_cover_photo="b.jpg",
-                colors={},
-                font="Assistant",
-                body_font="Frank Ruhl Libre",
-            )
-            session.add(album)
-            step = Step(
-                uid=UID,
-                aid=AID,
-                id=1,
-                name="Old Step",
-                description="",
-                cover_media_name=None,
-                timestamp=1_000_000.0,
-                timezone_id="UTC",
-                location=None,
-                elevation=0,
-                weather=Weather(
-                    day=WeatherData(temp=20.0, feels_like=18.0, icon="sun"),
-                    night=None,
-                ),
-            )
-            session.add(step)
-            segment = Segment(
-                uid=UID,
-                aid=AID,
-                start_time=100.0,
-                end_time=500.0,
-                kind=SegmentKind.driving,
-                timezone_id="UTC",
-                points=make_points([100.0, 300.0, 500.0]),
-            )
-            session.add(segment)
-            await session.commit()
+        album = _album()
+        await _seed_album_state(engine, album, _step(), _segment())
 
-        # New objects for the reupload (new step, no new segments - they'd
-        # normally be regenerated by the segment pipeline, but the reconcile
-        # path doesn't produce them).
-        new_album = Album(
-            uid=UID,
-            id=AID,
-            title="Reconciled Trip",
-            subtitle="",
-            hidden_steps=[],
-            maps_ranges=[],
-            front_cover_photo="c.jpg",
-            back_cover_photo="d.jpg",
-            colors={},
-            body_font="Frank Ruhl Libre",
-        )
-        new_step = Step(
-            uid=UID,
-            aid=AID,
-            id=2,
-            name="New Step",
-            description="",
-            cover_media_name=None,
-            timestamp=2_000_000.0,
-            timezone_id="UTC",
-            location=None,
-            elevation=0,
-            weather=Weather(
-                day=WeatherData(temp=25.0, feels_like=23.0, icon="cloud"),
-                night=None,
-            ),
+        await _save_reuploaded_objects(
+            engine,
+            tmp_path,
+            album,
+            _reuploaded_album(),
+            _reuploaded_step(),
         )
 
-        trip_dir = tmp_path / AID
-        trip_dir.mkdir()
-
-        with patch("app.logic.trip_pipeline.get_engine", return_value=engine):
-            await _save_reupload(
-                uid=UID,
-                objects=[new_album, new_step],
-                reconciled_aids={AID},
-                existing_albums={AID: album},
-                trip_dirs=[trip_dir],
-            )
-
-        # Verify: old segment must be gone, old step must be gone.
         async with AsyncSession(engine) as session:
             segments = (await session.exec(select(Segment))).all()
             steps = (await session.exec(select(Step))).all()
@@ -236,117 +293,24 @@ class TestSaveReuploadDeletesSegments:
     async def test_reupload_deletes_steps_before_cover_media(
         self, tmp_path: Path
     ) -> None:
-        engine = create_async_engine(
-            "sqlite+aiosqlite://",
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
-        event.listen(
-            engine.sync_engine,
-            "connect",
-            lambda dbapi_connection, _connection_record: dbapi_connection.execute(
-                "PRAGMA foreign_keys=ON"
-            ),
-        )
-        async with engine.begin() as conn:
-            await conn.run_sync(SQLModel.metadata.create_all)
+        engine = _sqlite_engine(foreign_keys=True)
+        await _create_schema(engine)
 
-        async with AsyncSession(engine) as session:
-            user = User(
-                id=UID,
-                first_name="Test",
-                locale="en-US",
-                unit_is_km=True,
-                temperature_is_celsius=True,
-                google_sub="test-sub",
-            )
-            album = Album(
-                uid=UID,
-                id=AID,
-                title="Old Trip",
-                subtitle="",
-                hidden_steps=[],
-                maps_ranges=[],
-                front_cover_photo="a.jpg",
-                back_cover_photo="b.jpg",
-                colors={},
-                font="Assistant",
-                body_font="Frank Ruhl Libre",
-            )
-            media = AlbumMedia(
-                uid=UID,
-                aid=AID,
-                name="cover.jpg",
-                kind="photo",
-                width=640,
-                height=480,
-                byte_size=10,
-                upgrade_candidate=True,
-            )
-            step = Step(
-                uid=UID,
-                aid=AID,
-                id=1,
-                name="Old Step",
-                description="",
-                cover_media_name="cover.jpg",
-                timestamp=1_000_000.0,
-                timezone_id="UTC",
-                location=None,
-                elevation=0,
-                weather=Weather(
-                    day=WeatherData(temp=20.0, feels_like=18.0, icon="sun"),
-                    night=None,
-                ),
-            )
-            session.add(user)
-            await session.flush()
-            session.add(album)
-            await session.flush()
-            session.add(media)
-            await session.flush()
-            session.add(step)
-            await session.commit()
-
-        new_album = Album(
-            uid=UID,
-            id=AID,
-            title="Reconciled Trip",
-            subtitle="",
-            hidden_steps=[],
-            maps_ranges=[],
-            front_cover_photo="c.jpg",
-            back_cover_photo="d.jpg",
-            colors={},
-            body_font="Frank Ruhl Libre",
+        album = _album()
+        await _seed_album_state(
+            engine,
+            album,
+            _cover_media(),
+            _step(cover_media_name="cover.jpg"),
         )
-        new_step = Step(
-            uid=UID,
-            aid=AID,
-            id=2,
-            name="New Step",
-            description="",
-            cover_media_name=None,
-            timestamp=2_000_000.0,
-            timezone_id="UTC",
-            location=None,
-            elevation=0,
-            weather=Weather(
-                day=WeatherData(temp=25.0, feels_like=23.0, icon="cloud"),
-                night=None,
-            ),
-        )
-        trip_dir = tmp_path / AID
-        trip_dir.mkdir()
 
-        with patch("app.logic.trip_pipeline.get_engine", return_value=engine):
-            await _save_reupload(
-                uid=UID,
-                objects=[new_album, new_step],
-                reconciled_aids={AID},
-                existing_albums={AID: album},
-                trip_dirs=[trip_dir],
-            )
+        await _save_reuploaded_objects(
+            engine,
+            tmp_path,
+            album,
+            _reuploaded_album(),
+            _reuploaded_step(),
+        )
 
         async with AsyncSession(engine) as session:
             steps = (await session.exec(select(Step))).all()

--- a/backend/tests/test_trip_processing.py
+++ b/backend/tests/test_trip_processing.py
@@ -8,29 +8,22 @@ from app.logic.trip_processing import (
     segment_timezone,
 )
 from app.models.polarsteps import Location, PSStep
-from app.models.user import User
+from tests.factories import make_ps_step, make_user
 
 
 class TestDefaultMediaResolutionWarningPreset:
     def test_uses_relaxed_warnings_for_normal_users(self) -> None:
-        user = User(
-            id=1,
-            first_name="Test",
-            locale="en-US",
-            unit_is_km=True,
-            temperature_is_celsius=True,
+        user = make_user(
+            1,
             google_sub="test-sub",
         )
 
         assert default_media_resolution_warning_preset(user) == "relaxed"
 
     def test_disables_warnings_for_demo_users(self) -> None:
-        user = User(
-            id=1,
+        user = make_user(
+            1,
             first_name="Demo",
-            locale="en-US",
-            unit_is_km=True,
-            temperature_is_celsius=True,
             is_demo=True,
         )
 
@@ -38,13 +31,11 @@ class TestDefaultMediaResolutionWarningPreset:
 
 
 def _step(name: str, country_code: str, timestamp: float = 0) -> PSStep:
-    return PSStep(
-        id=int(timestamp),
+    return make_ps_step(
+        int(timestamp),
         name=name,
-        slug=name.lower().replace(" ", "-"),
         description="",
         timestamp=timestamp,
-        timezone_id="UTC",
         location=Location(
             name=name, detail="", country_code=country_code, lat=0, lon=0
         ),

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -22,6 +22,12 @@ def _jpeg_bytes(width: int = 10, height: int = 10) -> bytes:
     return buf.getvalue()
 
 
+def _png_bytes(width: int = 10, height: int = 10) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height)).save(buf, "PNG")
+    return buf.getvalue()
+
+
 _DEFAULT_JPEG = _jpeg_bytes()
 
 
@@ -40,6 +46,11 @@ def _make_zip(**entries: bytes) -> io.BytesIO:
             zf.writestr(name, data)
     buf.seek(0)
     return buf
+
+
+def _assert_bad_zip(buf: io.BytesIO, tmp_path: Path, match: str) -> None:
+    with pytest.raises(zipfile.BadZipFile, match=match):
+        _safe_extract(buf, tmp_path)
 
 
 def _user_json(**overrides: str | int | bool) -> bytes:
@@ -103,8 +114,7 @@ class TestSafeExtract:
                 "c.jpg": _DEFAULT_JPEG,
             }
         )
-        with pytest.raises(zipfile.BadZipFile, match="too many files"):
-            _safe_extract(buf, tmp_path)
+        _assert_bad_zip(buf, tmp_path, "too many files")
 
     def test_rejects_symlinks(self, tmp_path: Path) -> None:
         buf = io.BytesIO()
@@ -114,16 +124,7 @@ class TestSafeExtract:
             info.external_attr = 0xA0000000
             zf.writestr(info, b"target")
         buf.seek(0)
-        with pytest.raises(zipfile.BadZipFile, match="Symlink not allowed"):
-            _safe_extract(buf, tmp_path)
-
-    def test_rejects_path_traversal(self, tmp_path: Path) -> None:
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, "w") as zf:
-            zf.writestr("../../etc/passwd", _DEFAULT_JPEG)
-        buf.seek(0)
-        with pytest.raises(zipfile.BadZipFile, match="Path traversal"):
-            _safe_extract(buf, tmp_path)
+        _assert_bad_zip(buf, tmp_path, "Symlink not allowed")
 
     def test_rejects_exceeding_size_limit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -131,23 +132,20 @@ class TestSafeExtract:
         monkeypatch.setattr("app.logic.upload._MAX_TOTAL_BYTES", 100)
         big_jpeg = _jpeg_bytes(200, 200)
         buf = _make_zip(**{"big.jpg": big_jpeg})
-        with pytest.raises(zipfile.BadZipFile, match="exceeds limit"):
-            _safe_extract(buf, tmp_path)
+        _assert_bad_zip(buf, tmp_path, "exceeds limit")
 
-    def test_rejects_disallowed_mime_type(self, tmp_path: Path) -> None:
-        # A PNG file has a recognizable MIME type that is NOT in the allow list
-        png_buf = io.BytesIO()
-        Image.new("RGB", (10, 10)).save(png_buf, "PNG")
-        buf = _make_zip(**{"image.png": png_buf.getvalue()})
-        with pytest.raises(zipfile.BadZipFile, match="Disallowed file type"):
-            _safe_extract(buf, tmp_path)
-
-    def test_rejects_executable(self, tmp_path: Path) -> None:
-        # ELF magic bytes → application/x-executable or similar
-        elf_header = b"\x7fELF" + b"\x00" * 100
-        buf = _make_zip(**{"malware.bin": elf_header})
-        with pytest.raises(zipfile.BadZipFile, match="Disallowed file type"):
-            _safe_extract(buf, tmp_path)
+    @pytest.mark.parametrize(
+        ("entry", "data", "match"),
+        [
+            ("../../etc/passwd", _DEFAULT_JPEG, "Path traversal"),
+            ("image.png", _png_bytes(), "Disallowed file type"),
+            ("malware.bin", b"\x7fELF" + b"\x00" * 100, "Disallowed file type"),
+        ],
+    )
+    def test_rejects_unsafe_entries(
+        self, tmp_path: Path, entry: str, data: bytes, match: str
+    ) -> None:
+        _assert_bad_zip(_make_zip(**{entry: data}), tmp_path, match)
 
 
 class TestScanUserFolder:

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -24,17 +24,13 @@ async def _insert_uploaded_albums(
 
 class TestDemoLocale:
     async def test_demo_respects_accept_language(self, user_routes: UserRoutes) -> None:
-        resp = await user_routes.demo(accept_language="he-IL,he;q=0.9,en;q=0.8")
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await user_routes.demo_ok(accept_language="he-IL,he;q=0.9,en;q=0.8")
         assert data["user"]["locale"] == "he-IL"
 
     async def test_demo_falls_back_to_fixture_locale(
         self, user_routes: UserRoutes
     ) -> None:
-        resp = await user_routes.demo()
-        assert resp.status_code == 200
-        data = resp.json()
+        data = await user_routes.demo_ok()
         # Fixture user.json has locale "en_GB" → normalized to "en-GB"
         assert data["user"]["locale"] == "en-GB"
 
@@ -43,8 +39,7 @@ class TestIsProcessed:
     """is_processed reflects whether albums in DB match the album_ids manifest."""
 
     async def test_demo_user_starts_unprocessed(self, user_routes: UserRoutes) -> None:
-        resp = await user_routes.demo()
-        body = resp.json()
+        body = await user_routes.demo_ok()
         assert body["user"]["has_data"] is True
         assert body["user"]["album_ids"]
         assert body["user"]["is_processed"] is False
@@ -62,9 +57,7 @@ class TestIsProcessed:
     ) -> None:
         await _insert_uploaded_albums(session, uploaded_user)
 
-        resp = await user_routes.current()
-        assert resp.status_code == 200
-        assert resp.json()["is_processed"] is True
+        assert (await user_routes.current_ok())["is_processed"] is True
 
     async def test_evicted_user_is_unprocessed(
         self,
@@ -76,9 +69,9 @@ class TestIsProcessed:
         await _insert_uploaded_albums(session, uploaded_user)
         shutil.rmtree(users_dir / str(uploaded_user["id"]))
 
-        resp = await user_routes.current()
-        assert resp.json()["is_processed"] is False
-        assert resp.json()["has_data"] is False
+        user = await user_routes.current_ok()
+        assert user["is_processed"] is False
+        assert user["has_data"] is False
 
     async def test_partial_processing_is_unprocessed(
         self,
@@ -96,5 +89,4 @@ class TestIsProcessed:
         )
         await session.commit()
 
-        resp = await user_routes.current()
-        assert resp.json()["is_processed"] is False
+        assert (await user_routes.current_ok())["is_processed"] is False

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -13,6 +13,15 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
+async def _insert_uploaded_albums(
+    session: AsyncSession,
+    uploaded_user: dict,
+) -> None:
+    for aid in uploaded_user["album_ids"]:
+        await insert_album(session, uploaded_user["id"], aid=aid)
+    await session.commit()
+
+
 class TestDemoLocale:
     async def test_demo_respects_accept_language(self, user_routes: UserRoutes) -> None:
         resp = await user_routes.demo(accept_language="he-IL,he;q=0.9,en;q=0.8")
@@ -51,9 +60,7 @@ class TestIsProcessed:
         user_routes: UserRoutes,
         uploaded_user: dict,
     ) -> None:
-        for aid in uploaded_user["album_ids"]:
-            await insert_album(session, uploaded_user["id"], aid=aid)
-        await session.commit()
+        await _insert_uploaded_albums(session, uploaded_user)
 
         resp = await user_routes.current()
         assert resp.status_code == 200
@@ -66,9 +73,7 @@ class TestIsProcessed:
         users_dir: Path,
         uploaded_user: dict,
     ) -> None:
-        for aid in uploaded_user["album_ids"]:
-            await insert_album(session, uploaded_user["id"], aid=aid)
-        await session.commit()
+        await _insert_uploaded_albums(session, uploaded_user)
         shutil.rmtree(users_dir / str(uploaded_user["id"]))
 
         resp = await user_routes.current()

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from app.models.user import User
 from tests.factories import insert_album, sign_in_and_upload
+from tests.helpers.users import UserRoutes
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -14,17 +15,16 @@ if TYPE_CHECKING:
 
 
 class TestDemoLocale:
-    async def test_demo_respects_accept_language(self, client: AsyncClient) -> None:
-        resp = await client.post(
-            "/api/v1/users/demo",
-            headers={"Accept-Language": "he-IL,he;q=0.9,en;q=0.8"},
-        )
+    async def test_demo_respects_accept_language(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.demo(accept_language="he-IL,he;q=0.9,en;q=0.8")
         assert resp.status_code == 200
         data = resp.json()
         assert data["user"]["locale"] == "he-IL"
 
-    async def test_demo_falls_back_to_fixture_locale(self, client: AsyncClient) -> None:
-        resp = await client.post("/api/v1/users/demo")
+    async def test_demo_falls_back_to_fixture_locale(
+        self, user_routes: UserRoutes
+    ) -> None:
+        resp = await user_routes.demo()
         assert resp.status_code == 200
         data = resp.json()
         # Fixture user.json has locale "en_GB" → normalized to "en-GB"
@@ -34,8 +34,8 @@ class TestDemoLocale:
 class TestIsProcessed:
     """is_processed reflects whether albums in DB match the album_ids manifest."""
 
-    async def test_demo_user_starts_unprocessed(self, client: AsyncClient) -> None:
-        resp = await client.post("/api/v1/users/demo")
+    async def test_demo_user_starts_unprocessed(self, user_routes: UserRoutes) -> None:
+        resp = await user_routes.demo()
         body = resp.json()
         assert body["user"]["has_data"] is True
         assert body["user"]["album_ids"]
@@ -50,19 +50,27 @@ class TestIsProcessed:
         assert user["is_processed"] is False
 
     async def test_processed_when_albums_exist(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        user_routes: UserRoutes,
+        tmp_path: Path,
     ) -> None:
         user = await sign_in_and_upload(client, tmp_path / "users")
         for aid in user["album_ids"]:
             await insert_album(session, user["id"], aid=aid)
         await session.commit()
 
-        resp = await client.get("/api/v1/users")
+        resp = await user_routes.current()
         assert resp.status_code == 200
         assert resp.json()["is_processed"] is True
 
     async def test_evicted_user_is_unprocessed(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        user_routes: UserRoutes,
+        tmp_path: Path,
     ) -> None:
         user = await sign_in_and_upload(client, tmp_path / "users")
         for aid in user["album_ids"]:
@@ -70,12 +78,16 @@ class TestIsProcessed:
         await session.commit()
         shutil.rmtree(tmp_path / "users" / str(user["id"]))
 
-        resp = await client.get("/api/v1/users")
+        resp = await user_routes.current()
         assert resp.json()["is_processed"] is False
         assert resp.json()["has_data"] is False
 
     async def test_partial_processing_is_unprocessed(
-        self, client: AsyncClient, session: AsyncSession, tmp_path: Path
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        user_routes: UserRoutes,
+        tmp_path: Path,
     ) -> None:
         user = await sign_in_and_upload(client, tmp_path / "users")
         u = await session.get(User, user["id"])
@@ -86,5 +98,5 @@ class TestIsProcessed:
         await insert_album(session, user["id"], aid=user["album_ids"][0])
         await session.commit()
 
-        resp = await client.get("/api/v1/users")
+        resp = await user_routes.current()
         assert resp.json()["is_processed"] is False

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -4,13 +4,12 @@ import shutil
 from typing import TYPE_CHECKING
 
 from app.models.user import User
-from tests.factories import insert_album, sign_in_and_upload
+from tests.factories import insert_album
 from tests.helpers.users import UserRoutes
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -41,24 +40,19 @@ class TestIsProcessed:
         assert body["user"]["album_ids"]
         assert body["user"]["is_processed"] is False
 
-    async def test_uploaded_user_starts_unprocessed(
-        self, client: AsyncClient, tmp_path: Path
-    ) -> None:
-        user = await sign_in_and_upload(client, tmp_path / "users")
-        assert user["has_data"] is True
-        assert user["album_ids"]
-        assert user["is_processed"] is False
+    async def test_uploaded_user_starts_unprocessed(self, uploaded_user: dict) -> None:
+        assert uploaded_user["has_data"] is True
+        assert uploaded_user["album_ids"]
+        assert uploaded_user["is_processed"] is False
 
     async def test_processed_when_albums_exist(
         self,
-        client: AsyncClient,
         session: AsyncSession,
         user_routes: UserRoutes,
-        tmp_path: Path,
+        uploaded_user: dict,
     ) -> None:
-        user = await sign_in_and_upload(client, tmp_path / "users")
-        for aid in user["album_ids"]:
-            await insert_album(session, user["id"], aid=aid)
+        for aid in uploaded_user["album_ids"]:
+            await insert_album(session, uploaded_user["id"], aid=aid)
         await session.commit()
 
         resp = await user_routes.current()
@@ -67,16 +61,15 @@ class TestIsProcessed:
 
     async def test_evicted_user_is_unprocessed(
         self,
-        client: AsyncClient,
         session: AsyncSession,
         user_routes: UserRoutes,
-        tmp_path: Path,
+        users_dir: Path,
+        uploaded_user: dict,
     ) -> None:
-        user = await sign_in_and_upload(client, tmp_path / "users")
-        for aid in user["album_ids"]:
-            await insert_album(session, user["id"], aid=aid)
+        for aid in uploaded_user["album_ids"]:
+            await insert_album(session, uploaded_user["id"], aid=aid)
         await session.commit()
-        shutil.rmtree(tmp_path / "users" / str(user["id"]))
+        shutil.rmtree(users_dir / str(uploaded_user["id"]))
 
         resp = await user_routes.current()
         assert resp.json()["is_processed"] is False
@@ -84,18 +77,18 @@ class TestIsProcessed:
 
     async def test_partial_processing_is_unprocessed(
         self,
-        client: AsyncClient,
         session: AsyncSession,
         user_routes: UserRoutes,
-        tmp_path: Path,
+        uploaded_user: dict,
     ) -> None:
-        user = await sign_in_and_upload(client, tmp_path / "users")
-        u = await session.get(User, user["id"])
+        u = await session.get(User, uploaded_user["id"])
         assert u is not None
-        u.album_ids = [user["album_ids"][0], "second-trip"]
+        u.album_ids = [uploaded_user["album_ids"][0], "second-trip"]
         session.add(u)
         await session.commit()
-        await insert_album(session, user["id"], aid=user["album_ids"][0])
+        await insert_album(
+            session, uploaded_user["id"], aid=uploaded_user["album_ids"][0]
+        )
         await session.commit()
 
         resp = await user_routes.current()

--- a/frontend/e2e/active-step-sync.test.ts
+++ b/frontend/e2e/active-step-sync.test.ts
@@ -1,20 +1,9 @@
-import { test, expect } from "./fixtures";
-
-async function ensureExternalMediaOpen(
-  page: import("@playwright/test").Page,
-) {
-  const importButton = page.getByRole("button", {
-    name: "Import external media",
-  });
-  const toggle = page.getByRole("button", { name: /External media/ });
-  if (!(await importButton.isVisible())) {
-    await toggle.click();
-  }
-  if (!(await importButton.isVisible())) {
-    await toggle.click();
-  }
-  await expect(importButton).toBeVisible();
-}
+import {
+  ensureExternalMediaOpen,
+  externalMediaImportButton,
+  test,
+  expect,
+} from "./fixtures";
 
 test.describe("Active step sync", () => {
   test("nav click keeps viewer, nav active state, and inspector target aligned", async ({
@@ -29,9 +18,7 @@ test.describe("Active step sync", () => {
     await nav.getByText("Argentina").click();
     await nav.locator('[data-nav-step="102"]').click();
     await expect(
-      page
-        .getByLabel("Inspector")
-        .getByRole("region", { name: "Unused" }),
+      page.getByLabel("Inspector").getByRole("region", { name: "Unused" }),
     ).toBeVisible();
 
     let importedStepId: string | null = null;
@@ -62,7 +49,8 @@ test.describe("Active step sync", () => {
 
     const fileChooser = page.waitForEvent("filechooser");
     await ensureExternalMediaOpen(page);
-    await page.getByRole("button", { name: "Import external media" }).click();
+    await expect(externalMediaImportButton(page)).toBeVisible();
+    await externalMediaImportButton(page).click();
     const chooser = await fileChooser;
     await chooser.setFiles({
       name: "import.jpg",

--- a/frontend/e2e/active-step-sync.test.ts
+++ b/frontend/e2e/active-step-sync.test.ts
@@ -1,5 +1,6 @@
 import {
   ensureExternalMediaOpen,
+  externalMediaCorsHeaders,
   externalMediaImportButton,
   test,
   expect,
@@ -25,14 +26,9 @@ test.describe("Active step sync", () => {
     await page.route(
       "**/api/v1/albums/*/external-media/add/device",
       async (route) => {
-        const headers = {
-          "access-control-allow-credentials": "true",
-          "access-control-allow-headers": "*",
-          "access-control-allow-methods": "POST, OPTIONS",
-          "access-control-allow-origin": new URL(page.url()).origin,
-        };
+        const headers = externalMediaCorsHeaders(page);
         if (route.request().method() === "OPTIONS") {
-          await route.fulfill({ headers, status: 204 });
+          await route.fulfill({ headers: headers.cors, status: 204 });
           return;
         }
         const form = route.request().postDataBuffer();
@@ -40,7 +36,7 @@ test.describe("Active step sync", () => {
           form.toString("utf8").match(/name="step_id"\r\n\r\n(\d+)/)?.[1] ??
           null;
         await route.fulfill({
-          headers: { ...headers, "content-type": "application/json" },
+          headers: headers.json,
           status: 200,
           body: JSON.stringify({ type: "import_completed", names: [] }),
         });

--- a/frontend/e2e/external-media-panel.test.ts
+++ b/frontend/e2e/external-media-panel.test.ts
@@ -1,8 +1,6 @@
 import { test, expect } from "./fixtures";
 
-async function ensureExternalMediaOpen(
-  page: import("@playwright/test").Page,
-) {
+async function ensureExternalMediaOpen(page: import("@playwright/test").Page) {
   const importButton = page.getByRole("button", {
     name: "Import external media",
   });
@@ -17,9 +15,8 @@ async function ensureExternalMediaOpen(
 
 test.describe("External media panel", () => {
   test("shows source status, upgrade action, and import target", async ({
-    authedPage: page,
+    editorPage: page,
   }) => {
-    await page.goto("/editor");
     await expect(page.getByText("South America")).toBeVisible({
       timeout: 15_000,
     });

--- a/frontend/e2e/external-media-panel.test.ts
+++ b/frontend/e2e/external-media-panel.test.ts
@@ -1,17 +1,9 @@
-import { test, expect } from "./fixtures";
-
-async function ensureExternalMediaOpen(page: import("@playwright/test").Page) {
-  const importButton = page.getByRole("button", {
-    name: "Import external media",
-  });
-  const toggle = page.getByRole("button", {
-    name: /Expand "External media"|Collapse "External media"/,
-  });
-  if (!(await importButton.isVisible())) {
-    await toggle.click();
-  }
-  await expect(importButton).toBeVisible();
-}
+import {
+  ensureExternalMediaOpen,
+  externalMediaImportButton,
+  test,
+  expect,
+} from "./fixtures";
 
 test.describe("External media panel", () => {
   test("shows source status, upgrade action, and import target", async ({
@@ -24,9 +16,7 @@ test.describe("External media panel", () => {
     await page.locator('[data-nav-step="1"]').click();
 
     await ensureExternalMediaOpen(page);
-    await expect(
-      page.getByRole("button", { name: "Import external media" }),
-    ).toBeVisible();
+    await expect(externalMediaImportButton(page)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Upgrade Media" }),
     ).toBeVisible();

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -174,6 +174,19 @@ export async function ensureExternalMediaOpen(page: Page) {
   await expect(toggle).toHaveAttribute("aria-expanded", "true");
 }
 
+export function externalMediaCorsHeaders(page: Page) {
+  const cors = {
+    "access-control-allow-credentials": "true",
+    "access-control-allow-headers": "*",
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-origin": new URL(page.url()).origin,
+  };
+  return {
+    cors,
+    json: { ...cors, "content-type": "application/json" },
+  };
+}
+
 export const test = base.extend<{
   anonymousPage: Page;
   authedPage: Page;

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -159,6 +159,21 @@ export async function openEditor(page: Page) {
   });
 }
 
+export function externalMediaImportButton(page: Page) {
+  return page.getByRole("button", { name: "Import external media" });
+}
+
+export async function ensureExternalMediaOpen(page: Page) {
+  const toggle = page.getByRole("button", {
+    name: /Expand "External media"|Collapse "External media"|External media/,
+  });
+  await expect(toggle).toBeVisible({ timeout: 15_000 });
+  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+}
+
 export const test = base.extend<{
   anonymousPage: Page;
   authedPage: Page;

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -159,6 +159,23 @@ export async function openEditor(page: Page) {
   });
 }
 
+export function photoButtons(page: Page) {
+  return page.locator('[role="button"][aria-pressed]');
+}
+
+export async function scrollToStep(
+  page: Page,
+  country: string,
+  stepName: string,
+) {
+  const nav = page.getByRole("navigation");
+  await nav.getByText(country).click();
+  const step = nav.getByText(stepName);
+  await expect(step).toBeVisible({ timeout: 3_000 });
+  await step.click();
+  await expect(photoButtons(page).first()).toBeVisible({ timeout: 5_000 });
+}
+
 export function externalMediaImportButton(page: Page) {
   return page.getByRole("button", { name: "Import external media" });
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,7 +1,9 @@
-import { test as base, type Page } from "@playwright/test";
+import { expect, test as base, type Page } from "@playwright/test";
 import {
   mockUser,
+  mockAuthStateAnonymous,
   mockAuthStateAuthenticated,
+  mockAuthStatePending,
   mockAlbum,
   mockMedia,
   mockSteps,
@@ -57,6 +59,37 @@ async function mockCommonApi(page: Page) {
   await page.route("**/media/**", (route) =>
     route.fulfill({ contentType: "image/jpeg", body: mediaBody }),
   );
+}
+
+async function mockUnauthorizedUser(page: Page) {
+  await page.route(`${API}/users`, (route) =>
+    route.fulfill({ status: 401, json: { detail: "Unauthorized" } }),
+  );
+}
+
+async function mockAnonymousApi(page: Page) {
+  await page.route(`${API}/auth/state`, (route) =>
+    route.fulfill({ json: mockAuthStateAnonymous }),
+  );
+}
+
+async function mockPendingSignupApi(page: Page) {
+  await page.route(`${API}/auth/state`, (route) =>
+    route.fulfill({ json: mockAuthStatePending }),
+  );
+  await mockUnauthorizedUser(page);
+}
+
+export async function mockGooglePendingSignupTransition(page: Page) {
+  let state = mockAuthStateAnonymous;
+  await page.route(`${API}/auth/state`, (route) =>
+    route.fulfill({ json: state }),
+  );
+  await page.route(`${API}/auth/google`, (route) => {
+    state = mockAuthStatePending;
+    return route.fulfill({ json: null });
+  });
+  await mockUnauthorizedUser(page);
 }
 
 async function mockDefaultSteps(page: Page) {
@@ -119,11 +152,28 @@ export async function blockPopup(page: Page) {
   });
 }
 
-export const test = base.extend<{ authedPage: Page; focusPage: Page }>({
+export async function openEditor(page: Page) {
+  await page.goto("/editor");
+  await expect(page.getByText("South America")).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+export const test = base.extend<{
+  anonymousPage: Page;
+  authedPage: Page;
+  editorPage: Page;
+  focusPage: Page;
+  pendingSignupPage: Page;
+}>({
   page: async ({ page }, use) => {
     const assertAllMocked = await installStrictMockGuard(page);
     await use(page);
     assertAllMocked();
+  },
+  anonymousPage: async ({ page }, use) => {
+    await mockAnonymousApi(page);
+    await use(page);
   },
   authedPage: async ({ page }, use) => {
     await mockCommonApi(page);
@@ -131,12 +181,20 @@ export const test = base.extend<{ authedPage: Page; focusPage: Page }>({
     await initPage(page);
     await use(page);
   },
+  editorPage: async ({ authedPage }, use) => {
+    await openEditor(authedPage);
+    await use(authedPage);
+  },
   focusPage: async ({ page }, use) => {
     await mockCommonApi(page);
     await mockFocusData(page);
     await initPage(page);
     await use(page);
   },
+  pendingSignupPage: async ({ page }, use) => {
+    await mockPendingSignupApi(page);
+    await use(page);
+  },
 });
 
-export { expect } from "@playwright/test";
+export { expect };

--- a/frontend/e2e/media-import.test.ts
+++ b/frontend/e2e/media-import.test.ts
@@ -1,5 +1,6 @@
 import {
   ensureExternalMediaOpen,
+  externalMediaCorsHeaders,
   externalMediaImportButton,
   test,
   expect,
@@ -34,22 +35,14 @@ async function mockDeviceImport(
   await page.route(
     `${API}/albums/*/external-media/add/device`,
     async (route) => {
-      const headers = {
-        "access-control-allow-credentials": "true",
-        "access-control-allow-headers": "*",
-        "access-control-allow-methods": "POST, OPTIONS",
-        "access-control-allow-origin": new URL(page.url()).origin,
-      };
+      const headers = externalMediaCorsHeaders(page);
       if (route.request().method() === "OPTIONS") {
-        await route.fulfill({ headers, status: 204 });
+        await route.fulfill({ headers: headers.cors, status: 204 });
         return;
       }
       onImport();
       await route.fulfill({
-        headers: {
-          ...headers,
-          "content-type": "application/json",
-        },
+        headers: headers.json,
         status: 200,
         body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
       });

--- a/frontend/e2e/media-import.test.ts
+++ b/frontend/e2e/media-import.test.ts
@@ -27,6 +27,36 @@ async function ensureUnusedTrayVisible(page: import("@playwright/test").Page) {
   await expect(count).toBeVisible();
 }
 
+async function mockDeviceImport(
+  page: import("@playwright/test").Page,
+  onImport: () => void,
+) {
+  await page.route(
+    `${API}/albums/*/external-media/add/device`,
+    async (route) => {
+      const headers = {
+        "access-control-allow-credentials": "true",
+        "access-control-allow-headers": "*",
+        "access-control-allow-methods": "POST, OPTIONS",
+        "access-control-allow-origin": new URL(page.url()).origin,
+      };
+      if (route.request().method() === "OPTIONS") {
+        await route.fulfill({ headers, status: 204 });
+        return;
+      }
+      onImport();
+      await route.fulfill({
+        headers: {
+          ...headers,
+          "content-type": "application/json",
+        },
+        status: 200,
+        body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
+      });
+    },
+  );
+}
+
 async function selectImportStep(
   page: import("@playwright/test").Page,
   stepId: number,
@@ -45,30 +75,9 @@ test.describe("Media import", () => {
   }) => {
     let imported = false;
 
-    await page.route(
-      `${API}/albums/*/external-media/add/device`,
-      async (route) => {
-        const headers = {
-          "access-control-allow-credentials": "true",
-          "access-control-allow-headers": "*",
-          "access-control-allow-methods": "POST, OPTIONS",
-          "access-control-allow-origin": new URL(page.url()).origin,
-        };
-        if (route.request().method() === "OPTIONS") {
-          await route.fulfill({ headers, status: 204 });
-          return;
-        }
-        imported = true;
-        await route.fulfill({
-          headers: {
-            ...headers,
-            "content-type": "application/json",
-          },
-          status: 200,
-          body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
-        });
-      },
-    );
+    await mockDeviceImport(page, () => {
+      imported = true;
+    });
     await page.route(`${API}/albums/*/steps`, async (route) => {
       const steps = imported
         ? [{ ...mockStep, unused: [IMPORTED, ...mockStep.unused] }]
@@ -165,30 +174,9 @@ test.describe("Media import", () => {
           : mockMedia;
       return route.fulfill({ json: media });
     });
-    await page.route(
-      `${API}/albums/*/external-media/add/device`,
-      async (route) => {
-        const headers = {
-          "access-control-allow-credentials": "true",
-          "access-control-allow-headers": "*",
-          "access-control-allow-methods": "POST, OPTIONS",
-          "access-control-allow-origin": new URL(page.url()).origin,
-        };
-        if (route.request().method() === "OPTIONS") {
-          await route.fulfill({ headers, status: 204 });
-          return;
-        }
-        imported = true;
-        await route.fulfill({
-          headers: {
-            ...headers,
-            "content-type": "application/json",
-          },
-          status: 200,
-          body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
-        });
-      },
-    );
+    await mockDeviceImport(page, () => {
+      imported = true;
+    });
 
     await page.goto("/editor");
     await expect(page.getByText("South America")).toBeVisible({

--- a/frontend/e2e/media-import.test.ts
+++ b/frontend/e2e/media-import.test.ts
@@ -1,4 +1,9 @@
-import { test, expect } from "./fixtures";
+import {
+  ensureExternalMediaOpen,
+  externalMediaImportButton,
+  test,
+  expect,
+} from "./fixtures";
 import {
   mockAlbum,
   mockMedia,
@@ -12,9 +17,7 @@ const IMPORTED =
   "11111111-1111-4111-8111-111111111111_22222222-2222-4222-8222-222222222222.jpg";
 
 function unusedDrawer(page: import("@playwright/test").Page) {
-  return page
-    .getByLabel("Inspector")
-    .getByRole("region", { name: "Unused" });
+  return page.getByLabel("Inspector").getByRole("region", { name: "Unused" });
 }
 
 async function ensureUnusedTrayVisible(page: import("@playwright/test").Page) {
@@ -22,23 +25,6 @@ async function ensureUnusedTrayVisible(page: import("@playwright/test").Page) {
   const count = drawer.getByText(/^\d+$/);
   await expect(drawer).toBeVisible();
   await expect(count).toBeVisible();
-}
-
-async function ensureExternalMediaOpen(
-  page: import("@playwright/test").Page,
-) {
-  const importButton = page.getByRole("button", {
-    name: "Import external media",
-  });
-  const toggle = page.getByRole("button", {
-    name: /Expand "External media"|Collapse "External media"/,
-  });
-  await expect(toggle).toBeVisible({ timeout: 15_000 });
-  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
-    await toggle.click();
-  }
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
-  await expect(importButton).toBeVisible();
 }
 
 async function selectImportStep(
@@ -50,6 +36,7 @@ async function selectImportStep(
   await expect(
     page.getByLabel("Inspector").getByText(`Import to ${mockStep.name}`),
   ).toBeVisible();
+  await expect(externalMediaImportButton(page)).toBeVisible();
 }
 
 test.describe("Media import", () => {
@@ -58,27 +45,30 @@ test.describe("Media import", () => {
   }) => {
     let imported = false;
 
-    await page.route(`${API}/albums/*/external-media/add/device`, async (route) => {
-      const headers = {
-        "access-control-allow-credentials": "true",
-        "access-control-allow-headers": "*",
-        "access-control-allow-methods": "POST, OPTIONS",
-        "access-control-allow-origin": new URL(page.url()).origin,
-      };
-      if (route.request().method() === "OPTIONS") {
-        await route.fulfill({ headers, status: 204 });
-        return;
-      }
-      imported = true;
-      await route.fulfill({
-        headers: {
-          ...headers,
-          "content-type": "application/json",
-        },
-        status: 200,
-        body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
-      });
-    });
+    await page.route(
+      `${API}/albums/*/external-media/add/device`,
+      async (route) => {
+        const headers = {
+          "access-control-allow-credentials": "true",
+          "access-control-allow-headers": "*",
+          "access-control-allow-methods": "POST, OPTIONS",
+          "access-control-allow-origin": new URL(page.url()).origin,
+        };
+        if (route.request().method() === "OPTIONS") {
+          await route.fulfill({ headers, status: 204 });
+          return;
+        }
+        imported = true;
+        await route.fulfill({
+          headers: {
+            ...headers,
+            "content-type": "application/json",
+          },
+          status: 200,
+          body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
+        });
+      },
+    );
     await page.route(`${API}/albums/*/steps`, async (route) => {
       const steps = imported
         ? [{ ...mockStep, unused: [IMPORTED, ...mockStep.unused] }]
@@ -101,7 +91,7 @@ test.describe("Media import", () => {
     await ensureExternalMediaOpen(page);
 
     const fileChooser = page.waitForEvent("filechooser");
-    await page.getByRole("button", { name: "Import external media" }).click();
+    await externalMediaImportButton(page).click();
     const importResponse = page.waitForResponse(
       (res) =>
         res.url().includes("/api/v1/albums/") &&
@@ -175,27 +165,30 @@ test.describe("Media import", () => {
           : mockMedia;
       return route.fulfill({ json: media });
     });
-    await page.route(`${API}/albums/*/external-media/add/device`, async (route) => {
-      const headers = {
-        "access-control-allow-credentials": "true",
-        "access-control-allow-headers": "*",
-        "access-control-allow-methods": "POST, OPTIONS",
-        "access-control-allow-origin": new URL(page.url()).origin,
-      };
-      if (route.request().method() === "OPTIONS") {
-        await route.fulfill({ headers, status: 204 });
-        return;
-      }
-      imported = true;
-      await route.fulfill({
-        headers: {
-          ...headers,
-          "content-type": "application/json",
-        },
-        status: 200,
-        body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
-      });
-    });
+    await page.route(
+      `${API}/albums/*/external-media/add/device`,
+      async (route) => {
+        const headers = {
+          "access-control-allow-credentials": "true",
+          "access-control-allow-headers": "*",
+          "access-control-allow-methods": "POST, OPTIONS",
+          "access-control-allow-origin": new URL(page.url()).origin,
+        };
+        if (route.request().method() === "OPTIONS") {
+          await route.fulfill({ headers, status: 204 });
+          return;
+        }
+        imported = true;
+        await route.fulfill({
+          headers: {
+            ...headers,
+            "content-type": "application/json",
+          },
+          status: 200,
+          body: JSON.stringify({ type: "import_completed", names: [IMPORTED] }),
+        });
+      },
+    );
 
     await page.goto("/editor");
     await expect(page.getByText("South America")).toBeVisible({
@@ -206,7 +199,7 @@ test.describe("Media import", () => {
     await ensureExternalMediaOpen(page);
 
     const fileChooser = page.waitForEvent("filechooser");
-    await page.getByRole("button", { name: "Import external media" }).click();
+    await externalMediaImportButton(page).click();
     const chooser = await fileChooser;
     await chooser.setFiles({
       name: "import.jpg",

--- a/frontend/e2e/media-replace.test.ts
+++ b/frontend/e2e/media-replace.test.ts
@@ -3,9 +3,7 @@ import { TINY_JPEG_BASE64 } from "../tests/fixtures/mocks";
 
 const API = "**/api/v1";
 
-async function ensureExternalMediaOpen(
-  page: import("@playwright/test").Page,
-) {
+async function ensureExternalMediaOpen(page: import("@playwright/test").Page) {
   const toggle = page.getByRole("button", {
     name: /Expand "External media"|Collapse "External media"/,
   });
@@ -18,9 +16,8 @@ async function ensureExternalMediaOpen(
 
 test.describe("External media replacement", () => {
   test("cover media can be selected for replacement", async ({
-    authedPage: page,
+    editorPage: page,
   }) => {
-    await page.goto("/editor");
     await expect(page.getByText("South America")).toBeVisible({
       timeout: 15_000,
     });
@@ -36,23 +33,26 @@ test.describe("External media replacement", () => {
   test("replaces focused media from a device file", async ({
     authedPage: page,
   }) => {
-    await page.route(`${API}/albums/*/external-media/replace/device`, async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          name: "photo1.jpg",
-          kind: "photo",
-          storage_path: "photo1.jpg",
-          width: 3000,
-          height: 2000,
-          byte_size: 12345,
-          source_ref_id: null,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        }),
-      });
-    });
+    await page.route(
+      `${API}/albums/*/external-media/replace/device`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            name: "photo1.jpg",
+            kind: "photo",
+            storage_path: "photo1.jpg",
+            width: 3000,
+            height: 2000,
+            byte_size: 12345,
+            source_ref_id: null,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          }),
+        });
+      },
+    );
 
     await page.goto("/editor");
     await expect(page.getByText("South America")).toBeVisible({
@@ -71,7 +71,9 @@ test.describe("External media replacement", () => {
     await page.getByRole("button", { name: /Replace selected media/i }).click();
     const chooser = page.waitForEvent("filechooser");
     await page.getByRole("menuitem", { name: "Device" }).click();
-    await (await chooser).setFiles({
+    await (
+      await chooser
+    ).setFiles({
       name: "better.jpg",
       mimeType: "image/jpeg",
       buffer: Buffer.from(TINY_JPEG_BASE64, "base64"),
@@ -82,7 +84,9 @@ test.describe("External media replacement", () => {
     await expect(
       reviewDialog.getByRole("button", { name: /Replace everywhere/i }),
     ).toBeVisible();
-    await reviewDialog.getByRole("button", { name: /Replace everywhere/i }).click();
+    await reviewDialog
+      .getByRole("button", { name: /Replace everywhere/i })
+      .click();
     await expect(
       page.getByText("Media replaced. Undo is available for 5 minutes."),
     ).toBeVisible();

--- a/frontend/e2e/media-replace.test.ts
+++ b/frontend/e2e/media-replace.test.ts
@@ -1,18 +1,7 @@
-import { test, expect } from "./fixtures";
+import { ensureExternalMediaOpen, test, expect } from "./fixtures";
 import { TINY_JPEG_BASE64 } from "../tests/fixtures/mocks";
 
 const API = "**/api/v1";
-
-async function ensureExternalMediaOpen(page: import("@playwright/test").Page) {
-  const toggle = page.getByRole("button", {
-    name: /Expand "External media"|Collapse "External media"/,
-  });
-  await expect(toggle).toBeVisible({ timeout: 15_000 });
-  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
-    await toggle.click();
-  }
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
-}
 
 test.describe("External media replacement", () => {
   test("cover media can be selected for replacement", async ({

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -96,6 +96,12 @@ async function expectUpgradeDone(page: Page, message: RegExp) {
   );
 }
 
+async function expectReadyFiles(page: Page, count: number) {
+  await expect(page.getByText(new RegExp(`${count} files ready`, "i"))).toBeVisible(
+    { timeout: 10_000 },
+  );
+}
+
 async function skipOnboarding(page: Page) {
   await page.addInitScript(
     ([key]) => localStorage.setItem(key, "true"),
@@ -152,6 +158,19 @@ async function mockMatchStream(page: Page, events: object[] = matchEvents) {
   );
 }
 
+async function mockMatchRounds(page: Page, rounds: object[][]) {
+  let round = 0;
+  await page.route(`${API}/google-photos/match/**`, (route) => {
+    const events = rounds[Math.min(round, rounds.length - 1)];
+    round += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: sseBody(events),
+    });
+  });
+}
+
 async function mockUpgradeStream(page: Page, events: object[]) {
   await page.route(`${API}/google-photos/upgrade/**`, (route) =>
     route.fulfill({
@@ -174,14 +193,23 @@ async function setupUpgradeRoutes(page: Page) {
 async function openReadyUpgradeSummary(page: Page) {
   await page.goto("/editor");
   await clickUpgradeMedia(page);
-  await expect(page.getByText(/2 files ready/i)).toBeVisible({
-    timeout: 10_000,
-  });
+  await expectReadyFiles(page, 2);
 }
 
 async function prepareOnboardedPopupFlow(page: Page) {
   await skipOnboarding(page);
   await mockPopup(page);
+}
+
+async function completeReadyUpgrade(
+  page: Page,
+  events: object[],
+  expectedDone: RegExp,
+) {
+  await mockUpgradeStream(page, events);
+  await openReadyUpgradeSummary(page);
+  await page.getByRole("button", { name: /upgrade \d+ files/i }).click();
+  await expectUpgradeDone(page, expectedDone);
 }
 
 test.describe("Media Upgrade", () => {
@@ -212,12 +240,7 @@ test.describe("Media Upgrade", () => {
   }) => {
     await setupUpgradeRoutes(page);
     await prepareOnboardedPopupFlow(page);
-    await mockUpgradeStream(page, upgradeEvents);
-    await openReadyUpgradeSummary(page);
-
-    await page.getByRole("button", { name: /upgrade \d+ files/i }).click();
-
-    await expectUpgradeDone(page, /upgraded 2 files/i);
+    await completeReadyUpgrade(page, upgradeEvents, /upgraded 2 files/i);
   });
 
   test("partial failure shows count in done message", async ({
@@ -225,12 +248,7 @@ test.describe("Media Upgrade", () => {
   }) => {
     await setupUpgradeRoutes(page);
     await prepareOnboardedPopupFlow(page);
-    await mockUpgradeStream(page, partialUpgradeEvents);
-    await openReadyUpgradeSummary(page);
-
-    await page.getByRole("button", { name: /upgrade \d+ files/i }).click();
-
-    await expectUpgradeDone(page, /upgraded 1 of 2/i);
+    await completeReadyUpgrade(page, partialUpgradeEvents, /upgraded 1 of 2/i);
   });
 
   test("disconnect option visible in dropdown when connected", async ({
@@ -318,21 +336,12 @@ test.describe("Media Upgrade", () => {
   test("clicking error button restarts the flow", async ({
     authedPage: page,
   }) => {
-    let matchCall = 0;
     await mockConnectedUser(page);
     await mockPickerSession(page, { dynamicSession: true });
-    await page.route(`${API}/google-photos/match/**`, (route) => {
-      matchCall += 1;
-      return route.fulfill({
-        status: 200,
-        contentType: "text/event-stream",
-        body: sseBody(
-          matchCall === 1
-            ? [{ type: "upgrade_failed", detail: "connectionLost" }]
-            : matchEvents,
-        ),
-      });
-    });
+    await mockMatchRounds(page, [
+      [{ type: "upgrade_failed", detail: "connectionLost" }],
+      matchEvents,
+    ]);
     await prepareOnboardedPopupFlow(page);
     await page.goto("/editor");
 
@@ -343,33 +352,21 @@ test.describe("Media Upgrade", () => {
     await expect(errorBtn).toBeVisible({ timeout: 10_000 });
     await errorBtn.click();
 
-    await expect(page.getByText(/2 files ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
+    await expectReadyFiles(page, 2);
   });
 
   test("select more accumulates matches across rounds", async ({
     authedPage: page,
   }) => {
-    let matchRound = 0;
     await mockConnectedUser(page);
     await mockPickerSession(page, { dynamicSession: true });
-    await page.route(`${API}/google-photos/match/**`, (route) => {
-      matchRound += 1;
-      return route.fulfill({
-        status: 200,
-        contentType: "text/event-stream",
-        body: sseBody(matchRound === 1 ? matchEvents : round2MatchEvents),
-      });
-    });
+    await mockMatchRounds(page, [matchEvents, round2MatchEvents]);
     await mockUpgradeStream(page, threeFileUpgradeEvents);
     await prepareOnboardedPopupFlow(page);
     await openReadyUpgradeSummary(page);
 
     await page.getByRole("button", { name: /select more/i }).click();
-    await expect(page.getByText(/3 files ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
+    await expectReadyFiles(page, 3);
     await page.getByRole("button", { name: /upgrade 3 files/i }).click();
 
     await expectUpgradeDone(page, /upgraded 3 files/i);

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 
 import { MEDIA_UPGRADE_ONBOARDED_KEY } from "../src/utils/storage-keys";
 import { mockMedia, mockUser } from "../tests/fixtures/mocks";
+import { sseBody } from "../tests/sse";
 import {
   blockPopup,
   ensureExternalMediaOpen,
@@ -64,10 +65,6 @@ const threeFileUpgradeEvents = [
   { type: "download_in_progress", done: 3, total: 3 },
   { type: "upgrade_completed", replaced: 3, skipped: 0, failed: 0 },
 ];
-
-function sseBody(events: object[]): string {
-  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
-}
 
 function upgradeMediaButton(page: Page) {
   return page

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -2,7 +2,13 @@ import type { Page } from "@playwright/test";
 
 import { MEDIA_UPGRADE_ONBOARDED_KEY } from "../src/utils/storage-keys";
 import { mockMedia, mockUser } from "../tests/fixtures/mocks";
-import { blockPopup, expect, mockPopup, test } from "./fixtures";
+import {
+  blockPopup,
+  ensureExternalMediaOpen,
+  expect,
+  mockPopup,
+  test,
+} from "./fixtures";
 
 const API = "**/api/v1";
 
@@ -69,21 +75,10 @@ function upgradeMediaButton(page: Page) {
     .getByRole("button", { name: "Upgrade Media" });
 }
 
-async function ensureExternalMediaOpen(page: Page) {
-  const toggle = page.getByRole("button", {
-    name: /Expand "External media"|Collapse "External media"/,
-  });
-  await expect(toggle).toBeVisible({ timeout: 15_000 });
-  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
-    await toggle.click();
-  }
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
-  await expect(upgradeMediaButton(page)).toBeVisible({ timeout: 15_000 });
-}
-
 async function clickUpgradeMedia(page: Page) {
   await ensureExternalMediaOpen(page);
   const button = upgradeMediaButton(page);
+  await expect(button).toBeVisible({ timeout: 15_000 });
   await button.scrollIntoViewIfNeeded();
   await button.click();
 }

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -97,9 +97,9 @@ async function expectUpgradeDone(page: Page, message: RegExp) {
 }
 
 async function expectReadyFiles(page: Page, count: number) {
-  await expect(page.getByText(new RegExp(`${count} files ready`, "i"))).toBeVisible(
-    { timeout: 10_000 },
-  );
+  await expect(
+    page.getByText(new RegExp(`${count} files ready`, "i")),
+  ).toBeVisible({ timeout: 10_000 });
 }
 
 async function skipOnboarding(page: Page) {
@@ -214,9 +214,8 @@ async function completeReadyUpgrade(
 
 test.describe("Media Upgrade", () => {
   test("upgrade button visible for Google-linked user", async ({
-    authedPage: page,
+    editorPage: page,
   }) => {
-    await page.goto("/editor");
     await ensureExternalMediaOpen(page);
     await expect(upgradeMediaButton(page)).toBeVisible({ timeout: 15_000 });
   });

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -1,56 +1,16 @@
-import { test, expect, mockPopup, blockPopup } from "./fixtures";
-import { MEDIA_UPGRADE_ONBOARDED_KEY } from "../src/utils/storage-keys";
-import { mockUser, mockMedia } from "../tests/fixtures/mocks";
 import type { Page } from "@playwright/test";
+
+import { MEDIA_UPGRADE_ONBOARDED_KEY } from "../src/utils/storage-keys";
+import { mockMedia, mockUser } from "../tests/fixtures/mocks";
+import { blockPopup, expect, mockPopup, test } from "./fixtures";
 
 const API = "**/api/v1";
 
-/** Build an SSE payload from an array of event objects. */
-function sseBody(events: object[]): string {
-  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
-}
-
-async function ensureExternalMediaOpen(page: Page) {
-  const toggle = page.getByRole("button", {
-    name: /Expand "External media"|Collapse "External media"/,
-  });
-  await expect(toggle).toBeVisible({ timeout: 15_000 });
-  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
-    await toggle.click();
-  }
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
-  await expect(upgradeMediaButton(page)).toBeVisible({ timeout: 15_000 });
-}
-
-async function expectUpgradeDone(page: Page, message: RegExp) {
-  await expect(page.locator(".media-panel .action-btn.done")).toHaveAttribute(
-    "aria-label",
-    message,
-    { timeout: 10_000 },
-  );
-}
-
-function upgradeMediaButton(page: Page) {
-  return page
-    .locator(".media-panel")
-    .getByRole("button", { name: "Upgrade Media" });
-}
-
-async function clickUpgradeMedia(page: Page) {
-  await ensureExternalMediaOpen(page);
-  const button = upgradeMediaButton(page);
-  await button.scrollIntoViewIfNeeded();
-  await expect(button).toBeVisible({ timeout: 15_000 });
-  await button.click();
-}
-
-/** Mock user with Google Photos already connected. */
 const connectedUser = {
   ...mockUser,
   google_photos_connected_at: "2026-01-01T00:00:00Z",
 };
 
-/** SSE match events: progress -> summary with 2 of 3 matched. */
 const matchEvents = [
   { type: "match_in_progress", phase: "matching", done: 1, total: 3 },
   { type: "match_in_progress", phase: "matching", done: 2, total: 3 },
@@ -68,62 +28,166 @@ const matchEvents = [
   },
 ];
 
-/** SSE upgrade events: progress -> completed with all replaced. */
+const round2MatchEvents = [
+  { type: "match_in_progress", phase: "matching", done: 1, total: 2 },
+  { type: "match_in_progress", phase: "matching", done: 2, total: 2 },
+  {
+    type: "match_completed",
+    total_picked: 2,
+    matched: 1,
+    already_upgraded: 0,
+    unmatched: 1,
+    matches: [{ local_name: "cover.jpg", google_id: "gid-3", distance: 0 }],
+  },
+];
+
 const upgradeEvents = [
   { type: "download_in_progress", done: 1, total: 2 },
   { type: "download_in_progress", done: 2, total: 2 },
   { type: "upgrade_completed", replaced: 2, skipped: 0, failed: 0 },
 ];
 
-/** SSE upgrade events where one file fails. */
-const upgradeEventsPartial = [
+const partialUpgradeEvents = [
   { type: "download_in_progress", done: 1, total: 2 },
   { type: "upgrade_completed", replaced: 1, skipped: 0, failed: 1 },
 ];
 
-async function setupUpgradeRoutes(page: Page) {
-  // Override user route with connected user
+const threeFileUpgradeEvents = [
+  { type: "download_in_progress", done: 1, total: 3 },
+  { type: "download_in_progress", done: 2, total: 3 },
+  { type: "download_in_progress", done: 3, total: 3 },
+  { type: "upgrade_completed", replaced: 3, skipped: 0, failed: 0 },
+];
+
+function sseBody(events: object[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+function upgradeMediaButton(page: Page) {
+  return page
+    .locator(".media-panel")
+    .getByRole("button", { name: "Upgrade Media" });
+}
+
+async function ensureExternalMediaOpen(page: Page) {
+  const toggle = page.getByRole("button", {
+    name: /Expand "External media"|Collapse "External media"/,
+  });
+  await expect(toggle).toBeVisible({ timeout: 15_000 });
+  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(upgradeMediaButton(page)).toBeVisible({ timeout: 15_000 });
+}
+
+async function clickUpgradeMedia(page: Page) {
+  await ensureExternalMediaOpen(page);
+  const button = upgradeMediaButton(page);
+  await button.scrollIntoViewIfNeeded();
+  await button.click();
+}
+
+async function expectUpgradeDone(page: Page, message: RegExp) {
+  await expect(page.locator(".media-panel .action-btn.done")).toHaveAttribute(
+    "aria-label",
+    message,
+    { timeout: 10_000 },
+  );
+}
+
+async function skipOnboarding(page: Page) {
+  await page.addInitScript(
+    ([key]) => localStorage.setItem(key, "true"),
+    [MEDIA_UPGRADE_ONBOARDED_KEY],
+  );
+}
+
+async function mockConnectedUser(page: Page) {
   await page.route(`${API}/users`, (route) =>
     route.fulfill({ json: connectedUser }),
   );
+}
 
-  // Picker session create
+async function mockPickerSession(
+  page: Page,
+  {
+    ready = true,
+    sessionId = "sess-1",
+    dynamicSession = false,
+  }: { ready?: boolean; sessionId?: string; dynamicSession?: boolean } = {},
+) {
+  let count = 0;
   await page.route(`${API}/google-photos/sessions`, (route) => {
-    if (route.request().method() === "POST") {
-      return route.fulfill({
-        json: {
-          session_id: "sess-1",
-          picker_uri: "https://photos.google.com/picker/sess-1",
-        },
-      });
+    if (route.request().method() !== "POST") {
+      return route.fallback();
     }
-    return route.fallback();
+    count += 1;
+    const id = dynamicSession ? `sess-${count}` : sessionId;
+    return route.fulfill({
+      json: {
+        session_id: id,
+        picker_uri: `https://photos.google.com/picker/${id}`,
+      },
+    });
   });
+  await page.route(
+    `${API}/google-photos/sessions/${dynamicSession ? "sess-*" : sessionId}`,
+    (route) => {
+      if (route.request().method() === "GET") {
+        return route.fulfill({ json: { ready } });
+      }
+      return route.fulfill({ status: 204, body: "" });
+    },
+  );
+}
 
-  // Picker session poll - immediately ready
-  await page.route(`${API}/google-photos/sessions/sess-1`, (route) => {
-    if (route.request().method() === "GET") {
-      return route.fulfill({ json: { ready: true } });
-    }
-    // DELETE
-    return route.fulfill({ status: 204, body: "" });
-  });
-
-  // Match SSE
+async function mockMatchStream(page: Page, events: object[] = matchEvents) {
   await page.route(`${API}/google-photos/match/**`, (route) =>
     route.fulfill({
       status: 200,
       contentType: "text/event-stream",
-      body: sseBody(matchEvents),
+      body: sseBody(events),
     }),
   );
+}
+
+async function mockUpgradeStream(page: Page, events: object[]) {
+  await page.route(`${API}/google-photos/upgrade/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: sseBody(events),
+    }),
+  );
+  await page.route(`${API}/albums/*/media`, (route) =>
+    route.fulfill({ json: mockMedia }),
+  );
+}
+
+async function setupUpgradeRoutes(page: Page) {
+  await mockConnectedUser(page);
+  await mockPickerSession(page);
+  await mockMatchStream(page);
+}
+
+async function openReadyUpgradeSummary(page: Page) {
+  await page.goto("/editor");
+  await clickUpgradeMedia(page);
+  await expect(page.getByText(/2 files ready/i)).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function prepareOnboardedPopupFlow(page: Page) {
+  await skipOnboarding(page);
+  await mockPopup(page);
 }
 
 test.describe("Media Upgrade", () => {
   test("upgrade button visible for Google-linked user", async ({
     authedPage: page,
   }) => {
-    // Default mockUser has google_sub set, so button should appear
     await page.goto("/editor");
     await ensureExternalMediaOpen(page);
     await expect(upgradeMediaButton(page)).toBeVisible({ timeout: 15_000 });
@@ -135,11 +199,9 @@ test.describe("Media Upgrade", () => {
     await setupUpgradeRoutes(page);
     await blockPopup(page);
     await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
 
     await clickUpgradeMedia(page);
 
-    // Onboarding dialog should appear since no localStorage key set
     await expect(page.getByText(/original quality/i)).toBeVisible({
       timeout: 5_000,
     });
@@ -149,48 +211,12 @@ test.describe("Media Upgrade", () => {
     authedPage: page,
   }) => {
     await setupUpgradeRoutes(page);
+    await prepareOnboardedPopupFlow(page);
+    await mockUpgradeStream(page, upgradeEvents);
+    await openReadyUpgradeSummary(page);
 
-    // Skip onboarding
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
+    await page.getByRole("button", { name: /upgrade \d+ files/i }).click();
 
-    await mockPopup(page);
-
-    // Upgrade SSE
-    await page.route(`${API}/google-photos/upgrade/**`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "text/event-stream",
-        body: sseBody(upgradeEvents),
-      }),
-    );
-
-    // Media invalidation after upgrade
-    await page.route(`${API}/albums/*/media`, (route) =>
-      route.fulfill({ json: mockMedia }),
-    );
-
-    await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
-
-    // Click upgrade
-    await clickUpgradeMedia(page);
-
-    // Match summary dialog should appear
-    await expect(page.getByText(/2 files ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
-
-    // Confirm upgrade
-    const confirmBtn = page.getByRole("button", {
-      name: /upgrade \d+ files/i,
-    });
-    await expect(confirmBtn).toBeVisible();
-    await confirmBtn.click();
-
-    // Done state should show "Upgraded 2 files"
     await expectUpgradeDone(page, /upgraded 2 files/i);
   });
 
@@ -198,66 +224,28 @@ test.describe("Media Upgrade", () => {
     authedPage: page,
   }) => {
     await setupUpgradeRoutes(page);
+    await prepareOnboardedPopupFlow(page);
+    await mockUpgradeStream(page, partialUpgradeEvents);
+    await openReadyUpgradeSummary(page);
 
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
-    await mockPopup(page);
-
-    // Upgrade SSE with partial failure
-    await page.route(`${API}/google-photos/upgrade/**`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "text/event-stream",
-        body: sseBody(upgradeEventsPartial),
-      }),
-    );
-
-    await page.route(`${API}/albums/*/media`, (route) =>
-      route.fulfill({ json: mockMedia }),
-    );
-
-    await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
-
-    await clickUpgradeMedia(page);
-
-    // Wait for match summary
-    await expect(page.getByText(/2 files ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
     await page.getByRole("button", { name: /upgrade \d+ files/i }).click();
 
-    // Partial failure: "Upgraded 1 of 2 files"
     await expectUpgradeDone(page, /upgraded 1 of 2/i);
   });
 
   test("disconnect option visible in dropdown when connected", async ({
     authedPage: page,
   }) => {
-    // Override user to be connected
-    await page.route(`${API}/users`, (route) =>
-      route.fulfill({ json: connectedUser }),
-    );
-
+    await mockConnectedUser(page);
     await page.goto("/editor");
     await ensureExternalMediaOpen(page);
 
-    // Split-trigger chevron opens the dropdown menu
-    const splitTrigger = page.getByRole("button", {
-      name: "Upgrade options",
-    });
-    await expect(splitTrigger).toBeVisible({ timeout: 15_000 });
-    await splitTrigger.click();
+    await page.getByRole("button", { name: "Upgrade options" }).click();
 
-    // Disconnect option should appear in the dropdown
     await expect(page.getByRole("button", { name: /disconnect/i })).toBeVisible(
       { timeout: 5_000 },
     );
   });
-
-  // -- Cancel flows ----------------------------------------------------------
 
   test("cancel from onboarding closes dialog and returns to idle", async ({
     authedPage: page,
@@ -265,20 +253,15 @@ test.describe("Media Upgrade", () => {
     await setupUpgradeRoutes(page);
     await blockPopup(page);
     await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
 
     const upgradeBtn = upgradeMediaButton(page);
     await clickUpgradeMedia(page);
-
-    // Onboarding dialog should appear
     await expect(page.getByText(/original quality/i)).toBeVisible({
       timeout: 5_000,
     });
 
-    // Cancel - computed setter triggers upgrade.cancel()
     await page.getByRole("button", { name: "Cancel" }).click();
 
-    // Should return to idle
     await expect(upgradeBtn).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText(/original quality/i)).not.toBeVisible();
   });
@@ -287,98 +270,44 @@ test.describe("Media Upgrade", () => {
     authedPage: page,
   }) => {
     await setupUpgradeRoutes(page);
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
-    await mockPopup(page);
-
-    await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
+    await prepareOnboardedPopupFlow(page);
+    await openReadyUpgradeSummary(page);
 
     const upgradeBtn = upgradeMediaButton(page);
-    await clickUpgradeMedia(page);
-
-    // Match summary with "2 files ready"
-    await expect(page.getByText(/2 files ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
-
-    // Cancel - computed setter triggers upgrade.cancel()
     await page.getByRole("button", { name: "Cancel" }).click();
 
-    // Should return to idle
     await expect(upgradeBtn).toBeVisible({ timeout: 5_000 });
   });
 
   test("cancel during picking aborts and returns to idle", async ({
     authedPage: page,
   }) => {
-    await page.route(`${API}/users`, (route) =>
-      route.fulfill({ json: connectedUser }),
-    );
-    await page.route(`${API}/google-photos/sessions`, (route) => {
-      if (route.request().method() === "POST") {
-        return route.fulfill({
-          json: {
-            session_id: "sess-1",
-            picker_uri: "https://photos.google.com/picker/sess-1",
-          },
-        });
-      }
-      return route.fallback();
-    });
-    // Poll always returns not-ready so picking phase persists
-    await page.route(`${API}/google-photos/sessions/sess-1`, (route) => {
-      if (route.request().method() === "GET") {
-        return route.fulfill({ json: { ready: false } });
-      }
-      return route.fulfill({ status: 204, body: "" });
-    });
-
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
-    await mockPopup(page);
-
+    await mockConnectedUser(page);
+    await mockPickerSession(page, { ready: false });
+    await prepareOnboardedPopupFlow(page);
     await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
 
     const upgradeBtn = upgradeMediaButton(page);
     await clickUpgradeMedia(page);
-
-    // Should enter picking phase with running button
     const runningBtn = page
       .locator(".media-panel")
       .getByRole("button", { name: /waiting for selection/i });
     await expect(runningBtn).toBeVisible({ timeout: 5_000 });
 
-    // Click running button to cancel
     await runningBtn.scrollIntoViewIfNeeded();
     await runningBtn.click();
 
-    // Should return to idle
     await expect(upgradeBtn).toBeVisible({ timeout: 5_000 });
   });
-
-  // -- Error paths -----------------------------------------------------------
 
   test("popup blocked surfaces error button", async ({ authedPage: page }) => {
     await setupUpgradeRoutes(page);
     await blockPopup(page);
-    // Skip onboarding so the start() path opens the popup directly
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
-
+    await skipOnboarding(page);
     await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
 
     await clickUpgradeMedia(page);
 
-    // Error state button appears with translated popup-blocked copy inside
     const errorBtn = page.getByRole("button", {
       name: /upgrade failed\. try again/i,
     });
@@ -389,164 +318,60 @@ test.describe("Media Upgrade", () => {
   test("clicking error button restarts the flow", async ({
     authedPage: page,
   }) => {
-    // First match request returns an SSE error; second returns real matches.
     let matchCall = 0;
-    await page.route(`${API}/users`, (route) =>
-      route.fulfill({ json: connectedUser }),
-    );
-    await page.route(`${API}/google-photos/sessions`, (route) => {
-      if (route.request().method() === "POST") {
-        return route.fulfill({
-          json: {
-            session_id: `sess-${matchCall + 1}`,
-            picker_uri: `https://photos.google.com/picker/sess-${matchCall + 1}`,
-          },
-        });
-      }
-      return route.fallback();
-    });
-    await page.route(`${API}/google-photos/sessions/sess-*`, (route) => {
-      if (route.request().method() === "GET") {
-        return route.fulfill({ json: { ready: true } });
-      }
-      return route.fulfill({ status: 204, body: "" });
-    });
+    await mockConnectedUser(page);
+    await mockPickerSession(page, { dynamicSession: true });
     await page.route(`${API}/google-photos/match/**`, (route) => {
-      matchCall++;
-      if (matchCall === 1) {
-        return route.fulfill({
-          status: 200,
-          contentType: "text/event-stream",
-          body: sseBody([{ type: "upgrade_failed", detail: "connectionLost" }]),
-        });
-      }
+      matchCall += 1;
       return route.fulfill({
         status: 200,
         contentType: "text/event-stream",
-        body: sseBody(matchEvents),
+        body: sseBody(
+          matchCall === 1
+            ? [{ type: "upgrade_failed", detail: "connectionLost" }]
+            : matchEvents,
+        ),
       });
     });
-
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
-    await mockPopup(page);
+    await prepareOnboardedPopupFlow(page);
     await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
 
     await clickUpgradeMedia(page);
-
     const errorBtn = page.getByRole("button", {
       name: /upgrade failed\. try again/i,
     });
     await expect(errorBtn).toBeVisible({ timeout: 10_000 });
     await errorBtn.click();
 
-    // Second attempt reaches match summary
     await expect(page.getByText(/2 files ready/i)).toBeVisible({
       timeout: 10_000,
     });
   });
 
-  // -- Select more flow ------------------------------------------------------
-
   test("select more accumulates matches across rounds", async ({
     authedPage: page,
   }) => {
-    let sessionCount = 0;
-
-    await page.route(`${API}/users`, (route) =>
-      route.fulfill({ json: connectedUser }),
-    );
-    await page.route(`${API}/google-photos/sessions`, (route) => {
-      if (route.request().method() === "POST") {
-        sessionCount++;
-        return route.fulfill({
-          json: {
-            session_id: `sess-${sessionCount}`,
-            picker_uri: `https://photos.google.com/picker/sess-${sessionCount}`,
-          },
-        });
-      }
-      return route.fallback();
-    });
-    // Both sessions immediately ready; DELETE returns 204
-    await page.route(`${API}/google-photos/sessions/sess-*`, (route) => {
-      if (route.request().method() === "GET") {
-        return route.fulfill({ json: { ready: true } });
-      }
-      return route.fulfill({ status: 204, body: "" });
-    });
-
-    const round2MatchEvents = [
-      { type: "match_in_progress", phase: "matching", done: 1, total: 2 },
-      { type: "match_in_progress", phase: "matching", done: 2, total: 2 },
-      {
-        type: "match_completed",
-        total_picked: 2,
-        matched: 1,
-        already_upgraded: 0,
-        unmatched: 1,
-        matches: [{ local_name: "cover.jpg", google_id: "gid-3", distance: 0 }],
-      },
-    ];
-
     let matchRound = 0;
+    await mockConnectedUser(page);
+    await mockPickerSession(page, { dynamicSession: true });
     await page.route(`${API}/google-photos/match/**`, (route) => {
-      matchRound++;
+      matchRound += 1;
       return route.fulfill({
         status: 200,
         contentType: "text/event-stream",
         body: sseBody(matchRound === 1 ? matchEvents : round2MatchEvents),
       });
     });
+    await mockUpgradeStream(page, threeFileUpgradeEvents);
+    await prepareOnboardedPopupFlow(page);
+    await openReadyUpgradeSummary(page);
 
-    await page.route(`${API}/google-photos/upgrade/**`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "text/event-stream",
-        body: sseBody([
-          { type: "download_in_progress", done: 1, total: 3 },
-          { type: "download_in_progress", done: 2, total: 3 },
-          { type: "download_in_progress", done: 3, total: 3 },
-          { type: "upgrade_completed", replaced: 3, skipped: 0, failed: 0 },
-        ]),
-      }),
-    );
-
-    await page.route(`${API}/albums/*/media`, (route) =>
-      route.fulfill({ json: mockMedia }),
-    );
-
-    await page.addInitScript(
-      ([key]) => localStorage.setItem(key, "true"),
-      [MEDIA_UPGRADE_ONBOARDED_KEY],
-    );
-    await mockPopup(page);
-
-    await page.goto("/editor");
-    await ensureExternalMediaOpen(page);
-
-    await clickUpgradeMedia(page);
-
-    // Round 1: summary shows "2 files ready to upgrade"
-    await expect(page.getByText(/2 files ready/i)).toBeVisible({
-      timeout: 10_000,
-    });
-
-    // Click "Select More" to start round 2
     await page.getByRole("button", { name: /select more/i }).click();
-
-    // After round 2, merged summary shows "3 files ready to upgrade"
     await expect(page.getByText(/3 files ready/i)).toBeVisible({
       timeout: 10_000,
     });
-
-    // Confirm upgrade
     await page.getByRole("button", { name: /upgrade 3 files/i }).click();
 
-    // Done
     await expectUpgradeDone(page, /upgraded 3 files/i);
   });
 });

--- a/frontend/e2e/navigation.test.ts
+++ b/frontend/e2e/navigation.test.ts
@@ -1,17 +1,14 @@
 import { test, expect } from "./fixtures";
 
 test.describe("Editor", () => {
-  test("loads editor page with album content", async ({
-    authedPage: page,
-  }) => {
+  test("loads editor page with album content", async ({ authedPage: page }) => {
     await page.goto("/");
     await page.waitForURL("/editor");
     // Editor should render and show album content
     await expect(page.locator("body")).toBeVisible();
   });
 
-  test("displays the album title", async ({ authedPage: page }) => {
-    await page.goto("/editor");
+  test("displays the album title", async ({ editorPage: page }) => {
     await page.waitForURL("/editor");
     // The album title "South America" should appear somewhere
     await expect(page.getByText("South America")).toBeVisible({
@@ -19,10 +16,11 @@ test.describe("Editor", () => {
     });
   });
 
-  test("shows step name in the viewer", async ({ authedPage: page }) => {
-    await page.goto("/editor");
+  test("shows step name in the viewer", async ({ editorPage: page }) => {
     await page.waitForURL("/editor");
     // The step name "Amsterdam" should be visible in the main viewer
-    await expect(page.getByRole("main")).toContainText("Amsterdam", { timeout: 15_000 });
+    await expect(page.getByRole("main")).toContainText("Amsterdam", {
+      timeout: 15_000,
+    });
   });
 });

--- a/frontend/e2e/oauth-handoff.test.ts
+++ b/frontend/e2e/oauth-handoff.test.ts
@@ -1,22 +1,9 @@
-import { test, expect } from "./fixtures";
-import {
-  mockAuthStateAnonymous,
-  mockAuthStatePending,
-} from "../tests/fixtures/mocks";
-
-const ANON = "**/api/v1/auth/state";
-const GOOGLE = "**/api/v1/auth/google";
+import { expect, mockGooglePendingSignupTransition, test } from "./fixtures";
 
 test.describe("OAuth pending-signup handoff", () => {
   test("pending_signup state sends user to /upload and renders the upload card", async ({
-    page,
+    pendingSignupPage: page,
   }) => {
-    await page.route(ANON, (route) =>
-      route.fulfill({ json: mockAuthStatePending }),
-    );
-    await page.route("**/api/v1/users", (route) =>
-      route.fulfill({ status: 401, json: { detail: "Unauthorized" } }),
-    );
     await page.goto("/");
     await page.waitForURL("/upload");
     await expect(
@@ -27,15 +14,7 @@ test.describe("OAuth pending-signup handoff", () => {
   test("after /auth/google returns null, app navigates to /upload", async ({
     page,
   }) => {
-    let state = mockAuthStateAnonymous;
-    await page.route(ANON, (route) => route.fulfill({ json: state }));
-    await page.route("**/api/v1/users", (route) =>
-      route.fulfill({ status: 401, json: { detail: "Unauthorized" } }),
-    );
-    await page.route(GOOGLE, (route) => {
-      state = mockAuthStatePending;
-      return route.fulfill({ json: null });
-    });
+    await mockGooglePendingSignupTransition(page);
     await page.goto("/");
     // Drive the OAuth callback path directly: the iframe popup can't be
     // clicked from Playwright, but we can invoke the SDK call it triggers.

--- a/frontend/e2e/photo-focus.test.ts
+++ b/frontend/e2e/photo-focus.test.ts
@@ -26,6 +26,14 @@ async function scrollToStep(page: Page, country: string, stepName: string) {
   await expect(photos(page).first()).toBeVisible({ timeout: 5_000 });
 }
 
+async function selectFirstPhoto(page: Page): Promise<Locator> {
+  await scrollToStep(page, "Argentina", "Buenos Aires");
+  const first = photos(page).first();
+  await first.click();
+  await expect(selected(page)).toHaveCount(1);
+  return first;
+}
+
 async function selectedIndex(page: Page): Promise<number> {
   return selected(page).evaluate((el) => {
     const all = [...document.querySelectorAll('[role="button"][aria-pressed]')];
@@ -46,18 +54,13 @@ test.describe("Photo focus & arrow navigation", () => {
   });
 
   test("click selects a photo", async ({ focusPage: page }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    const photo = photos(page).first();
-    await photo.click();
+    const photo = await selectFirstPhoto(page);
 
-    await expect(selected(page)).toHaveCount(1);
     await expect(photo).toHaveAttribute("aria-pressed", "true");
   });
 
   test("Escape deselects", async ({ focusPage: page }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
-    await expect(selected(page)).toHaveCount(1);
+    await selectFirstPhoto(page);
 
     await page.keyboard.press("Escape");
     await expect(selected(page)).toHaveCount(0);
@@ -66,9 +69,7 @@ test.describe("Photo focus & arrow navigation", () => {
   test("ArrowRight moves selection to next photo", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    const first = photos(page).first();
-    await first.click();
+    const first = await selectFirstPhoto(page);
     await expect(first).toHaveAttribute("aria-pressed", "true");
 
     await page.keyboard.press("ArrowRight");
@@ -80,9 +81,7 @@ test.describe("Photo focus & arrow navigation", () => {
   test("ArrowRight moves DOM focus to the selected photo", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    const first = photos(page).first();
-    await first.click();
+    const first = await selectFirstPhoto(page);
     await expect(first).toHaveAttribute("aria-pressed", "true");
 
     await page.keyboard.press("ArrowRight");
@@ -115,9 +114,7 @@ test.describe("Photo focus & arrow navigation", () => {
   });
 
   test("ArrowRight crosses step boundary", async ({ focusPage: page }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
-    await expect(selected(page)).toHaveCount(1);
+    await selectFirstPhoto(page);
 
     await press(page, "ArrowRight", 2);
     const beforeBoundary = await selected(page).boundingBox();
@@ -131,8 +128,7 @@ test.describe("Photo focus & arrow navigation", () => {
   });
 
   test("ArrowLeft crosses step boundary", async ({ focusPage: page }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
+    await selectFirstPhoto(page);
 
     await press(page, "ArrowRight", 3);
     const inStep2 = await selected(page).boundingBox();
@@ -148,8 +144,7 @@ test.describe("Photo focus & arrow navigation", () => {
   test("arrow navigation continues after crossing a step boundary", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
+    await selectFirstPhoto(page);
 
     const indices: number[] = [];
     for (let i = 0; i < 5; i++) {
@@ -163,8 +158,7 @@ test.describe("Photo focus & arrow navigation", () => {
   });
 
   test("forward then backward is a round trip", async ({ focusPage: page }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
+    await selectFirstPhoto(page);
 
     const startIdx = await selectedIndex(page);
 
@@ -178,9 +172,7 @@ test.describe("Photo focus & arrow navigation", () => {
   test("rapid ArrowRight presses settle with one selected photo", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
-    await expect(selected(page)).toHaveCount(1);
+    await selectFirstPhoto(page);
 
     for (let i = 0; i < 6; i++) {
       await page.keyboard.press("ArrowRight");
@@ -199,9 +191,7 @@ test.describe("Send to unused & set as cover", () => {
   test("sendToUnused removes photo and advances focus", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
-    await expect(selected(page)).toHaveCount(1);
+    await selectFirstPhoto(page);
 
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
 
@@ -212,9 +202,7 @@ test.describe("Send to unused & set as cover", () => {
   test("sendToUnused on last navigable photo advances to previous", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-
-    await photos(page).first().click();
+    await selectFirstPhoto(page);
     await press(page, "ArrowRight", 2);
 
     const indexBefore = await selectedIndex(page);
@@ -228,8 +216,7 @@ test.describe("Send to unused & set as cover", () => {
   test("sendToUnused on the only remaining photo clears focus", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    await photos(page).first().click();
+    await selectFirstPhoto(page);
 
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
@@ -243,9 +230,7 @@ test.describe("Send to unused & set as cover", () => {
   test("setAsCover advances focus to next photo", async ({
     focusPage: page,
   }) => {
-    await scrollToStep(page, "Argentina", "Buenos Aires");
-    const first = photos(page).first();
-    await first.click();
+    const first = await selectFirstPhoto(page);
     await expect(first).toHaveAttribute("aria-pressed", "true");
 
     await page.keyboard.press(PHOTO_SHORTCUTS.setAsCover);

--- a/frontend/e2e/photo-focus.test.ts
+++ b/frontend/e2e/photo-focus.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./fixtures";
+import { expect, openEditor, test } from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 import { PHOTO_SHORTCUTS } from "../src/composables/shortcutKeys";
 
@@ -8,13 +8,6 @@ function photos(page: Page): Locator {
 
 function selected(page: Page): Locator {
   return page.locator('[role="button"][aria-pressed="true"]');
-}
-
-async function openEditor(page: Page) {
-  await page.goto("/editor");
-  await expect(page.getByText("South America")).toBeVisible({
-    timeout: 15_000,
-  });
 }
 
 async function scrollToStep(page: Page, country: string, stepName: string) {

--- a/frontend/e2e/photo-focus.test.ts
+++ b/frontend/e2e/photo-focus.test.ts
@@ -16,11 +16,15 @@ function selected(page: Page): Locator {
   return page.locator('[role="button"][aria-pressed="true"]');
 }
 
+async function expectOneSelected(page: Page, timeout = 3_000) {
+  await expect(selected(page)).toHaveCount(1, { timeout });
+}
+
 async function selectFirstPhoto(page: Page): Promise<Locator> {
   await scrollToStep(page, "Argentina", "Buenos Aires");
   const first = photos(page).first();
   await first.click();
-  await expect(selected(page)).toHaveCount(1);
+  await expectOneSelected(page);
   return first;
 }
 
@@ -34,7 +38,7 @@ async function selectedIndex(page: Page): Promise<number> {
 async function press(page: Page, key: string, times: number) {
   for (let i = 0; i < times; i++) {
     await page.keyboard.press(key);
-    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+    await expectOneSelected(page);
   }
 }
 
@@ -65,7 +69,7 @@ test.describe("Photo focus & arrow navigation", () => {
     await page.keyboard.press("ArrowRight");
 
     await expect(first).toHaveAttribute("aria-pressed", "false");
-    await expect(selected(page)).toHaveCount(1);
+    await expectOneSelected(page);
   });
 
   test("ArrowRight moves DOM focus to the selected photo", async ({
@@ -75,7 +79,7 @@ test.describe("Photo focus & arrow navigation", () => {
     await expect(first).toHaveAttribute("aria-pressed", "true");
 
     await page.keyboard.press("ArrowRight");
-    await expect(selected(page)).toHaveCount(1);
+    await expectOneSelected(page);
 
     await expect
       .poll(async () =>
@@ -100,7 +104,7 @@ test.describe("Photo focus & arrow navigation", () => {
     await page.keyboard.press("ArrowLeft");
 
     await expect(second).toHaveAttribute("aria-pressed", "false");
-    await expect(selected(page)).toHaveCount(1);
+    await expectOneSelected(page);
   });
 
   test("ArrowRight crosses step boundary", async ({ focusPage: page }) => {
@@ -111,7 +115,7 @@ test.describe("Photo focus & arrow navigation", () => {
 
     await page.keyboard.press("ArrowRight");
 
-    await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
+    await expectOneSelected(page, 5_000);
     await expect(selected(page)).toBeInViewport({ timeout: 5_000 });
     const afterBoundary = await selected(page).boundingBox();
     expect(afterBoundary!.y).not.toBeCloseTo(beforeBoundary!.y, -1);
@@ -125,7 +129,7 @@ test.describe("Photo focus & arrow navigation", () => {
 
     await page.keyboard.press("ArrowLeft");
 
-    await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
+    await expectOneSelected(page, 5_000);
     await expect(selected(page)).toBeInViewport({ timeout: 5_000 });
     const backInStep1 = await selected(page).boundingBox();
     expect(backInStep1!.y).not.toBeCloseTo(inStep2!.y, -1);
@@ -139,7 +143,7 @@ test.describe("Photo focus & arrow navigation", () => {
     const indices: number[] = [];
     for (let i = 0; i < 5; i++) {
       await page.keyboard.press("ArrowRight");
-      await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+      await expectOneSelected(page);
       indices.push(await selectedIndex(page));
     }
 
@@ -168,7 +172,7 @@ test.describe("Photo focus & arrow navigation", () => {
       await page.keyboard.press("ArrowRight");
     }
 
-    await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
+    await expectOneSelected(page, 5_000);
     await expect(selected(page)).toBeInViewport({ timeout: 5_000 });
   });
 });
@@ -185,7 +189,7 @@ test.describe("Send to unused & set as cover", () => {
 
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
 
-    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+    await expectOneSelected(page);
     await expect(selected(page)).toBeInViewport();
   });
 
@@ -198,7 +202,7 @@ test.describe("Send to unused & set as cover", () => {
     const indexBefore = await selectedIndex(page);
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
 
-    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+    await expectOneSelected(page);
     const indexAfter = await selectedIndex(page);
     expect(indexAfter).toBeLessThan(indexBefore);
   });
@@ -209,9 +213,9 @@ test.describe("Send to unused & set as cover", () => {
     await selectFirstPhoto(page);
 
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
-    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+    await expectOneSelected(page);
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
-    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+    await expectOneSelected(page);
 
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(selected(page)).toHaveCount(0, { timeout: 3_000 });
@@ -225,7 +229,7 @@ test.describe("Send to unused & set as cover", () => {
 
     await page.keyboard.press(PHOTO_SHORTCUTS.setAsCover);
 
-    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+    await expectOneSelected(page);
     await expect(first).not.toHaveAttribute("aria-pressed", "true");
   });
 

--- a/frontend/e2e/photo-focus.test.ts
+++ b/frontend/e2e/photo-focus.test.ts
@@ -1,22 +1,19 @@
-import { expect, openEditor, test } from "./fixtures";
+import {
+  expect,
+  openEditor,
+  photoButtons,
+  scrollToStep,
+  test,
+} from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 import { PHOTO_SHORTCUTS } from "../src/composables/shortcutKeys";
 
 function photos(page: Page): Locator {
-  return page.locator('[role="button"][aria-pressed]');
+  return photoButtons(page);
 }
 
 function selected(page: Page): Locator {
   return page.locator('[role="button"][aria-pressed="true"]');
-}
-
-async function scrollToStep(page: Page, country: string, stepName: string) {
-  const nav = page.getByRole("navigation");
-  await nav.getByText(country).click();
-  const step = nav.getByText(stepName);
-  await expect(step).toBeVisible({ timeout: 3_000 });
-  await step.click();
-  await expect(photos(page).first()).toBeVisible({ timeout: 5_000 });
 }
 
 async function selectFirstPhoto(page: Page): Promise<Locator> {

--- a/frontend/e2e/photo-focus.test.ts
+++ b/frontend/e2e/photo-focus.test.ts
@@ -2,21 +2,14 @@ import { test, expect } from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 import { PHOTO_SHORTCUTS } from "../src/composables/shortcutKeys";
 
-// ---------------------------------------------------------------------------
-// Helpers - purely user-facing selectors
-// ---------------------------------------------------------------------------
-
-/** All focusable photos (role="button" with aria-pressed). */
 function photos(page: Page): Locator {
   return page.locator('[role="button"][aria-pressed]');
 }
 
-/** The currently selected photo (exactly 0 or 1 expected). */
 function selected(page: Page): Locator {
   return page.locator('[role="button"][aria-pressed="true"]');
 }
 
-/** Navigate to the editor and wait for it to load. */
 async function openEditor(page: Page) {
   await page.goto("/editor");
   await expect(page.getByText("South America")).toBeVisible({
@@ -24,26 +17,28 @@ async function openEditor(page: Page) {
   });
 }
 
-/**
- * Navigate to a step by clicking its country group, then its name
- * in the sidebar - the same way a real user would.
- */
 async function scrollToStep(page: Page, country: string, stepName: string) {
   const nav = page.getByRole("navigation");
-  // Expand the country group (click the country name header).
   await nav.getByText(country).click();
-  // Wait for the step name to become visible inside the expanded group.
   const step = nav.getByText(stepName);
   await expect(step).toBeVisible({ timeout: 3_000 });
-  // Click the step to scroll the album viewer there.
   await step.click();
-  // Wait for the virtualizer to scroll and mount the step's pages.
   await expect(photos(page).first()).toBeVisible({ timeout: 5_000 });
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+async function selectedIndex(page: Page): Promise<number> {
+  return selected(page).evaluate((el) => {
+    const all = [...document.querySelectorAll('[role="button"][aria-pressed]')];
+    return all.indexOf(el);
+  });
+}
+
+async function press(page: Page, key: string, times: number) {
+  for (let i = 0; i < times; i++) {
+    await page.keyboard.press(key);
+    await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
+  }
+}
 
 test.describe("Photo focus & arrow navigation", () => {
   test.beforeEach(async ({ focusPage: page }) => {
@@ -78,9 +73,7 @@ test.describe("Photo focus & arrow navigation", () => {
 
     await page.keyboard.press("ArrowRight");
 
-    // The first photo should no longer be selected.
     await expect(first).toHaveAttribute("aria-pressed", "false");
-    // Exactly one photo should be selected - a different one.
     await expect(selected(page)).toHaveCount(1);
   });
 
@@ -111,7 +104,6 @@ test.describe("Photo focus & arrow navigation", () => {
   }) => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
 
-    // Select the second visible photo.
     const second = photos(page).nth(1);
     await second.click();
     await expect(second).toHaveAttribute("aria-pressed", "true");
@@ -127,15 +119,11 @@ test.describe("Photo focus & arrow navigation", () => {
     await photos(page).first().click();
     await expect(selected(page)).toHaveCount(1);
 
-    // Arrow to the last photo of the first step (3 navigable photos → 2 presses).
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("ArrowRight");
+    await press(page, "ArrowRight", 2);
     const beforeBoundary = await selected(page).boundingBox();
 
-    // One more press crosses into the next step.
     await page.keyboard.press("ArrowRight");
 
-    // Selection should still be valid, visible, and at a different position.
     await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
     await expect(selected(page)).toBeInViewport({ timeout: 5_000 });
     const afterBoundary = await selected(page).boundingBox();
@@ -146,14 +134,9 @@ test.describe("Photo focus & arrow navigation", () => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     await photos(page).first().click();
 
-    // Arrow 3 times to cross into step 2 (first photo of step 2).
-    for (let i = 0; i < 3; i++) {
-      await page.keyboard.press("ArrowRight");
-    }
-    await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
+    await press(page, "ArrowRight", 3);
     const inStep2 = await selected(page).boundingBox();
 
-    // Press ArrowLeft to go back across the boundary.
     await page.keyboard.press("ArrowLeft");
 
     await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
@@ -168,29 +151,13 @@ test.describe("Photo focus & arrow navigation", () => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     await photos(page).first().click();
 
-    // Cross into step 2 (3 arrows) then continue forward (2 more).
-    // If the step boundary broke internal state, the 4th+ arrows
-    // would snap back to the previous step instead of continuing.
-
-    // Track which DOM element is selected at each step using its index
-    // among all [aria-pressed] elements in the document.
-    async function selectedIndex(): Promise<number> {
-      return selected(page).evaluate((el) => {
-        const all = [
-          ...document.querySelectorAll('[role="button"][aria-pressed]'),
-        ];
-        return all.indexOf(el);
-      });
-    }
-
     const indices: number[] = [];
     for (let i = 0; i < 5; i++) {
       await page.keyboard.press("ArrowRight");
       await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
-      indices.push(await selectedIndex());
+      indices.push(await selectedIndex(page));
     }
 
-    // Every arrow press should land on a different photo - no revisits.
     const unique = new Set(indices);
     expect(unique.size).toBe(indices.length);
   });
@@ -199,30 +166,12 @@ test.describe("Photo focus & arrow navigation", () => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     await photos(page).first().click();
 
-    async function selectedIndex(): Promise<number> {
-      return selected(page).evaluate((el) => {
-        const all = [
-          ...document.querySelectorAll('[role="button"][aria-pressed]'),
-        ];
-        return all.indexOf(el);
-      });
-    }
+    const startIdx = await selectedIndex(page);
 
-    const startIdx = await selectedIndex();
+    await press(page, "ArrowRight", 4);
+    await press(page, "ArrowLeft", 4);
 
-    // Go forward 4 times (crosses into step 2).
-    for (let i = 0; i < 4; i++) {
-      await page.keyboard.press("ArrowRight");
-      await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
-    }
-
-    // Go backward 4 times (should return to start).
-    for (let i = 0; i < 4; i++) {
-      await page.keyboard.press("ArrowLeft");
-      await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
-    }
-
-    const endIdx = await selectedIndex();
+    const endIdx = await selectedIndex(page);
     expect(endIdx).toBe(startIdx);
   });
 
@@ -233,20 +182,14 @@ test.describe("Photo focus & arrow navigation", () => {
     await photos(page).first().click();
     await expect(selected(page)).toHaveCount(1);
 
-    // Fire several rapid arrow presses - enough to cross at least one step boundary.
     for (let i = 0; i < 6; i++) {
       await page.keyboard.press("ArrowRight");
     }
 
-    // After settling, exactly one photo should be selected and visible.
     await expect(selected(page)).toHaveCount(1, { timeout: 5_000 });
     await expect(selected(page)).toBeInViewport({ timeout: 5_000 });
   });
 });
-
-// ---------------------------------------------------------------------------
-// Send-to-unused & set-as-cover shortcuts
-// ---------------------------------------------------------------------------
 
 test.describe("Send to unused & set as cover", () => {
   test.beforeEach(async ({ focusPage: page }) => {
@@ -262,7 +205,6 @@ test.describe("Send to unused & set as cover", () => {
 
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
 
-    // Focus should advance to a remaining photo (not drop).
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
     await expect(selected(page)).toBeInViewport();
   });
@@ -272,28 +214,14 @@ test.describe("Send to unused & set as cover", () => {
   }) => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
 
-    // Navigate to the last navigable photo (3 navigable → 2 ArrowRight presses).
     await photos(page).first().click();
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("ArrowRight");
-    await expect(selected(page)).toHaveCount(1);
+    await press(page, "ArrowRight", 2);
 
-    // Track which DOM element is selected by its index among all focusable photos.
-    async function selectedIndex(): Promise<number> {
-      return selected(page).evaluate((el) => {
-        const all = [
-          ...document.querySelectorAll('[role="button"][aria-pressed]'),
-        ];
-        return all.indexOf(el);
-      });
-    }
-
-    const indexBefore = await selectedIndex();
+    const indexBefore = await selectedIndex(page);
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
 
-    // Focus should move backward - the selected index should decrease.
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
-    const indexAfter = await selectedIndex();
+    const indexAfter = await selectedIndex(page);
     expect(indexAfter).toBeLessThan(indexBefore);
   });
 
@@ -303,13 +231,11 @@ test.describe("Send to unused & set as cover", () => {
     await scrollToStep(page, "Argentina", "Buenos Aires");
     await photos(page).first().click();
 
-    // Remove the first two navigable photos, leaving only one.
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
 
-    // Now only one navigable photo remains - removing it should clear focus.
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(selected(page)).toHaveCount(0, { timeout: 3_000 });
   });
@@ -324,7 +250,6 @@ test.describe("Send to unused & set as cover", () => {
 
     await page.keyboard.press(PHOTO_SHORTCUTS.setAsCover);
 
-    // Focus should advance - the photo became cover, so it's no longer navigable.
     await expect(selected(page)).toHaveCount(1, { timeout: 3_000 });
     await expect(first).not.toHaveAttribute("aria-pressed", "true");
   });

--- a/frontend/e2e/smoke.test.ts
+++ b/frontend/e2e/smoke.test.ts
@@ -1,29 +1,19 @@
 import { test, expect } from "./fixtures";
-import { mockAuthStateAnonymous } from "../tests/fixtures/mocks";
-
-const ANONYMOUS = async (page: import("@playwright/test").Page) => {
-  await page.route("**/api/v1/auth/state", (route) =>
-    route.fulfill({ json: mockAuthStateAnonymous }),
-  );
-};
 
 test.describe("Landing page", () => {
-  test.beforeEach(async ({ page }) => ANONYMOUS(page));
-
-  test("renders the landing page", async ({ page }) => {
+  test("renders the landing page", async ({ anonymousPage: page }) => {
     await page.goto("/");
     await expect(page).toHaveTitle(/wanderbound/i);
   });
 
-  test("shows sign-in area", async ({ page }) => {
+  test("shows sign-in area", async ({ anonymousPage: page }) => {
     await page.goto("/");
     await expect(page.locator("body")).toBeVisible();
   });
 });
 
 test.describe("Health check redirect", () => {
-  test("anonymous user stays on landing", async ({ page }) => {
-    await ANONYMOUS(page);
+  test("anonymous user stays on landing", async ({ anonymousPage: page }) => {
     await page.goto("/editor");
     await page.waitForURL("/", { timeout: 15_000 });
   });

--- a/frontend/e2e/text-editing.test.ts
+++ b/frontend/e2e/text-editing.test.ts
@@ -1,18 +1,5 @@
-import { expect, openEditor, test } from "./fixtures";
+import { expect, openEditor, scrollToStep, test } from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
-
-function photos(page: Page): Locator {
-  return page.locator('[role="button"][aria-pressed]');
-}
-
-async function scrollToStep(page: Page, country: string, stepName: string) {
-  const nav = page.getByRole("navigation");
-  await nav.getByText(country).click();
-  const step = nav.getByText(stepName);
-  await expect(step).toBeVisible({ timeout: 3_000 });
-  await step.click();
-  await expect(photos(page).first()).toBeVisible({ timeout: 5_000 });
-}
 
 /** Find the first step name textbox (aria-label="Step name") in the viewer. */
 function stepNameTextbox(page: Page): Locator {

--- a/frontend/e2e/text-editing.test.ts
+++ b/frontend/e2e/text-editing.test.ts
@@ -1,15 +1,8 @@
-import { test, expect } from "./fixtures";
+import { expect, openEditor, test } from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 
 function photos(page: Page): Locator {
   return page.locator('[role="button"][aria-pressed]');
-}
-
-async function openEditor(page: Page) {
-  await page.goto("/editor");
-  await expect(page.getByText("South America")).toBeVisible({
-    timeout: 15_000,
-  });
 }
 
 async function scrollToStep(page: Page, country: string, stepName: string) {
@@ -23,7 +16,10 @@ async function scrollToStep(page: Page, country: string, stepName: string) {
 
 /** Find the first step name textbox (aria-label="Step name") in the viewer. */
 function stepNameTextbox(page: Page): Locator {
-  return page.getByRole("main").getByRole("textbox", { name: "Step name" }).first();
+  return page
+    .getByRole("main")
+    .getByRole("textbox", { name: "Step name" })
+    .first();
 }
 
 test.describe("Text editing", () => {

--- a/frontend/e2e/text-editing.test.ts
+++ b/frontend/e2e/text-editing.test.ts
@@ -9,6 +9,16 @@ function stepNameTextbox(page: Page): Locator {
     .first();
 }
 
+async function editStepName(page: Page, value: string, commitKey: string) {
+  const textbox = stepNameTextbox(page);
+  await expect(textbox).toContainText("Buenos Aires");
+  await textbox.click();
+  await page.keyboard.press("Control+a");
+  await page.keyboard.type(value);
+  await page.keyboard.press(commitKey);
+  return textbox;
+}
+
 test.describe("Text editing", () => {
   test.beforeEach(async ({ focusPage: page }) => {
     await openEditor(page);
@@ -16,28 +26,14 @@ test.describe("Text editing", () => {
   });
 
   test("editing step name persists on blur", async ({ focusPage: page }) => {
-    const textbox = stepNameTextbox(page);
-    await expect(textbox).toContainText("Buenos Aires");
-
-    await textbox.click();
-    await page.keyboard.press("Control+a");
-    await page.keyboard.type("Renamed");
-
-    // Enter blurs single-line contenteditable (EditableText.vue onKeydown)
-    await page.keyboard.press("Enter");
+    const textbox = await editStepName(page, "Renamed", "Enter");
 
     // text-transform: uppercase means typed text is stored uppercase in the DOM
     await expect(textbox).toContainText("RENAMED", { timeout: 3_000 });
   });
 
   test("Escape reverts edit without saving", async ({ focusPage: page }) => {
-    const textbox = stepNameTextbox(page);
-    await expect(textbox).toContainText("Buenos Aires");
-
-    await textbox.click();
-    await page.keyboard.press("Control+a");
-    await page.keyboard.type("Discarded");
-    await page.keyboard.press("Escape");
+    const textbox = await editStepName(page, "Discarded", "Escape");
 
     // Escape restores modelValue via textContent assignment - original case preserved
     await expect(textbox).toContainText("Buenos Aires", { timeout: 3_000 });
@@ -46,14 +42,7 @@ test.describe("Text editing", () => {
   test("Ctrl+Z after editing step name restores original", async ({
     focusPage: page,
   }) => {
-    const textbox = stepNameTextbox(page);
-    await expect(textbox).toContainText("Buenos Aires");
-
-    // Edit and commit via blur
-    await textbox.click();
-    await page.keyboard.press("Control+a");
-    await page.keyboard.type("Renamed");
-    await page.keyboard.press("Enter");
+    const textbox = await editStepName(page, "Renamed", "Enter");
     await expect(textbox).toContainText("RENAMED", { timeout: 3_000 });
 
     // Undo - focus is off the contenteditable, so Ctrl+Z hits the undo stack

--- a/frontend/e2e/undo-redo.test.ts
+++ b/frontend/e2e/undo-redo.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./fixtures";
+import { expect, openEditor, test } from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 import { PHOTO_SHORTCUTS } from "../src/composables/shortcutKeys";
 
@@ -12,13 +12,6 @@ function unusedBadge(page: Page): Locator {
     .getByRole("complementary")
     .filter({ hasText: "Unused" })
     .getByText(/^\d+$/);
-}
-
-async function openEditor(page: Page) {
-  await page.goto("/editor");
-  await expect(page.getByText("South America")).toBeVisible({
-    timeout: 15_000,
-  });
 }
 
 async function scrollToStep(page: Page, country: string, stepName: string) {

--- a/frontend/e2e/undo-redo.test.ts
+++ b/frontend/e2e/undo-redo.test.ts
@@ -8,10 +8,6 @@ import {
 import type { Page, Locator } from "@playwright/test";
 import { PHOTO_SHORTCUTS } from "../src/composables/shortcutKeys";
 
-function photos(page: Page): Locator {
-  return photoButtons(page);
-}
-
 /** The unused photo count badge in the inspector panel. */
 function unusedBadge(page: Page): Locator {
   return page
@@ -31,7 +27,7 @@ test.describe("Undo & redo", () => {
   }) => {
     await expect(unusedBadge(page)).toHaveText("0");
 
-    await photos(page).first().click();
+    await photoButtons(page).first().click();
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(unusedBadge(page)).toHaveText("1", { timeout: 3_000 });
 
@@ -42,7 +38,7 @@ test.describe("Undo & redo", () => {
   test("Ctrl+Z after sendToUnused restores focus to the moved photo", async ({
     focusPage: page,
   }) => {
-    const photo = photos(page).first();
+    const photo = photoButtons(page).first();
     await photo.click();
     const originalMedia = await photo.getAttribute("data-media");
 
@@ -62,7 +58,7 @@ test.describe("Undo & redo", () => {
   }) => {
     await expect(unusedBadge(page)).toHaveText("0");
 
-    await photos(page).first().click();
+    await photoButtons(page).first().click();
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(unusedBadge(page)).toHaveText("1", { timeout: 3_000 });
 
@@ -81,7 +77,7 @@ test.describe("Undo & redo", () => {
     await expect(unusedBadge(page)).toHaveText("0");
 
     // Send two photos to unused
-    await photos(page).first().click();
+    await photoButtons(page).first().click();
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);
     await expect(unusedBadge(page)).toHaveText("1", { timeout: 3_000 });
     await page.keyboard.press(PHOTO_SHORTCUTS.sendToUnused);

--- a/frontend/e2e/undo-redo.test.ts
+++ b/frontend/e2e/undo-redo.test.ts
@@ -1,9 +1,15 @@
-import { expect, openEditor, test } from "./fixtures";
+import {
+  expect,
+  openEditor,
+  photoButtons,
+  scrollToStep,
+  test,
+} from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 import { PHOTO_SHORTCUTS } from "../src/composables/shortcutKeys";
 
 function photos(page: Page): Locator {
-  return page.locator('[role="button"][aria-pressed]');
+  return photoButtons(page);
 }
 
 /** The unused photo count badge in the inspector panel. */
@@ -12,15 +18,6 @@ function unusedBadge(page: Page): Locator {
     .getByRole("complementary")
     .filter({ hasText: "Unused" })
     .getByText(/^\d+$/);
-}
-
-async function scrollToStep(page: Page, country: string, stepName: string) {
-  const nav = page.getByRole("navigation");
-  await nav.getByText(country).click();
-  const step = nav.getByText(stepName);
-  await expect(step).toBeVisible({ timeout: 3_000 });
-  await step.click();
-  await expect(photos(page).first()).toBeVisible({ timeout: 5_000 });
 }
 
 test.describe("Undo & redo", () => {

--- a/frontend/e2e/video-keyboard.test.ts
+++ b/frontend/e2e/video-keyboard.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./fixtures";
+import { expect, openEditor, test } from "./fixtures";
 import type { Page, Locator } from "@playwright/test";
 import { FOCUS_VIDEO } from "../tests/fixtures/mocks";
 
@@ -8,13 +8,6 @@ function videoItem(page: Page): Locator {
 
 function playOverlay(page: Page): Locator {
   return videoItem(page).getByRole("button", { name: "Play video" });
-}
-
-async function openEditor(page: Page) {
-  await page.goto("/editor");
-  await expect(page.getByText("South America")).toBeVisible({
-    timeout: 15_000,
-  });
 }
 
 async function scrollToVideo(page: Page) {

--- a/frontend/tests/components/InspectorDrawer.test.ts
+++ b/frontend/tests/components/InspectorDrawer.test.ts
@@ -1,5 +1,5 @@
 import { defineComponent } from "vue";
-import { mountWithPlugins } from "../helpers";
+import { makeAlbumMedia, mountWithPlugins } from "../helpers";
 import InspectorDrawer from "@/components/editor/InspectorDrawer.vue";
 import { defaultAlbum, defaultSteps } from "../mocks/handlers";
 
@@ -32,18 +32,10 @@ describe("InspectorDrawer", () => {
         sectionKey: "step-1",
         step: { ...defaultSteps[0], unused: ["unused.jpg"] },
         media: [
-          {
-            uid: 1,
-            aid: defaultAlbum.id,
+          makeAlbumMedia({
             name: "unused.jpg",
-            kind: "photo",
-            width: 1920,
-            height: 1080,
-            byte_size: 1234,
-            upgrade_candidate: false,
-            created_at: "2026-05-13T12:00:00Z",
-            updated_at: "2026-05-13T12:34:56Z",
-          },
+            aid: defaultAlbum.id,
+          }),
         ],
       },
       global: {
@@ -74,18 +66,10 @@ describe("InspectorDrawer", () => {
         album: defaultAlbum,
         sectionKey: "cover-front",
         media: [
-          {
-            uid: 1,
-            aid: defaultAlbum.id,
+          makeAlbumMedia({
             name: "cover.jpg",
-            kind: "photo",
-            width: 1920,
-            height: 1080,
-            byte_size: 1234,
-            upgrade_candidate: false,
-            created_at: "2026-05-13T12:00:00Z",
-            updated_at: "2026-05-13T12:34:56Z",
-          },
+            aid: defaultAlbum.id,
+          }),
         ],
       },
       global: {

--- a/frontend/tests/components/MediaItem.test.ts
+++ b/frontend/tests/components/MediaItem.test.ts
@@ -1,10 +1,8 @@
 import { defineComponent, h, nextTick, ref, readonly } from "vue";
-import { mountWithPlugins } from "../helpers";
+import { makeAlbumMedia, mountWithPlugins, provideTestAlbum } from "../helpers";
 import MediaItem from "@/components/album/MediaItem.vue";
-import { provideAlbum } from "@/composables/useAlbum";
 import { STEP_ID_KEY, usePhotoFocus } from "@/composables/usePhotoFocus";
 import { PROGRAMMATIC_SCROLL_KEY } from "@/composables/useProgrammaticScroll";
-import { DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET } from "@/utils/photoQuality";
 
 const mutateAsync = vi.fn();
 let playSpy: ReturnType<typeof vi.spyOn>;
@@ -40,39 +38,14 @@ vi.mock("@/queries/useVideoFrameMutation", () => ({
   useVideoFrameMutation: () => ({ mutateAsync }),
 }));
 
-function mediaItem(overrides: Record<string, unknown> = {}) {
-  return {
-    uid: 1,
-    aid: "album-1",
-    name: "photo.jpg",
-    kind: "photo",
-    width: 1920,
-    height: 1080,
-    byte_size: 1234,
-    upgrade_candidate: false,
-    created_at: "2026-05-13T12:00:00Z",
-    updated_at: MEDIA_UPDATED_AT,
-    ...overrides,
-  };
-}
-
 function mountMediaItem(
-  media: Record<string, unknown>,
+  media: ReturnType<typeof makeAlbumMedia>,
   props: Record<string, unknown>,
   provide: Record<symbol, unknown>,
 ) {
   const Wrapper = defineComponent({
     setup() {
-      provideAlbum({
-        albumId: ref("album-1"),
-        colors: ref({}),
-        media: ref([media]),
-        tripStart: ref("2024-01-01"),
-        totalDays: ref(1),
-        mediaResolutionWarningPreset: ref(
-          DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
-        ),
-      });
+      provideTestAlbum({ media: [media] });
       return () => h(MediaItem, props);
     },
   });
@@ -87,7 +60,7 @@ function mountMediaItem(
 
 function mountVideoItem() {
   return mountMediaItem(
-    mediaItem({ name: "clip.mp4", kind: "video" }),
+    makeAlbumMedia({ name: "clip.mp4", kind: "video" }),
     { media: "clip.mp4", alt: "Clip" },
     { [STEP_ID_KEY as symbol]: 7 },
   );
@@ -96,10 +69,10 @@ function mountVideoItem() {
 function mountPhotoItem(
   programmaticScrolling = ref(false),
   props: Record<string, unknown> = {},
-  mediaOverrides: Record<string, unknown> = {},
+  mediaOverrides: Partial<ReturnType<typeof makeAlbumMedia>> = {},
 ) {
   return mountMediaItem(
-    mediaItem(mediaOverrides),
+    makeAlbumMedia({ updated_at: MEDIA_UPDATED_AT, ...mediaOverrides }),
     { media: "photo.jpg", alt: "Photo", ...props },
     {
       [STEP_ID_KEY as symbol]: 7,

--- a/frontend/tests/components/MediaItem.test.ts
+++ b/frontend/tests/components/MediaItem.test.ts
@@ -40,44 +40,57 @@ vi.mock("@/queries/useVideoFrameMutation", () => ({
   useVideoFrameMutation: () => ({ mutateAsync }),
 }));
 
-function mountVideoItem() {
+function mediaItem(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: 1,
+    aid: "album-1",
+    name: "photo.jpg",
+    kind: "photo",
+    width: 1920,
+    height: 1080,
+    byte_size: 1234,
+    upgrade_candidate: false,
+    created_at: "2026-05-13T12:00:00Z",
+    updated_at: MEDIA_UPDATED_AT,
+    ...overrides,
+  };
+}
+
+function mountMediaItem(
+  media: Record<string, unknown>,
+  props: Record<string, unknown>,
+  provide: Record<symbol, unknown>,
+) {
   const Wrapper = defineComponent({
     setup() {
       provideAlbum({
         albumId: ref("album-1"),
         colors: ref({}),
-        media: ref([
-          {
-            uid: 1,
-            aid: "album-1",
-            name: "clip.mp4",
-            kind: "video",
-            width: 1920,
-            height: 1080,
-            byte_size: 1234,
-            upgrade_candidate: false,
-            created_at: "2026-05-13T12:00:00Z",
-            updated_at: MEDIA_UPDATED_AT,
-          },
-        ]),
+        media: ref([media]),
         tripStart: ref("2024-01-01"),
         totalDays: ref(1),
         mediaResolutionWarningPreset: ref(
           DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
         ),
       });
-      return () => h(MediaItem, { media: "clip.mp4", alt: "Clip" });
+      return () => h(MediaItem, props);
     },
   });
 
   return mountWithPlugins(Wrapper, {
     global: {
-      provide: {
-        [STEP_ID_KEY as symbol]: 7,
-      },
+      provide,
     },
     attachTo: document.body,
   });
+}
+
+function mountVideoItem() {
+  return mountMediaItem(
+    mediaItem({ name: "clip.mp4", kind: "video" }),
+    { media: "clip.mp4", alt: "Clip" },
+    { [STEP_ID_KEY as symbol]: 7 },
+  );
 }
 
 function mountPhotoItem(
@@ -85,45 +98,14 @@ function mountPhotoItem(
   props: Record<string, unknown> = {},
   mediaOverrides: Record<string, unknown> = {},
 ) {
-  const Wrapper = defineComponent({
-    setup() {
-      provideAlbum({
-        albumId: ref("album-1"),
-        colors: ref({}),
-        media: ref([
-          {
-            uid: 1,
-            aid: "album-1",
-            name: "photo.jpg",
-            kind: "photo",
-            width: 1920,
-            height: 1080,
-            byte_size: 1234,
-            upgrade_candidate: false,
-            created_at: "2026-05-13T12:00:00Z",
-            updated_at: MEDIA_UPDATED_AT,
-            ...mediaOverrides,
-          },
-        ]),
-        tripStart: ref("2024-01-01"),
-        totalDays: ref(1),
-        mediaResolutionWarningPreset: ref(
-          DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
-        ),
-      });
-      return () => h(MediaItem, { media: "photo.jpg", alt: "Photo", ...props });
+  return mountMediaItem(
+    mediaItem(mediaOverrides),
+    { media: "photo.jpg", alt: "Photo", ...props },
+    {
+      [STEP_ID_KEY as symbol]: 7,
+      [PROGRAMMATIC_SCROLL_KEY as symbol]: readonly(programmaticScrolling),
     },
-  });
-
-  return mountWithPlugins(Wrapper, {
-    global: {
-      provide: {
-        [STEP_ID_KEY as symbol]: 7,
-        [PROGRAMMATIC_SCROLL_KEY as symbol]: readonly(programmaticScrolling),
-      },
-    },
-    attachTo: document.body,
-  });
+  );
 }
 
 describe("MediaItem video controls", () => {

--- a/frontend/tests/components/MediaItem.test.ts
+++ b/frontend/tests/components/MediaItem.test.ts
@@ -117,7 +117,7 @@ describe("MediaItem video controls", () => {
     const video = wrapper.get("video").element as HTMLVideoElement;
 
     await wrapper.get(".media-item").trigger("keydown", { key: "Enter" });
-    await new Promise((resolve) => setTimeout(resolve));
+    await nextTick();
 
     expect(playSpy).toHaveBeenCalled();
     expect(document.activeElement).toBe(video);
@@ -161,7 +161,6 @@ describe("MediaItem video controls", () => {
     const programmaticScrolling = ref(false);
     const wrapper = mountPhotoItem(programmaticScrolling);
     await nextTick();
-    await new Promise((resolve) => setTimeout(resolve));
     MockIntersectionObserver.instances.at(-1)?.trigger(true);
     await nextTick();
     const img = wrapper.get("img");

--- a/frontend/tests/components/mapSegments.test.ts
+++ b/frontend/tests/components/mapSegments.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { drawSegmentsAndMarkers } from "@/components/album/map/mapSegments";
-import type { Segment } from "@/client";
+import { makeSegment } from "../helpers";
 
 function makeMap() {
   const container = document.createElement("div");
@@ -18,19 +18,14 @@ function makeMap() {
   };
 }
 
-const segment: Segment = {
-  uid: 1,
-  aid: "a1",
+const segment = makeSegment({
   start_time: 0,
   end_time: 1,
-  kind: "driving",
-  timezone_id: "UTC",
   points: [
     { lat: 1, lon: 2, time: 0 },
     { lat: 3, lon: 4, time: 1 },
   ],
-  route: null,
-};
+});
 
 describe("drawSegmentsAndMarkers", () => {
   it("temporarily detaches terrain while replacing segment sources", () => {

--- a/frontend/tests/composables/useAddExternalMedia.test.ts
+++ b/frontend/tests/composables/useAddExternalMedia.test.ts
@@ -1,6 +1,7 @@
 import {
   mockGooglePickerPopup,
   mockReadyGooglePickerSession,
+  resetGooglePhotosMock,
   withSetup,
 } from "../helpers";
 import { useAddExternalMedia } from "@/composables/useAddExternalMedia";
@@ -20,12 +21,7 @@ vi.mock("@/composables/useGooglePhotos", () => ({
 
 describe("useAddExternalMedia", () => {
   afterEach(() => {
-    googlePhotosMock.authorize.mockReset();
-    googlePhotosMock.closeSession.mockReset();
-    googlePhotosMock.createPickerSession.mockReset();
-    googlePhotosMock.pollSession.mockReset();
-    googlePhotosMock.isConnected.value = true;
-    googlePhotosMock.state.value = "connected";
+    resetGooglePhotosMock(googlePhotosMock);
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/frontend/tests/composables/useAddExternalMedia.test.ts
+++ b/frontend/tests/composables/useAddExternalMedia.test.ts
@@ -1,4 +1,8 @@
-import { withSetup } from "../helpers";
+import {
+  mockGooglePickerPopup,
+  mockReadyGooglePickerSession,
+  withSetup,
+} from "../helpers";
 import { useAddExternalMedia } from "@/composables/useAddExternalMedia";
 
 const googlePhotosMock = vi.hoisted(() => ({
@@ -27,22 +31,8 @@ describe("useAddExternalMedia", () => {
   });
 
   it("limits Google import picker sessions to the backend import cap", async () => {
-    googlePhotosMock.createPickerSession.mockResolvedValue({
-      sessionId: "session-1",
-      pickerUri: "https://photos.google.com/picker/session-1",
-    });
-    googlePhotosMock.pollSession.mockResolvedValue({ ready: true });
-    googlePhotosMock.closeSession.mockResolvedValue(undefined);
-
-    const popup = {
-      close: vi.fn(),
-      document: {
-        body: { style: {}, textContent: "" },
-        title: "",
-      },
-      location: { href: "" },
-    };
-    vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    mockReadyGooglePickerSession(googlePhotosMock);
+    mockGooglePickerPopup();
     vi.stubGlobal(
       "fetch",
       vi

--- a/frontend/tests/composables/useMediaImport.test.ts
+++ b/frontend/tests/composables/useMediaImport.test.ts
@@ -1,6 +1,7 @@
 import { readImportStream } from "@/composables/useMediaImport";
 import { externalMediaInvalidationKeys } from "@/composables/useAddExternalMedia";
 import { queryKeys } from "@/queries/keys";
+import { sseBody } from "../sse";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -9,10 +10,6 @@ function streamFromText(text: string): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
-}
-
-function sseBody(events: object[]): string {
-  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
 }
 
 describe("readImportStream", () => {

--- a/frontend/tests/composables/useOverview.test.ts
+++ b/frontend/tests/composables/useOverview.test.ts
@@ -1,12 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { computeOverview } from "@/composables/useOverview";
-import { makeStep } from "../helpers";
+import { makeLocation, makeStep } from "../helpers";
 
 describe("computeOverview", () => {
   it("excludes countries with code '00'", () => {
     const steps = [
-      makeStep({ location: { lat: 0, lon: 0, name: "Unknown", detail: "Unknown", country_code: "00" } }),
-      makeStep({ id: 2, location: { lat: 52.52, lon: 13.4, name: "Berlin", detail: "Germany", country_code: "DE" } }),
+      makeStep({
+        location: makeLocation({
+          name: "Unknown",
+          detail: "Unknown",
+          country_code: "00",
+        }),
+      }),
+      makeStep({
+        id: 2,
+        location: makeLocation({
+          lat: 52.52,
+          lon: 13.4,
+          name: "Berlin",
+          detail: "Germany",
+          country_code: "DE",
+        }),
+      }),
     ];
     const overview = computeOverview(steps, [], null, null);
     expect(overview.countries).toEqual([{ code: "DE", detail: "Germany" }]);
@@ -50,5 +65,4 @@ describe("computeOverview", () => {
     const overview = computeOverview(steps, [], null, null);
     expect(overview.coldest).toMatchObject({ value: -5, isNight: true });
   });
-
 });

--- a/frontend/tests/composables/useOverview.test.ts
+++ b/frontend/tests/composables/useOverview.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { computeOverview } from "@/composables/useOverview";
-import { makeLocation, makeStep } from "../helpers";
+import { makeLocation, makeStep, makeWeather } from "../helpers";
 
 describe("computeOverview", () => {
   it("excludes countries with code '00'", () => {
@@ -31,18 +31,18 @@ describe("computeOverview", () => {
     const steps = [
       makeStep({
         name: "Hot Place",
-        weather: {
-          day: { temp: 35, feels_like: 38, icon: "clear-day" },
-          night: { temp: 25, feels_like: 27, icon: "clear-night" },
-        },
+        weather: makeWeather({
+          day: { feels_like: 38 },
+          night: { feels_like: 27 },
+        }),
       }),
       makeStep({
         id: 2,
         name: "Cold Place",
-        weather: {
-          day: { temp: 5, feels_like: 2, icon: "snow" },
-          night: { temp: -3, feels_like: -8, icon: "snow" },
-        },
+        weather: makeWeather({
+          day: { feels_like: 2 },
+          night: { feels_like: -8 },
+        }),
       }),
     ];
     const overview = computeOverview(steps, [], null, null);
@@ -56,10 +56,10 @@ describe("computeOverview", () => {
     const steps = [
       makeStep({
         name: "Only Step",
-        weather: {
-          day: { temp: 10, feels_like: 8, icon: "cloudy" },
-          night: { temp: -2, feels_like: -5, icon: "snow" },
-        },
+        weather: makeWeather({
+          day: { feels_like: 8 },
+          night: { feels_like: -5 },
+        }),
       }),
     ];
     const overview = computeOverview(steps, [], null, null);

--- a/frontend/tests/composables/useReplaceExternalMedia.test.ts
+++ b/frontend/tests/composables/useReplaceExternalMedia.test.ts
@@ -1,13 +1,10 @@
-import { ref } from "vue";
-import { withParentSetup } from "../helpers";
-import { provideAlbum } from "@/composables/useAlbum";
+import { makeAlbumMedia, provideTestAlbum, withParentSetup } from "../helpers";
 import { usePhotoFocus } from "@/composables/usePhotoFocus";
 import {
   replacementInvalidationKeys,
   useReplaceExternalMedia,
 } from "@/composables/useReplaceExternalMedia";
 import { queryKeys } from "@/queries/keys";
-import { DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET } from "@/utils/photoQuality";
 
 const googlePhotosMock = vi.hoisted(() => ({
   authorize: vi.fn(),
@@ -34,26 +31,8 @@ class PreviewImage {
 }
 
 function provideReplacementAlbum() {
-  provideAlbum({
-    albumId: ref("album-1"),
-    colors: ref({}),
-    media: ref([
-      {
-        uid: 1,
-        aid: "album-1",
-        name: "photo.jpg",
-        kind: "photo",
-        width: 1920,
-        height: 1080,
-        byte_size: 1234,
-        upgrade_candidate: false,
-        created_at: "2026-05-13T12:00:00Z",
-        updated_at: "2026-05-13T12:34:56Z",
-      },
-    ]),
-    tripStart: ref("2024-01-01"),
-    totalDays: ref(1),
-    mediaResolutionWarningPreset: ref(DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET),
+  provideTestAlbum({
+    media: [makeAlbumMedia()],
   });
 }
 

--- a/frontend/tests/composables/useReplaceExternalMedia.test.ts
+++ b/frontend/tests/composables/useReplaceExternalMedia.test.ts
@@ -1,4 +1,10 @@
-import { makeAlbumMedia, provideTestAlbum, withParentSetup } from "../helpers";
+import {
+  makeAlbumMedia,
+  mockGooglePickerPopup,
+  mockReadyGooglePickerSession,
+  provideTestAlbum,
+  withParentSetup,
+} from "../helpers";
 import { usePhotoFocus } from "@/composables/usePhotoFocus";
 import {
   replacementInvalidationKeys,
@@ -71,22 +77,8 @@ describe("useReplaceExternalMedia", () => {
   });
 
   it("limits Google replacement picker sessions to one item", async () => {
-    googlePhotosMock.createPickerSession.mockResolvedValue({
-      sessionId: "session-1",
-      pickerUri: "https://photos.google.com/picker/session-1",
-    });
-    googlePhotosMock.pollSession.mockResolvedValue({ ready: true });
-    googlePhotosMock.closeSession.mockResolvedValue(undefined);
-
-    const popup = {
-      close: vi.fn(),
-      document: {
-        body: { style: {}, textContent: "" },
-        title: "",
-      },
-      location: { href: "" },
-    };
-    vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    mockReadyGooglePickerSession(googlePhotosMock);
+    mockGooglePickerPopup();
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(new Response("{}", { status: 200 })),

--- a/frontend/tests/composables/useReplaceExternalMedia.test.ts
+++ b/frontend/tests/composables/useReplaceExternalMedia.test.ts
@@ -1,5 +1,5 @@
-import { defineComponent, h, ref } from "vue";
-import { mountWithPlugins } from "../helpers";
+import { ref } from "vue";
+import { withParentSetup } from "../helpers";
 import { provideAlbum } from "@/composables/useAlbum";
 import { usePhotoFocus } from "@/composables/usePhotoFocus";
 import {
@@ -33,6 +33,35 @@ class PreviewImage {
   }
 }
 
+function provideReplacementAlbum() {
+  provideAlbum({
+    albumId: ref("album-1"),
+    colors: ref({}),
+    media: ref([
+      {
+        uid: 1,
+        aid: "album-1",
+        name: "photo.jpg",
+        kind: "photo",
+        width: 1920,
+        height: 1080,
+        byte_size: 1234,
+        upgrade_candidate: false,
+        created_at: "2026-05-13T12:00:00Z",
+        updated_at: "2026-05-13T12:34:56Z",
+      },
+    ]),
+    tripStart: ref("2024-01-01"),
+    totalDays: ref(1),
+    mediaResolutionWarningPreset: ref(DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET),
+  });
+}
+
+function mountReplaceExternalMedia() {
+  return withParentSetup(provideReplacementAlbum, useReplaceExternalMedia)
+    .result;
+}
+
 describe("useReplaceExternalMedia", () => {
   afterEach(() => {
     usePhotoFocus().blur();
@@ -51,43 +80,7 @@ describe("useReplaceExternalMedia", () => {
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:replacement");
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
     usePhotoFocus().focus(1, "photo.jpg");
-    let result!: ReturnType<typeof useReplaceExternalMedia>;
-
-    const Child = defineComponent({
-      setup() {
-        result = useReplaceExternalMedia();
-        return () => null;
-      },
-    });
-    const Parent = defineComponent({
-      setup() {
-        provideAlbum({
-          albumId: ref("album-1"),
-          colors: ref({}),
-          media: ref([
-            {
-              uid: 1,
-              aid: "album-1",
-              name: "photo.jpg",
-              kind: "photo",
-              width: 1920,
-              height: 1080,
-              byte_size: 1234,
-              upgrade_candidate: false,
-              created_at: "2026-05-13T12:00:00Z",
-              updated_at: "2026-05-13T12:34:56Z",
-            },
-          ]),
-          tripStart: ref("2024-01-01"),
-          totalDays: ref(1),
-          mediaResolutionWarningPreset: ref(
-            DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
-          ),
-        });
-        return () => h(Child);
-      },
-    });
-    mountWithPlugins(Parent);
+    const result = mountReplaceExternalMedia();
 
     const review = await result.prepareDeviceReview(
       new File(["image"], "replacement.jpg", { type: "image/jpeg" }),
@@ -121,43 +114,7 @@ describe("useReplaceExternalMedia", () => {
     );
 
     usePhotoFocus().focus(1, "photo.jpg");
-    let result!: ReturnType<typeof useReplaceExternalMedia>;
-
-    const Child = defineComponent({
-      setup() {
-        result = useReplaceExternalMedia();
-        return () => null;
-      },
-    });
-    const Parent = defineComponent({
-      setup() {
-        provideAlbum({
-          albumId: ref("album-1"),
-          colors: ref({}),
-          media: ref([
-            {
-              uid: 1,
-              aid: "album-1",
-              name: "photo.jpg",
-              kind: "photo",
-              width: 1920,
-              height: 1080,
-              byte_size: 1234,
-              upgrade_candidate: false,
-              created_at: "2026-05-13T12:00:00Z",
-              updated_at: "2026-05-13T12:34:56Z",
-            },
-          ]),
-          tripStart: ref("2024-01-01"),
-          totalDays: ref(1),
-          mediaResolutionWarningPreset: ref(
-            DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
-          ),
-        });
-        return () => h(Child);
-      },
-    });
-    mountWithPlugins(Parent);
+    const result = mountReplaceExternalMedia();
 
     await expect(result.replaceFromGoogle()).resolves.toBe("photo.jpg");
 

--- a/frontend/tests/composables/useReplaceExternalMedia.test.ts
+++ b/frontend/tests/composables/useReplaceExternalMedia.test.ts
@@ -3,6 +3,7 @@ import {
   mockGooglePickerPopup,
   mockReadyGooglePickerSession,
   provideTestAlbum,
+  resetGooglePhotosMock,
   withParentSetup,
 } from "../helpers";
 import { usePhotoFocus } from "@/composables/usePhotoFocus";
@@ -50,12 +51,7 @@ function mountReplaceExternalMedia() {
 describe("useReplaceExternalMedia", () => {
   afterEach(() => {
     usePhotoFocus().blur();
-    googlePhotosMock.authorize.mockReset();
-    googlePhotosMock.closeSession.mockReset();
-    googlePhotosMock.createPickerSession.mockReset();
-    googlePhotosMock.pollSession.mockReset();
-    googlePhotosMock.isConnected.value = true;
-    googlePhotosMock.state.value = "connected";
+    resetGooglePhotosMock(googlePhotosMock);
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/frontend/tests/composables/useStepLayout.test.ts
+++ b/frontend/tests/composables/useStepLayout.test.ts
@@ -1,55 +1,37 @@
-import { createApp, defineComponent, h, ref, type Ref } from "vue";
+import { ref, type Ref } from "vue";
 import type { StepRead as Step, StepUpdate } from "@/client";
 import { provideStepMutate, useStepLayout } from "@/composables/useStepLayout";
-import { makeStep } from "../helpers";
+import { makeStep, withParentSetup } from "../helpers";
 
 vi.mock("vue-draggable-plus", () => ({
   useDraggable: vi.fn(),
 }));
 
-interface LayoutResult {
-  saveField: (patch: Partial<StepUpdate>) => void;
-  onPageUpdate: (idx: number, page: string[]) => void;
-  onCoverUpdate: (cover: string) => void;
-  printMode: boolean;
-}
-
 function mountStepLayout(step: Step) {
   const stepRef = ref(step);
   const mutateSpy =
     vi.fn<(payload: { sid: number; update: StepUpdate }) => void>();
-  let result!: LayoutResult;
-
-  const Child = defineComponent({
-    setup() {
+  const { result } = withParentSetup(
+    () => {
+      provideStepMutate(mutateSpy);
+    },
+    () => {
       const dropZoneRef = ref(null);
       const coverDropRef = ref(null);
-      result = useStepLayout(stepRef as Ref<Step>, {
+      return useStepLayout(stepRef as Ref<Step>, {
         dropZoneRef,
         coverDropRef,
       });
-      return () => null;
     },
-  });
-
-  const Parent = defineComponent({
-    setup() {
-      provideStepMutate(mutateSpy);
-      return () => h(Child);
-    },
-  });
-
-  const app = createApp(Parent);
-  app.mount(document.createElement("div"));
-
-  onTestFinished(() => {
-    app.unmount();
-  });
+    { plugins: false },
+  );
 
   return { result, mutateSpy, stepRef };
 }
 
-function lastUpdate(mutateSpy: ReturnType<typeof mountStepLayout>["mutateSpy"]) {
+function lastUpdate(
+  mutateSpy: ReturnType<typeof mountStepLayout>["mutateSpy"],
+) {
   expect(mutateSpy).toHaveBeenCalledOnce();
   return mutateSpy.mock.calls[0][0].update;
 }
@@ -72,7 +54,9 @@ describe("onCoverUpdate", () => {
       { cover: "new_cover", unused: ["u1", "u2"] },
     ],
   ])("updates cover placement", (stepPatch, cover, expected) => {
-    const { result, mutateSpy } = mountStepLayout(makeStep({ id: 1, ...stepPatch }));
+    const { result, mutateSpy } = mountStepLayout(
+      makeStep({ id: 1, ...stepPatch }),
+    );
 
     result.onCoverUpdate(cover);
 
@@ -83,7 +67,13 @@ describe("onCoverUpdate", () => {
 describe("onPageUpdate", () => {
   it.each([
     [
-      { pages: [["a", "b"], ["c", "d"]], unused: [] },
+      {
+        pages: [
+          ["a", "b"],
+          ["c", "d"],
+        ],
+        unused: [],
+      },
       ["a", "b", "c"],
       { pages: [["a", "b", "c"], ["d"]], unused: [] },
     ],
@@ -98,7 +88,9 @@ describe("onPageUpdate", () => {
       { pages: [["a", "b"]] },
     ],
   ])("updates page placement", (stepPatch, page, expected) => {
-    const { result, mutateSpy } = mountStepLayout(makeStep({ id: 1, ...stepPatch }));
+    const { result, mutateSpy } = mountStepLayout(
+      makeStep({ id: 1, ...stepPatch }),
+    );
 
     result.onPageUpdate(0, page);
 

--- a/frontend/tests/composables/useStepLayout.test.ts
+++ b/frontend/tests/composables/useStepLayout.test.ts
@@ -1,18 +1,8 @@
-/**
- * Tests for useStepLayout's pure logic functions.
- *
- * useStepLayout itself is tightly coupled (useDraggable, inject, usePrintMode),
- * so we test the logic by mounting it with withSetup + providing dependencies.
- * The key functions tested: withoutPhotos (via onCoverUpdate/onPageUpdate),
- * and the various list-management operations.
- */
-
 import { createApp, defineComponent, h, ref, type Ref } from "vue";
 import type { StepRead as Step, StepUpdate } from "@/client";
 import { provideStepMutate, useStepLayout } from "@/composables/useStepLayout";
 import { makeStep } from "../helpers";
 
-// Mock vue-draggable-plus to avoid DOM requirements
 vi.mock("vue-draggable-plus", () => ({
   useDraggable: vi.fn(),
 }));
@@ -24,10 +14,6 @@ interface LayoutResult {
   printMode: boolean;
 }
 
-/**
- * Mount useStepLayout with a provided step and mutate function.
- * Returns the composable's API and the mutate spy.
- */
 function mountStepLayout(step: Step) {
   const stepRef = ref(step);
   const mutateSpy =
@@ -63,120 +49,59 @@ function mountStepLayout(step: Step) {
   return { result, mutateSpy, stepRef };
 }
 
-// ---------------------------------------------------------------------------
-// onCoverUpdate
-// ---------------------------------------------------------------------------
+function lastUpdate(mutateSpy: ReturnType<typeof mountStepLayout>["mutateSpy"]) {
+  expect(mutateSpy).toHaveBeenCalledOnce();
+  return mutateSpy.mock.calls[0][0].update;
+}
 
 describe("onCoverUpdate", () => {
-  it("sets cover and removes photo from pages", () => {
-    const step = makeStep({
-      id: 1,
-      cover: null,
-      pages: [["p1", "p2"], ["p3"]],
-      unused: [],
-    });
-    const { result, mutateSpy } = mountStepLayout(step);
+  it.each([
+    [
+      { cover: null, pages: [["p1", "p2"], ["p3"]], unused: [] },
+      "p2",
+      { cover: "p2", pages: [["p1"], ["p3"]], unused: [] },
+    ],
+    [
+      { cover: "old_cover", pages: [["p1", "new_cover"]], unused: ["u1"] },
+      "new_cover",
+      { cover: "new_cover", pages: [["p1"]], unused: ["u1", "old_cover"] },
+    ],
+    [
+      { cover: null, pages: [], unused: ["u1", "new_cover", "u2"] },
+      "new_cover",
+      { cover: "new_cover", unused: ["u1", "u2"] },
+    ],
+  ])("updates cover placement", (stepPatch, cover, expected) => {
+    const { result, mutateSpy } = mountStepLayout(makeStep({ id: 1, ...stepPatch }));
 
-    result.onCoverUpdate("p2");
+    result.onCoverUpdate(cover);
 
-    expect(mutateSpy).toHaveBeenCalledOnce();
-    const payload = mutateSpy.mock.calls[0][0];
-    expect(payload.sid).toBe(1);
-    expect(payload.update.cover).toBe("p2");
-    // p2 should be removed from pages
-    expect(payload.update.pages).toEqual([["p1"], ["p3"]]);
-    // No old cover to add to unused
-    expect(payload.update.unused).toEqual([]);
-  });
-
-  it("moves old cover to unused when replacing", () => {
-    const step = makeStep({
-      id: 1,
-      cover: "old_cover",
-      pages: [["p1", "new_cover"]],
-      unused: ["u1"],
-    });
-    const { result, mutateSpy } = mountStepLayout(step);
-
-    result.onCoverUpdate("new_cover");
-
-    const payload = mutateSpy.mock.calls[0][0];
-    expect(payload.update.cover).toBe("new_cover");
-    expect(payload.update.pages).toEqual([["p1"]]);
-    // Old cover should be added to unused list
-    expect(payload.update.unused).toEqual(["u1", "old_cover"]);
-  });
-
-  it("removes cover photo from unused if it was there", () => {
-    const step = makeStep({
-      id: 1,
-      cover: null,
-      pages: [],
-      unused: ["u1", "new_cover", "u2"],
-    });
-    const { result, mutateSpy } = mountStepLayout(step);
-
-    result.onCoverUpdate("new_cover");
-
-    const payload = mutateSpy.mock.calls[0][0];
-    expect(payload.update.cover).toBe("new_cover");
-    expect(payload.update.unused).toEqual(["u1", "u2"]);
+    expect(lastUpdate(mutateSpy)).toMatchObject(expected);
   });
 });
 
-// ---------------------------------------------------------------------------
-// onPageUpdate
-// ---------------------------------------------------------------------------
-
 describe("onPageUpdate", () => {
-  it("handles cross-list moves: strips added photos from other pages", () => {
-    const step = makeStep({
-      id: 1,
-      pages: [
-        ["a", "b"],
-        ["c", "d"],
-      ],
-      unused: [],
-    });
-    const { result, mutateSpy } = mountStepLayout(step);
+  it.each([
+    [
+      { pages: [["a", "b"], ["c", "d"]], unused: [] },
+      ["a", "b", "c"],
+      { pages: [["a", "b", "c"], ["d"]], unused: [] },
+    ],
+    [
+      { pages: [["a"]], unused: ["u1", "u2"] },
+      ["a", "u1"],
+      { pages: [["a", "u1"]], unused: ["u2"] },
+    ],
+    [
+      { pages: [["a"], ["b"]], unused: [] },
+      ["a", "b"],
+      { pages: [["a", "b"]] },
+    ],
+  ])("updates page placement", (stepPatch, page, expected) => {
+    const { result, mutateSpy } = mountStepLayout(makeStep({ id: 1, ...stepPatch }));
 
-    // "c" dragged from page 1 to page 0
-    result.onPageUpdate(0, ["a", "b", "c"]);
+    result.onPageUpdate(0, page);
 
-    const payload = mutateSpy.mock.calls[0][0];
-    expect(payload.update.pages).toEqual([["a", "b", "c"], ["d"]]);
-    expect(payload.update.unused).toEqual([]);
-  });
-
-  it("strips photos from unused when moved to a page", () => {
-    const step = makeStep({
-      id: 1,
-      pages: [["a"]],
-      unused: ["u1", "u2"],
-    });
-    const { result, mutateSpy } = mountStepLayout(step);
-
-    // "u1" dragged from unused to page 0
-    result.onPageUpdate(0, ["a", "u1"]);
-
-    const payload = mutateSpy.mock.calls[0][0];
-    expect(payload.update.pages).toEqual([["a", "u1"]]);
-    expect(payload.update.unused).toEqual(["u2"]);
-  });
-
-  it("filters out empty pages after cross-list move", () => {
-    const step = makeStep({
-      id: 1,
-      pages: [["a"], ["b"]],
-      unused: [],
-    });
-    const { result, mutateSpy } = mountStepLayout(step);
-
-    // Move "b" from page 1 to page 0
-    result.onPageUpdate(0, ["a", "b"]);
-
-    const payload = mutateSpy.mock.calls[0][0];
-    // Page 1 becomes empty after removing "b", should be filtered out
-    expect(payload.update.pages).toEqual([["a", "b"]]);
+    expect(lastUpdate(mutateSpy)).toMatchObject(expected);
   });
 });

--- a/frontend/tests/composables/useTripProcessingStream.test.ts
+++ b/frontend/tests/composables/useTripProcessingStream.test.ts
@@ -21,7 +21,6 @@ async function* streamEvents(events: unknown[]) {
 
 async function waitForStream() {
   await flushPromises();
-  await new Promise((resolve) => setTimeout(resolve));
   await flushPromises();
 }
 

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -12,7 +12,6 @@ client.setConfig({ baseUrl: "http://localhost:8000" });
 
 /**
  * Mount a composable in a minimal app with Pinia + PiniaColada + Quasar.
- * Call `cleanup()` when done, or use `onTestFinished` for auto-cleanup.
  */
 export function withSetup<T>(composable: () => T): T {
   let result!: T;
@@ -64,6 +63,14 @@ export function withParentSetup<T>(
   const unmount = () => app.unmount();
   onTestFinished(unmount);
   return { result, unmount };
+}
+
+export function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 /** Shared plugin list for mounting components under test. */

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -148,6 +148,22 @@ export function mockReadyGooglePickerSession(googlePhotosMock: {
   googlePhotosMock.closeSession.mockResolvedValue(undefined);
 }
 
+export function resetGooglePhotosMock(googlePhotosMock: {
+  authorize: Mock;
+  closeSession: Mock;
+  createPickerSession: Mock;
+  isConnected: { value: boolean };
+  pollSession: Mock;
+  state: { value: string };
+}) {
+  googlePhotosMock.authorize.mockReset();
+  googlePhotosMock.closeSession.mockReset();
+  googlePhotosMock.createPickerSession.mockReset();
+  googlePhotosMock.pollSession.mockReset();
+  googlePhotosMock.isConnected.value = true;
+  googlePhotosMock.state.value = "connected";
+}
+
 export function mockGooglePickerPopup() {
   const popup = {
     close: vi.fn(),

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -1,11 +1,23 @@
-import { createApp, defineComponent, h, type Component } from "vue";
+import {
+  computed,
+  createApp,
+  defineComponent,
+  h,
+  ref,
+  type Component,
+} from "vue";
 import { mount, type ComponentMountingOptions } from "@vue/test-utils";
 import { createPinia } from "pinia";
 import { PiniaColada } from "@pinia/colada";
 import { Quasar } from "quasar";
 import i18n from "@/i18n";
 import { client } from "@/client/client.gen";
-import type { Segment, StepRead as Step } from "@/client";
+import type { AlbumMedia, Segment, StepRead as Step } from "@/client";
+import { provideAlbum } from "@/composables/useAlbum";
+import {
+  DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
+  type MediaResolutionWarningPreset,
+} from "@/utils/photoQuality";
 
 // Set base URL for test API calls (MSW intercepts these).
 client.setConfig({ baseUrl: "http://localhost:8000" });
@@ -71,6 +83,49 @@ export function deferred<T>() {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+export function makeAlbumMedia(
+  overrides: Partial<AlbumMedia> = {},
+): AlbumMedia {
+  return {
+    uid: 1,
+    aid: "album-1",
+    name: "photo.jpg",
+    kind: "photo",
+    width: 1920,
+    height: 1080,
+    byte_size: 1234,
+    upgrade_candidate: false,
+    created_at: "2026-05-13T12:00:00Z",
+    updated_at: "2026-05-13T12:34:56Z",
+    ...overrides,
+  };
+}
+
+export function provideTestAlbum({
+  albumId = "album-1",
+  colors = {},
+  media = [],
+  tripStart = "2024-01-01",
+  totalDays = 1,
+  mediaResolutionWarningPreset = DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
+}: {
+  albumId?: string;
+  colors?: Record<string, string>;
+  media?: AlbumMedia[];
+  tripStart?: string;
+  totalDays?: number;
+  mediaResolutionWarningPreset?: MediaResolutionWarningPreset;
+} = {}) {
+  return provideAlbum({
+    albumId: ref(albumId),
+    colors: computed(() => colors),
+    media: computed(() => media),
+    tripStart: computed(() => tripStart),
+    totalDays: computed(() => totalDays),
+    mediaResolutionWarningPreset: computed(() => mediaResolutionWarningPreset),
+  });
 }
 
 /** Shared plugin list for mounting components under test. */

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -12,7 +12,7 @@ import { PiniaColada } from "@pinia/colada";
 import { Quasar } from "quasar";
 import i18n from "@/i18n";
 import { client } from "@/client/client.gen";
-import type { AlbumMedia, Segment, StepRead as Step } from "@/client";
+import type { AlbumMedia, Location, Segment, StepRead as Step } from "@/client";
 import { provideAlbum } from "@/composables/useAlbum";
 import {
   DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
@@ -103,6 +103,17 @@ export function makeAlbumMedia(
   };
 }
 
+export function makeLocation(overrides: Partial<Location> = {}): Location {
+  return {
+    lat: 0,
+    lon: 0,
+    name: "Place",
+    detail: "",
+    country_code: "US",
+    ...overrides,
+  };
+}
+
 export function provideTestAlbum({
   albumId = "album-1",
   colors = {},
@@ -155,7 +166,7 @@ export function makeStep(overrides: Partial<Step> = {}): Step {
     aid: "a1",
     timestamp: 1704067200,
     timezone_id: "UTC",
-    location: { lat: 0, lon: 0, name: "Place", detail: "", country_code: "US" },
+    location: makeLocation(),
     elevation: 0,
     weather: {
       day: { temp: 20, feels_like: 18, icon: "clear-day" },

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -7,6 +7,7 @@ import {
   type Component,
 } from "vue";
 import { mount, type ComponentMountingOptions } from "@vue/test-utils";
+import type { Mock } from "vitest";
 import { createPinia } from "pinia";
 import { PiniaColada } from "@pinia/colada";
 import { Quasar } from "quasar";
@@ -112,6 +113,32 @@ export function makeLocation(overrides: Partial<Location> = {}): Location {
     country_code: "US",
     ...overrides,
   };
+}
+
+export function mockReadyGooglePickerSession(googlePhotosMock: {
+  closeSession: Mock;
+  createPickerSession: Mock;
+  pollSession: Mock;
+}) {
+  googlePhotosMock.createPickerSession.mockResolvedValue({
+    sessionId: "session-1",
+    pickerUri: "https://photos.google.com/picker/session-1",
+  });
+  googlePhotosMock.pollSession.mockResolvedValue({ ready: true });
+  googlePhotosMock.closeSession.mockResolvedValue(undefined);
+}
+
+export function mockGooglePickerPopup() {
+  const popup = {
+    close: vi.fn(),
+    document: {
+      body: { style: {}, textContent: "" },
+      title: "",
+    },
+    location: { href: "" },
+  };
+  vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+  return popup;
 }
 
 export function provideTestAlbum({

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -13,7 +13,14 @@ import { PiniaColada } from "@pinia/colada";
 import { Quasar } from "quasar";
 import i18n from "@/i18n";
 import { client } from "@/client/client.gen";
-import type { AlbumMedia, Location, Segment, StepRead as Step } from "@/client";
+import type {
+  AlbumMedia,
+  Location,
+  Segment,
+  StepRead as Step,
+  Weather,
+  WeatherData,
+} from "@/client";
 import { provideAlbum } from "@/composables/useAlbum";
 import {
   DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
@@ -115,6 +122,19 @@ export function makeLocation(overrides: Partial<Location> = {}): Location {
   };
 }
 
+export function makeWeather({
+  day = {},
+  night = null,
+}: {
+  day?: Partial<WeatherData>;
+  night?: Partial<WeatherData> | null;
+} = {}): Weather {
+  return {
+    day: { temp: 20, feels_like: 18, icon: "clear-day", ...day },
+    night: night && { temp: 10, feels_like: 8, icon: "clear-night", ...night },
+  };
+}
+
 export function mockReadyGooglePickerSession(googlePhotosMock: {
   closeSession: Mock;
   createPickerSession: Mock;
@@ -195,10 +215,7 @@ export function makeStep(overrides: Partial<Step> = {}): Step {
     timezone_id: "UTC",
     location: makeLocation(),
     elevation: 0,
-    weather: {
-      day: { temp: 20, feels_like: 18, icon: "clear-day" },
-      night: null,
-    },
+    weather: makeWeather(),
     datetime: "2024-01-01T00:00:00Z",
     ...overrides,
   };

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { createApp, type Component } from "vue";
+import { createApp, defineComponent, h, type Component } from "vue";
 import { mount, type ComponentMountingOptions } from "@vue/test-utils";
 import { createPinia } from "pinia";
 import { PiniaColada } from "@pinia/colada";
@@ -33,6 +33,37 @@ export function withSetup<T>(composable: () => T): T {
   });
 
   return result;
+}
+
+export function withParentSetup<T>(
+  parentSetup: () => void,
+  composable: () => T,
+  { plugins = true }: { plugins?: boolean } = {},
+): { result: T; unmount: () => void } {
+  let result!: T;
+  const Child = defineComponent({
+    setup() {
+      result = composable();
+      return () => null;
+    },
+  });
+  const Parent = defineComponent({
+    setup() {
+      parentSetup();
+      return () => h(Child);
+    },
+  });
+  const app = createApp(Parent);
+  if (plugins) {
+    app.use(createPinia());
+    app.use(PiniaColada);
+    app.use(Quasar, {});
+    app.use(i18n);
+  }
+  app.mount(document.createElement("div"));
+  const unmount = () => app.unmount();
+  onTestFinished(unmount);
+  return { result, unmount };
 }
 
 /** Shared plugin list for mounting components under test. */

--- a/frontend/tests/logic/albumSections.test.ts
+++ b/frontend/tests/logic/albumSections.test.ts
@@ -9,48 +9,39 @@ import {
 import type { DateRange } from "@/client";
 import { makeStep, makeSegment } from "../helpers";
 
-// Mock layoutDescription to avoid DOM measurement in tests
 vi.mock("@/composables/useTextLayout", () => ({
   layoutDescription: (text: string) => {
     if (!text || text.length < 100) return { pages: [] };
-    return { pages: [[], []] }; // 1 sidebar + 1 continuation page
+    return { pages: [[], []] };
   },
 }));
 
-// ---------------------------------------------------------------------------
-// filterCoverFromPages
-// ---------------------------------------------------------------------------
+const expectTypes = (sections: Section[], types: Section["type"][]) => {
+  expect(sections.map((section) => section.type)).toEqual(types);
+};
 
 describe("filterCoverFromPages", () => {
-  it("filters cover from pages", () => {
-    const pages = [["cover", "p1"], ["p2"]];
-    const result = filterCoverFromPages(pages, "cover");
-    expect(result).toEqual([
-      { originalIdx: 0, page: ["p1"] },
-      { originalIdx: 1, page: ["p2"] },
-    ]);
-  });
-
-  it("removes pages that become empty after cover filtering", () => {
-    const pages = [["cover"], ["p1", "p2"]];
-    const result = filterCoverFromPages(pages, "cover");
-    expect(result).toEqual([{ originalIdx: 1, page: ["p1", "p2"] }]);
-  });
-
-  it("handles cover appearing in multiple pages", () => {
-    const pages = [["cover", "p1"], ["cover", "p2"], ["p3"]];
-    const result = filterCoverFromPages(pages, "cover");
-    expect(result).toEqual([
-      { originalIdx: 0, page: ["p1"] },
-      { originalIdx: 1, page: ["p2"] },
-      { originalIdx: 2, page: ["p3"] },
-    ]);
+  it.each([
+    [
+      [["cover", "p1"], ["p2"]],
+      [
+        { originalIdx: 0, page: ["p1"] },
+        { originalIdx: 1, page: ["p2"] },
+      ],
+    ],
+    [[["cover"], ["p1", "p2"]], [{ originalIdx: 1, page: ["p1", "p2"] }]],
+    [
+      [["cover", "p1"], ["cover", "p2"], ["p3"]],
+      [
+        { originalIdx: 0, page: ["p1"] },
+        { originalIdx: 1, page: ["p2"] },
+        { originalIdx: 2, page: ["p3"] },
+      ],
+    ],
+  ])("filters cover entries from %j", (pages, expected) => {
+    expect(filterCoverFromPages(pages, "cover")).toEqual(expected);
   });
 });
-
-// ---------------------------------------------------------------------------
-// segmentsOverlapping
-// ---------------------------------------------------------------------------
 
 describe("segmentsOverlapping", () => {
   const segments = [
@@ -59,33 +50,19 @@ describe("segmentsOverlapping", () => {
     makeSegment({ start_time: 500, end_time: 600 }),
   ];
 
-  it("returns segments that overlap the time window", () => {
-    const result = segmentsOverlapping(segments, 150, 350);
-    expect(result).toHaveLength(2);
-    expect(result[0].start_time).toBe(100);
-    expect(result[1].start_time).toBe(300);
-  });
-
-  it("includes segment when window touches segment start", () => {
-    const result = segmentsOverlapping(segments, 50, 100);
-    expect(result).toHaveLength(1);
-    expect(result[0].start_time).toBe(100);
-  });
-
-  it("includes segment when window touches segment end", () => {
-    const result = segmentsOverlapping(segments, 200, 250);
-    expect(result).toHaveLength(1);
-    expect(result[0].start_time).toBe(100);
-  });
-
-  it("returns empty when no overlap", () => {
-    expect(segmentsOverlapping(segments, 210, 290)).toEqual([]);
+  it.each([
+    [150, 350, [100, 300]],
+    [50, 100, [100]],
+    [200, 250, [100]],
+    [210, 290, []],
+  ])("returns overlaps for %s..%s", (from, to, starts) => {
+    expect(
+      segmentsOverlapping(segments, from, to).map(
+        (segment) => segment.start_time,
+      ),
+    ).toEqual(starts);
   });
 });
-
-// ---------------------------------------------------------------------------
-// buildSections
-// ---------------------------------------------------------------------------
 
 describe("buildSections", () => {
   it("inserts map section before its first step", () => {
@@ -98,12 +75,7 @@ describe("buildSections", () => {
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
     const result = buildSections(steps, segments, ranges);
-    // Map before step 1, then step 1, step 2, step 3
-    expect(result).toHaveLength(4);
-    expect(result[0].type).toBe("map");
-    expect(result[1].type).toBe("step");
-    expect(result[2].type).toBe("step");
-    expect(result[3].type).toBe("step");
+    expectTypes(result, ["map", "step", "step", "step"]);
   });
 
   it("creates hike section when only hike segments (no transport)", () => {
@@ -114,8 +86,7 @@ describe("buildSections", () => {
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
     const result = buildSections(steps, segments, ranges);
-    expect(result).toHaveLength(2);
-    expect(result[0].type).toBe("hike");
+    expectTypes(result, ["hike", "step"]);
     if (result[0].type === "hike") {
       expect(result[0].hikeSegment.kind).toBe("hike");
     }
@@ -132,19 +103,16 @@ describe("buildSections", () => {
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
     const result = buildSections(steps, segments, ranges);
-    expect(result).toHaveLength(2);
-    expect(result[0].type).toBe("map");
+    expectTypes(result, ["map", "step"]);
   });
 
   it("skips ranges with no matching steps", () => {
     const steps = [
       makeStep({ id: 1, datetime: "2024-03-10T00:00:00Z", timestamp: 100 }),
     ];
-    const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]]; // no steps in this range
+    const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
     const result = buildSections(steps, [], ranges);
-    // Only the step, no map for the empty range
-    expect(result).toHaveLength(1);
-    expect(result[0].type).toBe("step");
+    expectTypes(result, ["step"]);
   });
 
   it("handles multiple map ranges with different steps", () => {
@@ -162,12 +130,7 @@ describe("buildSections", () => {
     ];
 
     const result = buildSections(steps, segments, ranges);
-    // map1, step1, map2, step2
-    expect(result).toHaveLength(4);
-    expect(result[0].type).toBe("map");
-    expect(result[1].type).toBe("step");
-    expect(result[2].type).toBe("map");
-    expect(result[3].type).toBe("step");
+    expectTypes(result, ["map", "step", "map", "step"]);
   });
 
   it("attaches overlapping segments to map sections", () => {
@@ -177,7 +140,7 @@ describe("buildSections", () => {
     ];
     const segments = [
       makeSegment({ start_time: 50, end_time: 150, kind: "driving" }),
-      makeSegment({ start_time: 500, end_time: 600, kind: "driving" }), // outside range
+      makeSegment({ start_time: 500, end_time: 600, kind: "driving" }),
     ];
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
@@ -190,10 +153,6 @@ describe("buildSections", () => {
     }
   });
 });
-
-// ---------------------------------------------------------------------------
-// activeSectionId - maps virtualizer indices to section identifiers
-// ---------------------------------------------------------------------------
 
 describe("activeSectionId", () => {
   const stepSection = (id: number): Section => ({

--- a/frontend/tests/logic/albumSections.test.ts
+++ b/frontend/tests/logic/albumSections.test.ts
@@ -20,6 +20,12 @@ const expectTypes = (sections: Section[], types: Section["type"][]) => {
   expect(sections.map((section) => section.type)).toEqual(types);
 };
 
+const stepAt = (id: number, datetime: string, timestamp = id * 100) =>
+  makeStep({ id, datetime, timestamp });
+
+const drivingSegment = (start_time: number, end_time: number) =>
+  makeSegment({ start_time, end_time, kind: "driving" });
+
 describe("filterCoverFromPages", () => {
   it.each([
     [
@@ -67,11 +73,11 @@ describe("segmentsOverlapping", () => {
 describe("buildSections", () => {
   it("inserts map section before its first step", () => {
     const steps = [
-      makeStep({ id: 1, datetime: "2024-01-10T00:00:00Z", timestamp: 100 }),
-      makeStep({ id: 2, datetime: "2024-01-20T00:00:00Z", timestamp: 200 }),
-      makeStep({ id: 3, datetime: "2024-02-15T00:00:00Z", timestamp: 300 }),
+      stepAt(1, "2024-01-10T00:00:00Z"),
+      stepAt(2, "2024-01-20T00:00:00Z"),
+      stepAt(3, "2024-02-15T00:00:00Z"),
     ];
-    const segments = [makeSegment({ start_time: 50, end_time: 250, kind: "driving" })];
+    const segments = [drivingSegment(50, 250)];
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
     const result = buildSections(steps, segments, ranges);
@@ -79,10 +85,10 @@ describe("buildSections", () => {
   });
 
   it("creates hike section when only hike segments (no transport)", () => {
-    const steps = [
-      makeStep({ id: 1, datetime: "2024-01-10T00:00:00Z", timestamp: 100 }),
+    const steps = [stepAt(1, "2024-01-10T00:00:00Z")];
+    const segments = [
+      makeSegment({ start_time: 50, end_time: 150, kind: "hike" }),
     ];
-    const segments = [makeSegment({ start_time: 50, end_time: 150, kind: "hike" })];
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
     const result = buildSections(steps, segments, ranges);
@@ -93,12 +99,10 @@ describe("buildSections", () => {
   });
 
   it("creates map section (not hike) when there are transport segments", () => {
-    const steps = [
-      makeStep({ id: 1, datetime: "2024-01-10T00:00:00Z", timestamp: 100 }),
-    ];
+    const steps = [stepAt(1, "2024-01-10T00:00:00Z")];
     const segments = [
       makeSegment({ start_time: 50, end_time: 150, kind: "hike" }),
-      makeSegment({ start_time: 50, end_time: 150, kind: "driving" }),
+      drivingSegment(50, 150),
     ];
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
@@ -107,9 +111,7 @@ describe("buildSections", () => {
   });
 
   it("skips ranges with no matching steps", () => {
-    const steps = [
-      makeStep({ id: 1, datetime: "2024-03-10T00:00:00Z", timestamp: 100 }),
-    ];
+    const steps = [stepAt(1, "2024-03-10T00:00:00Z")];
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
     const result = buildSections(steps, [], ranges);
     expectTypes(result, ["step"]);
@@ -117,13 +119,10 @@ describe("buildSections", () => {
 
   it("handles multiple map ranges with different steps", () => {
     const steps = [
-      makeStep({ id: 1, datetime: "2024-01-10T00:00:00Z", timestamp: 100 }),
-      makeStep({ id: 2, datetime: "2024-02-10T00:00:00Z", timestamp: 200 }),
+      stepAt(1, "2024-01-10T00:00:00Z"),
+      stepAt(2, "2024-02-10T00:00:00Z"),
     ];
-    const segments = [
-      makeSegment({ start_time: 50, end_time: 150, kind: "driving" }),
-      makeSegment({ start_time: 150, end_time: 250, kind: "driving" }),
-    ];
+    const segments = [drivingSegment(50, 150), drivingSegment(150, 250)];
     const ranges: DateRange[] = [
       ["2024-01-01", "2024-01-31"],
       ["2024-02-01", "2024-02-28"],
@@ -135,13 +134,10 @@ describe("buildSections", () => {
 
   it("attaches overlapping segments to map sections", () => {
     const steps = [
-      makeStep({ id: 1, datetime: "2024-01-10T00:00:00Z", timestamp: 100 }),
-      makeStep({ id: 2, datetime: "2024-01-20T00:00:00Z", timestamp: 200 }),
+      stepAt(1, "2024-01-10T00:00:00Z"),
+      stepAt(2, "2024-01-20T00:00:00Z"),
     ];
-    const segments = [
-      makeSegment({ start_time: 50, end_time: 150, kind: "driving" }),
-      makeSegment({ start_time: 500, end_time: 600, kind: "driving" }),
-    ];
+    const segments = [drivingSegment(50, 150), drivingSegment(500, 600)];
     const ranges: DateRange[] = [["2024-01-01", "2024-01-31"]];
 
     const result = buildSections(steps, segments, ranges);

--- a/frontend/tests/mutations/useAlbumMutation.test.ts
+++ b/frontend/tests/mutations/useAlbumMutation.test.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { http, HttpResponse } from "msw";
 import { server } from "../mocks/server";
 import { BASE, defaultAlbum } from "../mocks/handlers";
-import { withSetup } from "../helpers";
+import { deferred, withSetup } from "../helpers";
 import { useAlbumQuery } from "@/queries/queries";
 import { useAlbumMutation } from "@/queries/useAlbumMutation";
 import { useUndoStack } from "@/composables/useUndoStack";
@@ -13,29 +13,25 @@ describe("useAlbumMutation", () => {
     useUndoStack().clear();
   });
 
-  // ---------------------------------------------------------------------------
-  // Optimistic update
-  // ---------------------------------------------------------------------------
+  function mountAlbumMutation() {
+    const aid = ref<string | null>(defaultAlbum.id);
+    return withSetup(() => {
+      const query = useAlbumQuery(aid);
+      const mutation = useAlbumMutation(() => aid.value!);
+      return { query, mutation };
+    });
+  }
 
   describe("optimistic update", () => {
     it("updates cache immediately before server responds", async () => {
-      const aid = ref<string | null>(defaultAlbum.id);
+      const result = mountAlbumMutation();
 
-      const result = withSetup(() => {
-        const query = useAlbumQuery(aid);
-        const mutation = useAlbumMutation(() => aid.value!);
-        return { query, mutation };
-      });
-
-      // Wait for initial query to load
       await flushPromises();
       expect(result.query.data.value?.title).toBe("South America");
 
+      const updateResponse = deferred<Response>();
       server.use(
-        http.patch(`${BASE}/albums/:aid`, async () => {
-          await new Promise((r) => setTimeout(r, 50));
-          return HttpResponse.json({ ...defaultAlbum, title: "Updated Title" });
-        }),
+        http.patch(`${BASE}/albums/:aid`, () => updateResponse.promise),
       );
 
       result.mutation.mutate({ title: "Updated Title" });
@@ -43,16 +39,12 @@ describe("useAlbumMutation", () => {
 
       expect(result.query.data.value?.title).toBe("Updated Title");
 
-      // Let the delayed response settle before MSW resets handlers
-      await new Promise((r) => setTimeout(r, 100));
+      updateResponse.resolve(
+        HttpResponse.json({ ...defaultAlbum, title: "Updated Title" }),
+      );
       await flushPromises();
     });
-
-});
-
-  // ---------------------------------------------------------------------------
-  // Error rollback
-  // ---------------------------------------------------------------------------
+  });
 
   describe("error rollback", () => {
     it("reverts cache to previous value on error", async () => {
@@ -62,13 +54,7 @@ describe("useAlbumMutation", () => {
         ),
       );
 
-      const aid = ref<string | null>(defaultAlbum.id);
-
-      const result = withSetup(() => {
-        const query = useAlbumQuery(aid);
-        const mutation = useAlbumMutation(() => aid.value!);
-        return { query, mutation };
-      });
+      const result = mountAlbumMutation();
 
       await flushPromises();
       expect(result.query.data.value?.title).toBe("South America");
@@ -79,5 +65,4 @@ describe("useAlbumMutation", () => {
       expect(result.query.data.value?.title).toBe("South America");
     });
   });
-
 });

--- a/frontend/tests/mutations/useStepMutation.test.ts
+++ b/frontend/tests/mutations/useStepMutation.test.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { http, HttpResponse } from "msw";
 import { server } from "../mocks/server";
 import { BASE, defaultAlbum, defaultSteps } from "../mocks/handlers";
-import { withSetup } from "../helpers";
+import { deferred, withSetup } from "../helpers";
 import { useStepsQuery } from "@/queries/queries";
 import { useStepMutation } from "@/queries/useStepMutation";
 import { useUndoStack } from "@/composables/useUndoStack";
@@ -15,28 +15,28 @@ describe("useStepMutation", () => {
     useUndoStack().clear();
   });
 
-  // ---------------------------------------------------------------------------
-  // Optimistic update
-  // ---------------------------------------------------------------------------
+  function mountStepMutation() {
+    const aid = ref<string | null>(defaultAlbum.id);
+    return withSetup(() => {
+      const query = useStepsQuery(aid);
+      const mutation = useStepMutation(() => aid.value!);
+      return { query, mutation };
+    });
+  }
 
   describe("optimistic update", () => {
     it("updates the matching step in cache immediately", async () => {
-      const aid = ref<string | null>(defaultAlbum.id);
-
-      const result = withSetup(() => {
-        const query = useStepsQuery(aid);
-        const mutation = useStepMutation(() => aid.value!);
-        return { query, mutation };
-      });
+      const result = mountStepMutation();
 
       await flushPromises();
       expect(result.query.data.value?.[0]?.name).toBe("Amsterdam");
 
+      const updateResponse = deferred<Response>();
       server.use(
-        http.patch(`${BASE}/albums/:aid/steps/:sid`, async () => {
-          await new Promise((r) => setTimeout(r, 50));
-          return HttpResponse.json({ ...defaultStep, name: "Rotterdam" });
-        }),
+        http.patch(
+          `${BASE}/albums/:aid/steps/:sid`,
+          () => updateResponse.promise,
+        ),
       );
 
       result.mutation.mutate({ sid: 1, update: { name: "Rotterdam" } });
@@ -44,7 +44,9 @@ describe("useStepMutation", () => {
 
       expect(result.query.data.value?.[0]?.name).toBe("Rotterdam");
 
-      await new Promise((r) => setTimeout(r, 100));
+      updateResponse.resolve(
+        HttpResponse.json({ ...defaultStep, name: "Rotterdam" }),
+      );
       await flushPromises();
     });
 
@@ -56,11 +58,12 @@ describe("useStepMutation", () => {
       };
       const updatedStep1 = { ...defaultStep, name: "Utrecht" };
 
-      // First GET returns initial data; after mutation, GET returns updated data
       let mutated = false;
       server.use(
         http.get(`${BASE}/albums/:aid/steps`, () =>
-          HttpResponse.json(mutated ? [updatedStep1, step2] : [defaultStep, step2]),
+          HttpResponse.json(
+            mutated ? [updatedStep1, step2] : [defaultStep, step2],
+          ),
         ),
         http.patch(`${BASE}/albums/:aid/steps/:sid`, () => {
           mutated = true;
@@ -68,13 +71,7 @@ describe("useStepMutation", () => {
         }),
       );
 
-      const aid = ref<string | null>(defaultAlbum.id);
-
-      const result = withSetup(() => {
-        const query = useStepsQuery(aid);
-        const mutation = useStepMutation(() => aid.value!);
-        return { query, mutation };
-      });
+      const result = mountStepMutation();
 
       await flushPromises();
       expect(result.query.data.value).toHaveLength(2);
@@ -87,21 +84,19 @@ describe("useStepMutation", () => {
     });
 
     it("sends explicit null cover in layout updates", async () => {
-      const aid = ref<string | null>(defaultAlbum.id);
       let body: unknown;
 
       server.use(
-        http.put(`${BASE}/albums/:aid/steps/:sid/media-layout`, async ({ request }) => {
-          body = await request.json();
-          return HttpResponse.json({ ...defaultStep, cover: null });
-        }),
+        http.put(
+          `${BASE}/albums/:aid/steps/:sid/media-layout`,
+          async ({ request }) => {
+            body = await request.json();
+            return HttpResponse.json({ ...defaultStep, cover: null });
+          },
+        ),
       );
 
-      const result = withSetup(() => {
-        const query = useStepsQuery(aid);
-        const mutation = useStepMutation(() => aid.value!);
-        return { query, mutation };
-      });
+      const result = mountStepMutation();
 
       await flushPromises();
 
@@ -110,25 +105,15 @@ describe("useStepMutation", () => {
 
       expect(body).toMatchObject({ cover: null });
     });
-
-});
-
-  // ---------------------------------------------------------------------------
-  // Undo stack integration
-  // ---------------------------------------------------------------------------
+  });
 
   describe("undo stack", () => {
     it("stores step-specific before/after snapshots", async () => {
-      const aid = ref<string | null>(defaultAlbum.id);
       const undoStack = useUndoStack();
       const stepMutator = vi.fn();
       undoStack.registerMutators(stepMutator, vi.fn());
 
-      const result = withSetup(() => {
-        const query = useStepsQuery(aid);
-        const mutation = useStepMutation(() => aid.value!);
-        return { query, mutation };
-      });
+      const result = mountStepMutation();
 
       await flushPromises();
 
@@ -140,14 +125,9 @@ describe("useStepMutation", () => {
     });
 
     it("does not push to undo stack if step is not found", async () => {
-      const aid = ref<string | null>(defaultAlbum.id);
       const undoStack = useUndoStack();
 
-      const result = withSetup(() => {
-        const query = useStepsQuery(aid);
-        const mutation = useStepMutation(() => aid.value!);
-        return { query, mutation };
-      });
+      const result = mountStepMutation();
 
       await flushPromises();
 
@@ -158,5 +138,4 @@ describe("useStepMutation", () => {
       expect(undoStack.canUndo.value).toBe(false);
     });
   });
-
 });

--- a/frontend/tests/queries/useSegmentPointsQuery.test.ts
+++ b/frontend/tests/queries/useSegmentPointsQuery.test.ts
@@ -1,18 +1,21 @@
 import { flushPromises } from "@vue/test-utils";
 import { http, HttpResponse } from "msw";
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import type { Ref } from "vue";
 import { server } from "../mocks/server";
 import { BASE } from "../mocks/handlers";
-import { deferred, makeSegment, withParentSetup } from "../helpers";
-import { provideAlbum } from "@/composables/useAlbum";
+import {
+  deferred,
+  makeSegment,
+  provideTestAlbum,
+  withParentSetup,
+} from "../helpers";
 import {
   ROUTE_REFETCH_LIMIT,
   ROUTE_REFETCH_MS,
   useSegmentPointsQuery,
 } from "@/queries/useSegmentPointsQuery";
 import type { Segment } from "@/client";
-import { DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET } from "@/utils/photoQuality";
 
 type SegmentHandlerResult = Segment[] | Promise<Response>;
 
@@ -22,16 +25,7 @@ function mountQuery(
 ) {
   const { result: query, unmount } = withParentSetup(
     () => {
-      provideAlbum({
-        albumId: ref("aid-1"),
-        colors: computed(() => ({})),
-        media: computed(() => []),
-        tripStart: computed(() => "2024-01-01T00:00:00Z"),
-        totalDays: computed(() => 1),
-        mediaResolutionWarningPreset: computed(
-          () => DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
-        ),
-      });
+      provideTestAlbum({ albumId: "aid-1" });
     },
     () => useSegmentPointsQuery(fromTime, toTime),
   );

--- a/frontend/tests/queries/useSegmentPointsQuery.test.ts
+++ b/frontend/tests/queries/useSegmentPointsQuery.test.ts
@@ -48,6 +48,11 @@ function mockSegmentPoints(handler: (calls: number) => SegmentHandlerResult) {
 const missingDrivingRoute = () =>
   [makeSegment({ kind: "driving", route: null })] satisfies Segment[];
 
+async function advanceRoutePoll() {
+  await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
+  await flushPromises();
+}
+
 describe("useSegmentPointsQuery", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -64,8 +69,7 @@ describe("useSegmentPointsQuery", () => {
     await flushPromises();
     expect(calls()).toBe(1);
 
-    await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    await flushPromises();
+    await advanceRoutePoll();
 
     expect(calls()).toBe(2);
   });
@@ -81,8 +85,7 @@ describe("useSegmentPointsQuery", () => {
 
     mountQuery();
     await flushPromises();
-    await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    await flushPromises();
+    await advanceRoutePoll();
 
     expect(calls()).toBe(1);
   });
@@ -98,8 +101,7 @@ describe("useSegmentPointsQuery", () => {
 
     mountQuery();
     await flushPromises();
-    await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    await flushPromises();
+    await advanceRoutePoll();
 
     expect(calls()).toBe(1);
   });
@@ -113,8 +115,7 @@ describe("useSegmentPointsQuery", () => {
     await flushPromises();
 
     for (let i = 0; i < ROUTE_REFETCH_LIMIT + 1; i += 1) {
-      await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-      await flushPromises();
+      await advanceRoutePoll();
     }
 
     expect(calls()).toBe(1 + ROUTE_REFETCH_LIMIT);
@@ -128,16 +129,14 @@ describe("useSegmentPointsQuery", () => {
     mountQuery(fromTime, toTime);
     await flushPromises();
     for (let i = 0; i < ROUTE_REFETCH_LIMIT + 1; i += 1) {
-      await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-      await flushPromises();
+      await advanceRoutePoll();
     }
     expect(calls()).toBe(1 + ROUTE_REFETCH_LIMIT);
 
     fromTime.value = 100;
     toTime.value = 200;
     await flushPromises();
-    await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    await flushPromises();
+    await advanceRoutePoll();
 
     expect(calls()).toBe(3 + ROUTE_REFETCH_LIMIT);
   });

--- a/frontend/tests/queries/useSegmentPointsQuery.test.ts
+++ b/frontend/tests/queries/useSegmentPointsQuery.test.ts
@@ -4,7 +4,7 @@ import { computed, ref } from "vue";
 import type { Ref } from "vue";
 import { server } from "../mocks/server";
 import { BASE } from "../mocks/handlers";
-import { makeSegment, withParentSetup } from "../helpers";
+import { deferred, makeSegment, withParentSetup } from "../helpers";
 import { provideAlbum } from "@/composables/useAlbum";
 import {
   ROUTE_REFETCH_LIMIT,
@@ -149,14 +149,12 @@ describe("useSegmentPointsQuery", () => {
   });
 
   it("does not start another refetch while the previous one is loading", async () => {
-    let resolveSecond: (() => void) | undefined;
+    const secondResponse = deferred<Response>();
     const calls = mockSegmentPoints((call) => {
       if (call === 1) {
         return missingDrivingRoute();
       }
-      return new Promise((resolve) => {
-        resolveSecond = () => resolve(HttpResponse.json(missingDrivingRoute()));
-      });
+      return secondResponse.promise;
     });
 
     mountQuery();
@@ -167,19 +165,17 @@ describe("useSegmentPointsQuery", () => {
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
     expect(calls()).toBe(2);
 
-    resolveSecond?.();
+    secondResponse.resolve(HttpResponse.json(missingDrivingRoute()));
     await flushPromises();
   });
 
   it("does not schedule another poll after unmounting during a refetch", async () => {
-    let resolveSecond: (() => void) | undefined;
+    const secondResponse = deferred<Response>();
     const calls = mockSegmentPoints((call) => {
       if (call === 1) {
         return missingDrivingRoute();
       }
-      return new Promise((resolve) => {
-        resolveSecond = () => resolve(HttpResponse.json(missingDrivingRoute()));
-      });
+      return secondResponse.promise;
     });
 
     const { unmount } = mountQuery();
@@ -188,7 +184,7 @@ describe("useSegmentPointsQuery", () => {
     expect(calls()).toBe(2);
 
     unmount();
-    resolveSecond?.();
+    secondResponse.resolve(HttpResponse.json(missingDrivingRoute()));
     await flushPromises();
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
 

--- a/frontend/tests/queries/useSegmentPointsQuery.test.ts
+++ b/frontend/tests/queries/useSegmentPointsQuery.test.ts
@@ -1,12 +1,10 @@
 import { flushPromises } from "@vue/test-utils";
-import { PiniaColada } from "@pinia/colada";
-import { createPinia } from "pinia";
 import { http, HttpResponse } from "msw";
-import { createApp, computed, defineComponent, h, ref } from "vue";
+import { computed, ref } from "vue";
 import type { Ref } from "vue";
 import { server } from "../mocks/server";
 import { BASE } from "../mocks/handlers";
-import { makeSegment } from "../helpers";
+import { makeSegment, withParentSetup } from "../helpers";
 import { provideAlbum } from "@/composables/useAlbum";
 import {
   ROUTE_REFETCH_LIMIT,
@@ -22,15 +20,8 @@ function mountQuery(
   fromTime: Ref<number> = ref(0),
   toTime: Ref<number> = ref(100),
 ) {
-  let result!: ReturnType<typeof useSegmentPointsQuery>;
-  const Child = defineComponent({
-    setup() {
-      result = useSegmentPointsQuery(fromTime, toTime);
-      return () => null;
-    },
-  });
-  const Parent = defineComponent({
-    setup() {
+  const { result: query, unmount } = withParentSetup(
+    () => {
       provideAlbum({
         albumId: ref("aid-1"),
         colors: computed(() => ({})),
@@ -41,16 +32,11 @@ function mountQuery(
           () => DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
         ),
       });
-      return () => h(Child);
     },
-  });
-  const app = createApp(Parent);
-  app.use(createPinia());
-  app.use(PiniaColada);
-  app.mount(document.createElement("div"));
-  onTestFinished(() => app.unmount());
+    () => useSegmentPointsQuery(fromTime, toTime),
+  );
 
-  return { query: result, unmount: () => app.unmount() };
+  return { query, unmount };
 }
 
 function mockSegmentPoints(handler: (calls: number) => SegmentHandlerResult) {

--- a/frontend/tests/queries/useSegmentPointsQuery.test.ts
+++ b/frontend/tests/queries/useSegmentPointsQuery.test.ts
@@ -16,6 +16,8 @@ import {
 import type { Segment } from "@/client";
 import { DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET } from "@/utils/photoQuality";
 
+type SegmentHandlerResult = Segment[] | Promise<Response>;
+
 function mountQuery(
   fromTime: Ref<number> = ref(0),
   toTime: Ref<number> = ref(100),
@@ -51,6 +53,21 @@ function mountQuery(
   return { query: result, unmount: () => app.unmount() };
 }
 
+function mockSegmentPoints(handler: (calls: number) => SegmentHandlerResult) {
+  let calls = 0;
+  server.use(
+    http.get(`${BASE}/albums/:aid/segments/points`, () => {
+      calls += 1;
+      const result = handler(calls);
+      return result instanceof Promise ? result : HttpResponse.json(result);
+    }),
+  );
+  return () => calls;
+}
+
+const missingDrivingRoute = () =>
+  [makeSegment({ kind: "driving", route: null })] satisfies Segment[];
+
 describe("useSegmentPointsQuery", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -61,36 +78,25 @@ describe("useSegmentPointsQuery", () => {
   });
 
   it("refetches about every minute while driving routes are missing", async () => {
-    let calls = 0;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        return HttpResponse.json([
-          makeSegment({ kind: "driving", route: null }),
-        ] satisfies Segment[]);
-      }),
-    );
+    const calls = mockSegmentPoints(missingDrivingRoute);
 
     mountQuery();
     await flushPromises();
-    expect(calls).toBe(1);
+    expect(calls()).toBe(1);
 
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
     await flushPromises();
 
-    expect(calls).toBe(2);
+    expect(calls()).toBe(2);
   });
 
   it("does not refetch when all matchable segments have routes", async () => {
-    let calls = 0;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        return HttpResponse.json([
+    const calls = mockSegmentPoints(
+      () =>
+        [
           makeSegment({ kind: "walking", route: [[1, 2]] }),
           makeSegment({ kind: "driving", route: [[3, 4]] }),
-        ] satisfies Segment[]);
-      }),
+        ] satisfies Segment[],
     );
 
     mountQuery();
@@ -98,19 +104,16 @@ describe("useSegmentPointsQuery", () => {
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
     await flushPromises();
 
-    expect(calls).toBe(1);
+    expect(calls()).toBe(1);
   });
 
   it("does not refetch for hike and flight segments without routes", async () => {
-    let calls = 0;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        return HttpResponse.json([
+    const calls = mockSegmentPoints(
+      () =>
+        [
           makeSegment({ kind: "hike", route: null }),
           makeSegment({ kind: "flight", route: null }),
-        ] satisfies Segment[]);
-      }),
+        ] satisfies Segment[],
     );
 
     mountQuery();
@@ -118,18 +121,12 @@ describe("useSegmentPointsQuery", () => {
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
     await flushPromises();
 
-    expect(calls).toBe(1);
+    expect(calls()).toBe(1);
   });
 
   it("stops polling after the route refetch cap", async () => {
-    let calls = 0;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        return HttpResponse.json([
-          makeSegment({ kind: "walking", route: null }),
-        ] satisfies Segment[]);
-      }),
+    const calls = mockSegmentPoints(
+      () => [makeSegment({ kind: "walking", route: null })] satisfies Segment[],
     );
 
     mountQuery();
@@ -140,21 +137,13 @@ describe("useSegmentPointsQuery", () => {
       await flushPromises();
     }
 
-    expect(calls).toBe(1 + ROUTE_REFETCH_LIMIT);
+    expect(calls()).toBe(1 + ROUTE_REFETCH_LIMIT);
   });
 
   it("resets the route refetch cap when the query range changes", async () => {
     const fromTime = ref(0);
     const toTime = ref(100);
-    let calls = 0;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        return HttpResponse.json([
-          makeSegment({ kind: "driving", route: null }),
-        ] satisfies Segment[]);
-      }),
-    );
+    const calls = mockSegmentPoints(missingDrivingRoute);
 
     mountQuery(fromTime, toTime);
     await flushPromises();
@@ -162,7 +151,7 @@ describe("useSegmentPointsQuery", () => {
       await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
       await flushPromises();
     }
-    expect(calls).toBe(1 + ROUTE_REFETCH_LIMIT);
+    expect(calls()).toBe(1 + ROUTE_REFETCH_LIMIT);
 
     fromTime.value = 100;
     toTime.value = 200;
@@ -170,75 +159,53 @@ describe("useSegmentPointsQuery", () => {
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
     await flushPromises();
 
-    expect(calls).toBe(3 + ROUTE_REFETCH_LIMIT);
+    expect(calls()).toBe(3 + ROUTE_REFETCH_LIMIT);
   });
 
   it("does not start another refetch while the previous one is loading", async () => {
-    let calls = 0;
     let resolveSecond: (() => void) | undefined;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        if (calls === 1) {
-          return HttpResponse.json([
-            makeSegment({ kind: "driving", route: null }),
-          ] satisfies Segment[]);
-        }
-        return new Promise((resolve) => {
-          resolveSecond = () =>
-            resolve(
-              HttpResponse.json([
-                makeSegment({ kind: "driving", route: null }),
-              ] satisfies Segment[]),
-            );
-        });
-      }),
-    );
+    const calls = mockSegmentPoints((call) => {
+      if (call === 1) {
+        return missingDrivingRoute();
+      }
+      return new Promise((resolve) => {
+        resolveSecond = () => resolve(HttpResponse.json(missingDrivingRoute()));
+      });
+    });
 
     mountQuery();
     await flushPromises();
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    expect(calls).toBe(2);
+    expect(calls()).toBe(2);
 
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    expect(calls).toBe(2);
+    expect(calls()).toBe(2);
 
     resolveSecond?.();
     await flushPromises();
   });
 
   it("does not schedule another poll after unmounting during a refetch", async () => {
-    let calls = 0;
     let resolveSecond: (() => void) | undefined;
-    server.use(
-      http.get(`${BASE}/albums/:aid/segments/points`, () => {
-        calls += 1;
-        if (calls === 1) {
-          return HttpResponse.json([
-            makeSegment({ kind: "driving", route: null }),
-          ] satisfies Segment[]);
-        }
-        return new Promise((resolve) => {
-          resolveSecond = () =>
-            resolve(
-              HttpResponse.json([
-                makeSegment({ kind: "driving", route: null }),
-              ] satisfies Segment[]),
-            );
-        });
-      }),
-    );
+    const calls = mockSegmentPoints((call) => {
+      if (call === 1) {
+        return missingDrivingRoute();
+      }
+      return new Promise((resolve) => {
+        resolveSecond = () => resolve(HttpResponse.json(missingDrivingRoute()));
+      });
+    });
 
     const { unmount } = mountQuery();
     await flushPromises();
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
-    expect(calls).toBe(2);
+    expect(calls()).toBe(2);
 
     unmount();
     resolveSecond?.();
     await flushPromises();
     await vi.advanceTimersByTimeAsync(ROUTE_REFETCH_MS);
 
-    expect(calls).toBe(2);
+    expect(calls()).toBe(2);
   });
 });

--- a/frontend/tests/queries/useUserQuery.test.ts
+++ b/frontend/tests/queries/useUserQuery.test.ts
@@ -5,16 +5,20 @@ import { BASE, defaultUser } from "../mocks/handlers";
 import { withSetup } from "../helpers";
 import { useUserQuery, KM_TO_MI } from "@/queries/useUserQuery";
 
+async function loadUserQuery(overrides: Partial<typeof defaultUser>) {
+  server.use(
+    http.get(`${BASE}/users`, () =>
+      HttpResponse.json({ ...defaultUser, ...overrides }),
+    ),
+  );
+  const result = withSetup(() => useUserQuery());
+  await flushPromises();
+  return result;
+}
+
 describe("useUserQuery", () => {
   it("converts km to miles for formatDistance", async () => {
-    server.use(
-      http.get(`${BASE}/users`, () =>
-        HttpResponse.json({ ...defaultUser, unit_is_km: false }),
-      ),
-    );
-
-    const result = withSetup(() => useUserQuery());
-    await flushPromises();
+    const result = await loadUserQuery({ unit_is_km: false });
 
     // 100 km * 0.621371 = 62.1371 -> rounds to 62
     const expected = Math.round(100 * KM_TO_MI).toLocaleString("en-US");
@@ -22,22 +26,11 @@ describe("useUserQuery", () => {
   });
 
   it("converts Celsius to Fahrenheit for formatTemp", async () => {
-    server.use(
-      http.get(`${BASE}/users`, () =>
-        HttpResponse.json({
-          ...defaultUser,
-          temperature_is_celsius: false,
-        }),
-      ),
-    );
-
-    const result = withSetup(() => useUserQuery());
-    await flushPromises();
+    const result = await loadUserQuery({ temperature_is_celsius: false });
 
     // 0 C -> 32 F
     expect(result.formatTemp(0)).toBe("32\u00B0");
     // 100 C -> 212 F
     expect(result.formatTemp(100)).toBe("212\u00B0");
   });
-
 });

--- a/frontend/tests/sse.ts
+++ b/frontend/tests/sse.ts
@@ -1,0 +1,3 @@
+export function sseBody(events: object[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}

--- a/frontend/tests/utils/photoQuality.test.ts
+++ b/frontend/tests/utils/photoQuality.test.ts
@@ -116,36 +116,52 @@ describe("summarizeQuality", () => {
     return makeAlbumMedia({ name, width, height });
   }
 
+  function mediaMap(...items: ReturnType<typeof media>[]) {
+    return new Map(items.map((item) => [item.name, item]));
+  }
+
   it("counts low-res cover as warning", () => {
-    const mediaMap = new Map([["lo.jpg", media("lo.jpg", 500, 400)]]);
-    const result = summarizeQuality([], "lo.jpg", undefined, mediaMap);
+    const result = summarizeQuality(
+      [],
+      "lo.jpg",
+      undefined,
+      mediaMap(media("lo.jpg", 500, 400)),
+    );
     expect(result.warning).toBe(1);
   });
 
   it("does not count warnings when warnings are off", () => {
-    const mediaMap = new Map([["lo.jpg", media("lo.jpg", 500, 400)]]);
-    const result = summarizeQuality([], "lo.jpg", undefined, mediaMap, "off");
+    const result = summarizeQuality(
+      [],
+      "lo.jpg",
+      undefined,
+      mediaMap(media("lo.jpg", 500, 400)),
+      "off",
+    );
     expect(result).toEqual({ caution: 0, warning: 0 });
   });
 
   it("uses print-quality thresholds when requested", () => {
-    const mediaMap = new Map([["medium.jpg", media("medium.jpg", 1800, 1800)]]);
     const result = summarizeQuality(
       [],
       "medium.jpg",
       undefined,
-      mediaMap,
+      mediaMap(media("medium.jpg", 1800, 1800)),
       "print",
     );
     expect(result).toEqual({ caution: 1, warning: 0 });
   });
 
   it("handles cover photo appearing in both cover and step.cover", () => {
-    const mediaMap = new Map([["lo.jpg", media("lo.jpg", 800, 700)]]);
     const steps: Step[] = [
       makeStep({ id: 1, cover: "lo.jpg", pages: [["lo.jpg"]] }),
     ];
-    const result = summarizeQuality(steps, "lo.jpg", undefined, mediaMap);
+    const result = summarizeQuality(
+      steps,
+      "lo.jpg",
+      undefined,
+      mediaMap(media("lo.jpg", 800, 700)),
+    );
     expect(result.warning).toBe(1);
     expect(result.caution).toBe(1);
   });
@@ -153,17 +169,18 @@ describe("summarizeQuality", () => {
   it("applies orientation ordering before assigning cell fractions", () => {
     const portrait = media("portrait.jpg", 600, 900);
     const landscape = media("landscape.jpg", 800, 500);
-    const mediaMap = new Map([
-      [portrait.name, portrait],
-      [landscape.name, landscape],
-    ]);
     const steps = [
       makeStep({
         id: 1,
         pages: [["landscape.jpg", "portrait.jpg", "landscape.jpg"]],
       }),
     ];
-    const result = summarizeQuality(steps, undefined, undefined, mediaMap);
+    const result = summarizeQuality(
+      steps,
+      undefined,
+      undefined,
+      mediaMap(portrait, landscape),
+    );
     expect(result).toEqual({ caution: 0, warning: 0 });
   });
 });

--- a/frontend/tests/utils/photoQuality.test.ts
+++ b/frontend/tests/utils/photoQuality.test.ts
@@ -1,4 +1,5 @@
 import type { StepRead as Step } from "@/client";
+import { makeAlbumMedia, makeStep } from "../helpers";
 import { PAGE_WIDTH_MM, PAGE_HEIGHT_MM, MM_PER_INCH } from "@/utils/pageSize";
 import {
   DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
@@ -112,32 +113,7 @@ describe("enforceOrientationOrder", () => {
 
 describe("summarizeQuality", () => {
   function media(name: string, width: number, height: number) {
-    return { name, width, height };
-  }
-
-  function step(overrides: Partial<Step> & { id: number }): Step {
-    return {
-      uid: 1,
-      aid: "trip",
-      name: "Step",
-      description: "",
-      cover: null,
-      pages: [],
-      unused: [],
-      timestamp: 0,
-      timezone_id: "UTC",
-      location: { city: "", country: "", country_code: "US" },
-      elevation: 0,
-      weather: {
-        icon: "clear-day",
-        high: 20,
-        low: 10,
-        code: 0,
-        condition: "Clear",
-      },
-      datetime: "2024-01-01T00:00:00Z",
-      ...overrides,
-    };
+    return makeAlbumMedia({ name, width, height });
   }
 
   it("counts low-res cover as warning", () => {
@@ -166,7 +142,9 @@ describe("summarizeQuality", () => {
 
   it("handles cover photo appearing in both cover and step.cover", () => {
     const mediaMap = new Map([["lo.jpg", media("lo.jpg", 800, 700)]]);
-    const steps = [step({ id: 1, cover: "lo.jpg", pages: [["lo.jpg"]] })];
+    const steps: Step[] = [
+      makeStep({ id: 1, cover: "lo.jpg", pages: [["lo.jpg"]] }),
+    ];
     const result = summarizeQuality(steps, "lo.jpg", undefined, mediaMap);
     expect(result.warning).toBe(1);
     expect(result.caution).toBe(1);
@@ -180,7 +158,7 @@ describe("summarizeQuality", () => {
       [landscape.name, landscape],
     ]);
     const steps = [
-      step({
+      makeStep({
         id: 1,
         pages: [["landscape.jpg", "portrait.jpg", "landscape.jpg"]],
       }),

--- a/frontend/tests/utils/photoQuality.test.ts
+++ b/frontend/tests/utils/photoQuality.test.ts
@@ -12,7 +12,8 @@ import {
   enforceOrientationOrder,
 } from "@/utils/photoLayout";
 
-// -- computeDpi --
+type DpiPreset = Parameters<typeof dpiTier>[1];
+type DpiTier = ReturnType<typeof dpiTier>;
 
 describe("computeDpi", () => {
   it("computes DPI for a full-page photo", () => {
@@ -27,51 +28,31 @@ describe("computeDpi", () => {
   });
 });
 
-// -- dpiTier --
-
 describe("dpiTier", () => {
   it("defaults normal albums to relaxed warnings and demo albums to off", () => {
     expect(DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET).toBe("relaxed");
     expect(DEMO_MEDIA_RESOLUTION_WARNING_PRESET).toBe("off");
   });
 
-  it("classifies >= 100 as ok (default thresholds)", () => {
-    expect(dpiTier(100)).toBe("ok");
-    expect(dpiTier(300)).toBe("ok");
-  });
-
-  it("classifies 75-99 as caution (default thresholds)", () => {
-    expect(dpiTier(99)).toBe("caution");
-    expect(dpiTier(75)).toBe("caution");
-  });
-
-  it("classifies < 75 as warning (default thresholds)", () => {
-    expect(dpiTier(74)).toBe("warning");
-    expect(dpiTier(50)).toBe("warning");
-  });
-
-  it("classifies all photos as ok when warnings are off", () => {
-    expect(dpiTier(1, "off")).toBe("ok");
-    expect(dpiTier(50, "off")).toBe("ok");
-  });
-
-  it("classifies >= 300 as ok with print-quality thresholds", () => {
-    expect(dpiTier(300, "print")).toBe("ok");
-    expect(dpiTier(450, "print")).toBe("ok");
-  });
-
-  it("classifies 150-299 as caution with print-quality thresholds", () => {
-    expect(dpiTier(299, "print")).toBe("caution");
-    expect(dpiTier(150, "print")).toBe("caution");
-  });
-
-  it("classifies < 150 as warning with print-quality thresholds", () => {
-    expect(dpiTier(149, "print")).toBe("warning");
-    expect(dpiTier(50, "print")).toBe("warning");
+  it.each<[number, DpiPreset, DpiTier]>([
+    [100, undefined, "ok"],
+    [300, undefined, "ok"],
+    [99, undefined, "caution"],
+    [75, undefined, "caution"],
+    [74, undefined, "warning"],
+    [50, undefined, "warning"],
+    [1, "off", "ok"],
+    [50, "off", "ok"],
+    [300, "print", "ok"],
+    [450, "print", "ok"],
+    [299, "print", "caution"],
+    [150, "print", "caution"],
+    [149, "print", "warning"],
+    [50, "print", "warning"],
+  ])("classifies %s dpi with %s preset as %s", (dpi, preset, expected) => {
+    expect(dpiTier(dpi, preset)).toBe(expected);
   });
 });
-
-// -- photoPageFraction --
 
 describe("photoPageFraction", () => {
   it("returns full page for single-photo layouts", () => {
@@ -109,8 +90,6 @@ describe("photoPageFraction", () => {
   });
 });
 
-// -- enforceOrientationOrder --
-
 describe("enforceOrientationOrder", () => {
   const isP = (name: string) => name.startsWith("p");
 
@@ -130,8 +109,6 @@ describe("enforceOrientationOrder", () => {
     ]);
   });
 });
-
-// -- summarizeQuality --
 
 describe("summarizeQuality", () => {
   function media(name: string, width: number, height: number) {
@@ -164,7 +141,6 @@ describe("summarizeQuality", () => {
   }
 
   it("counts low-res cover as warning", () => {
-    // 500px on full 297mm page → ~43 DPI → warning
     const mediaMap = new Map([["lo.jpg", media("lo.jpg", 500, 400)]]);
     const result = summarizeQuality([], "lo.jpg", undefined, mediaMap);
     expect(result.warning).toBe(1);
@@ -189,28 +165,20 @@ describe("summarizeQuality", () => {
   });
 
   it("handles cover photo appearing in both cover and step.cover", () => {
-    // 800×700: front cover min(68,85)=68 → warning; side panel min(124,85)=85 → caution
     const mediaMap = new Map([["lo.jpg", media("lo.jpg", 800, 700)]]);
     const steps = [step({ id: 1, cover: "lo.jpg", pages: [["lo.jpg"]] })];
-    // Front cover (full bleed) + step cover (side panel) - the page entry is
-    // filtered out because it matches step.cover
     const result = summarizeQuality(steps, "lo.jpg", undefined, mediaMap);
     expect(result.warning).toBe(1);
     expect(result.caution).toBe(1);
   });
 
   it("applies orientation ordering before assigning cell fractions", () => {
-    // 1p-2l layout: portrait spans full height (left), landscapes are half-height (right).
-    // A low-res landscape in the raw data at index 0 should be evaluated in its
-    // actual (half-height) cell after orientation reordering, not the portrait cell.
-    const portrait = media("portrait.jpg", 600, 900); // portrait
-    const landscape = media("landscape.jpg", 800, 500); // landscape - low res
+    const portrait = media("portrait.jpg", 600, 900);
+    const landscape = media("landscape.jpg", 800, 500);
     const mediaMap = new Map([
       [portrait.name, portrait],
       [landscape.name, landscape],
     ]);
-    // Raw order: landscape first - without enforceOrientationOrder this assigns
-    // the landscape the portrait's full-height cell (inflating its DPI).
     const steps = [
       step({
         id: 1,
@@ -218,10 +186,6 @@ describe("summarizeQuality", () => {
       }),
     ];
     const result = summarizeQuality(steps, undefined, undefined, mediaMap);
-    // After reordering: [portrait, landscape, landscape] in layout-1p-2l.
-    // Portrait (600×900) in cell {0.5, 1}: min(600/(148.5/25.4), 900/(210/25.4)) ≈ min(103, 109) = 103 → ok
-    // Landscape (800×500) in cell {0.5, 0.5}: min(800/(148.5/25.4), 500/(105/25.4)) ≈ min(137, 121) = 121 → ok
-    // Both landscapes are the same media at 121 DPI → ok. All photos are ok.
     expect(result).toEqual({ caution: 0, warning: 0 });
   });
 });


### PR DESCRIPTION
- Update the testing philosophy note to prefer focused integration coverage and fewer abstraction layers.
- Consolidate repeated backend route helpers, factories, fixtures, and HTTP mocks.
- Consolidate repeated frontend and Playwright test builders, setup helpers, and e2e flow utilities.
- Prune helpers that ended up with only one call site after the cleanup.