### PR TITLE
feat: add durable processing workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,8 @@ POSTGRES_USER=postgres
 
 # --- Defaults - DBOS Workflows -----------------------
 # DBOS stores durable workflow state in Postgres. By default it uses the app DB.
-# Each worker generates a unique executor ID unless DBOS_EXECUTOR_ID is set.
+# Each backend process gets a unique executor ID automatically. If you override
+# DBOS_EXECUTOR_ID, use a different value per backend worker.
 
 # DBOS_SYSTEM_DATABASE_URI=
 # DBOS_EXECUTOR_ID=

--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,14 @@ MAX_STORAGE_BYTES=10737418240       # 10 GB. 0 = auto-detect (90% of filesystem 
 
 POSTGRES_DB=app
 POSTGRES_USER=postgres
+
+# --- Defaults - DBOS Workflows -----------------------
+# DBOS stores durable workflow state in Postgres. By default it uses the app DB.
+# Each worker generates a unique executor ID unless DBOS_EXECUTOR_ID is set.
+
+# DBOS_SYSTEM_DATABASE_URI=
+# DBOS_EXECUTOR_ID=
+# DBOS_ADMIN_PORT=3001
+# DBOS_RUN_ADMIN_SERVER=true
+# DBOS_HEARTBEAT_TTL_SECONDS=60
+# DBOS_RECOVERY_INTERVAL_SECONDS=10

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ For production, set `DOMAIN` and `ENVIRONMENT=production` in `.env` and run
 The Compose stack runs the app, database, and frontend. Configure database and
 app data backups in your deployment infrastructure.
 
-> [!WARNING]
-> The backend uses in-memory state and must run as a single worker process.
-> Do not run multiple backend containers or uvicorn workers.
+The backend stores upload and processing progress in shared storage and Postgres,
+so multiple backend workers can serve the same user flow. All backend workers
+must use the same `DATA_FOLDER` volume and database.
 
 ## Development
 

--- a/backend/app/alembic/versions/1f6d2e8c9a0b_widen_upload_session_byte_counts.py
+++ b/backend/app/alembic/versions/1f6d2e8c9a0b_widen_upload_session_byte_counts.py
@@ -1,0 +1,51 @@
+# ruff: noqa: INP001
+"""Widen upload session byte counts.
+
+Revision ID: 1f6d2e8c9a0b
+Revises: 8b0c4f2d9e11
+Create Date: 2026-06-11 20:20:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1f6d2e8c9a0b"
+down_revision = "8b0c4f2d9e11"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "upload_session",
+        "max_bytes",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "upload_session",
+        "accumulated_bytes",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "upload_session",
+        "accumulated_bytes",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "upload_session",
+        "max_bytes",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+    )

--- a/backend/app/alembic/versions/4d9e8a71c2b3_processing_workflow_tables.py
+++ b/backend/app/alembic/versions/4d9e8a71c2b3_processing_workflow_tables.py
@@ -1,0 +1,139 @@
+# ruff: noqa: INP001
+"""Processing workflow tables.
+
+Revision ID: 4d9e8a71c2b3
+Revises: 9f7c8a4d1b2e
+Create Date: 2026-05-22 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4d9e8a71c2b3"
+down_revision = "9f7c8a4d1b2e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "processing_operation",
+        sa.Column("operation_id", sa.String(), nullable=False),
+        sa.Column("uid", sa.Integer(), nullable=False),
+        sa.Column("upload_generation", sa.Integer(), nullable=False),
+        sa.Column("workflow_id", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("started_by_executor_id", sa.String(length=255), nullable=True),
+        sa.Column("error_code", sa.String(length=100), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["uid"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("operation_id"),
+    )
+    op.create_index(
+        "ix_processing_operation_status",
+        "processing_operation",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_processing_operation_uid",
+        "processing_operation",
+        ["uid"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_processing_operation_uid_generation_created",
+        "processing_operation",
+        ["uid", "upload_generation", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_processing_operation_upload_generation",
+        "processing_operation",
+        ["upload_generation"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_processing_operation_workflow_id",
+        "processing_operation",
+        ["workflow_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "processing_event",
+        sa.Column("operation_id", sa.String(), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=50), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["operation_id"],
+            ["processing_operation.operation_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("operation_id", "seq"),
+    )
+    op.create_index(
+        "ix_processing_event_event_type",
+        "processing_event",
+        ["event_type"],
+        unique=False,
+    )
+
+    op.create_table(
+        "workflow_executor_heartbeat",
+        sa.Column("executor_id", sa.String(length=255), nullable=False),
+        sa.Column("admin_base_url", sa.String(length=500), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("executor_id"),
+    )
+    op.create_index(
+        "ix_workflow_executor_heartbeat_last_seen_at",
+        "workflow_executor_heartbeat",
+        ["last_seen_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_workflow_executor_heartbeat_status",
+        "workflow_executor_heartbeat",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_workflow_executor_heartbeat_status",
+        table_name="workflow_executor_heartbeat",
+    )
+    op.drop_index(
+        "ix_workflow_executor_heartbeat_last_seen_at",
+        table_name="workflow_executor_heartbeat",
+    )
+    op.drop_table("workflow_executor_heartbeat")
+
+    op.drop_index("ix_processing_event_event_type", table_name="processing_event")
+    op.drop_table("processing_event")
+
+    op.drop_index(
+        "ix_processing_operation_workflow_id",
+        table_name="processing_operation",
+    )
+    op.drop_index(
+        "ix_processing_operation_upload_generation",
+        table_name="processing_operation",
+    )
+    op.drop_index(
+        "ix_processing_operation_uid_generation_created",
+        table_name="processing_operation",
+    )
+    op.drop_index("ix_processing_operation_uid", table_name="processing_operation")
+    op.drop_index("ix_processing_operation_status", table_name="processing_operation")
+    op.drop_table("processing_operation")

--- a/backend/app/alembic/versions/8b0c4f2d9e11_runtime_artifact_state_tables.py
+++ b/backend/app/alembic/versions/8b0c4f2d9e11_runtime_artifact_state_tables.py
@@ -1,0 +1,78 @@
+# ruff: noqa: INP001
+"""Runtime artifact state tables.
+
+Revision ID: 8b0c4f2d9e11
+Revises: 4d9e8a71c2b3
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8b0c4f2d9e11"
+down_revision = "4d9e8a71c2b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "upload_session",
+        sa.Column("upload_id", sa.String(length=255), nullable=False),
+        sa.Column("owner", sa.String(length=255), nullable=False),
+        sa.Column("max_bytes", sa.Integer(), nullable=False),
+        sa.Column("max_chunks", sa.Integer(), nullable=False),
+        sa.Column("accumulated_bytes", sa.Integer(), nullable=False),
+        sa.Column("chunks_written", sa.JSON(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("upload_id"),
+    )
+    op.create_index(
+        "ix_upload_session_expires_at",
+        "upload_session",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_upload_session_owner",
+        "upload_session",
+        ["owner"],
+        unique=False,
+    )
+
+    op.create_table(
+        "artifact_token",
+        sa.Column("token", sa.String(length=255), nullable=False),
+        sa.Column("namespace", sa.String(length=100), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("token"),
+    )
+    op.create_index(
+        "ix_artifact_token_expires_at",
+        "artifact_token",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_artifact_token_namespace",
+        "artifact_token",
+        ["namespace"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_artifact_token_namespace", table_name="artifact_token")
+    op.drop_index("ix_artifact_token_expires_at", table_name="artifact_token")
+    op.drop_table("artifact_token")
+
+    op.drop_index("ix_upload_session_owner", table_name="upload_session")
+    op.drop_index("ix_upload_session_expires_at", table_name="upload_session")
+    op.drop_table("upload_session")

--- a/backend/app/api/v1/routes/albums.py
+++ b/backend/app/api/v1/routes/albums.py
@@ -56,8 +56,9 @@ router = APIRouter(prefix="/albums", tags=["albums"])
 async def download_pdf(
     token: str,
     background_tasks: BackgroundTasks,
+    session: SessionDep,
 ) -> FileResponse:
-    result = pop_pdf_token(token)
+    result = await pop_pdf_token(session, token)
     if result is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, detail="Invalid or expired token"
@@ -289,10 +290,11 @@ async def generate_pdf(
     aid: str,
     browser: BrowserDep,
     request: Request,
+    session: SessionDep,
     dark: Annotated[bool, Query()] = True,  # noqa: FBT002
 ) -> AsyncIterable[PdfEvent]:
     session_cookie = request.cookies.get("session", "")
     async for event in render_album_pdf_stream(
-        browser, aid, session_cookie=session_cookie, dark=dark
+        browser, session, aid, session_cookie=session_cookie, dark=dark
     ):
         yield event

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -229,6 +229,7 @@ async def init_chunked_upload(
     max_bytes = get_settings().VITE_MAX_UPLOAD_GB * 1024 * MiB
     owner = _upload_owner(existing, identity)
     upload_id = await upload_store.create(session, max_bytes, owner=owner)
+    await session.commit()
     return {"upload_id": upload_id}
 
 
@@ -249,6 +250,7 @@ async def upload_chunk(
         await upload_store.write_chunk_stream(
             session, upload_id, chunk_index, request.stream()
         )
+        await session.commit()
     except ClientDisconnect:
         logger.info(
             "upload.chunk_client_disconnected",
@@ -284,6 +286,7 @@ async def complete_chunked_upload(
         assembled, upload_dir = await upload_store.assemble(
             session, upload_id, owner=owner
         )
+        await session.commit()
     except KeyError:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, "Upload session not found"

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -36,6 +36,7 @@ from app.logic.export import (
     export_user_data,
     pop_export_token,
 )
+from app.logic.processing_operations import mark_user_processing_operations_stale
 from app.logic.session import cancel_session, process_stream
 from app.logic.trip_processing import ProcessingEvent
 from app.logic.upload import TripMeta, UploadResult, extract_and_scan, scan_user_folder
@@ -126,6 +127,7 @@ async def _finalize_upload(  # noqa: PLR0913
             },
         ):
             cancel_session(ps_user.id)
+            await mark_user_processing_operations_stale(session, uid=ps_user.id)
 
             if existing is not None:
                 existing.album_ids = album_ids
@@ -443,9 +445,9 @@ async def delete_demo(
     responses={200: {"model": list[ProcessingEvent]}},
 )
 async def process_user(
-    user: UserDep, http: HttpClientsDep
+    user: UserDep, http: HttpClientsDep, session: SessionDep
 ) -> AsyncIterable[ProcessingEvent]:
-    async for event in process_stream(http, user):
+    async for event in process_stream(http, user, session):
         yield event
 
 

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -228,7 +228,7 @@ async def init_chunked_upload(
 
     max_bytes = get_settings().VITE_MAX_UPLOAD_GB * 1024 * MiB
     owner = _upload_owner(existing, identity)
-    upload_id = upload_store.create(max_bytes, owner=owner)
+    upload_id = await upload_store.create(session, max_bytes, owner=owner)
     return {"upload_id": upload_id}
 
 
@@ -237,6 +237,7 @@ async def upload_chunk(
     upload_id: str,
     chunk_index: int,
     request: Request,
+    session: SessionDep,
 ) -> Response:
     """Stream a chunk body to disk without loading it into memory.
 
@@ -245,7 +246,9 @@ async def upload_chunk(
     verified when the session is finalized in ``complete_chunked_upload``.
     """
     try:
-        await upload_store.write_chunk_stream(upload_id, chunk_index, request.stream())
+        await upload_store.write_chunk_stream(
+            session, upload_id, chunk_index, request.stream()
+        )
     except ClientDisconnect:
         logger.info(
             "upload.chunk_client_disconnected",
@@ -278,8 +281,8 @@ async def complete_chunked_upload(
 
     owner = _upload_owner(existing, identity)
     try:
-        assembled, upload_dir = await asyncio.to_thread(
-            upload_store.assemble, upload_id, owner=owner
+        assembled, upload_dir = await upload_store.assemble(
+            session, upload_id, owner=owner
         )
     except KeyError:
         raise HTTPException(
@@ -463,9 +466,9 @@ async def export_data(user: UserDep, session: SessionDep) -> AsyncIterable[Expor
 
 @router.get("/export/download/{token}")
 async def download_export(
-    token: str, background_tasks: BackgroundTasks
+    token: str, background_tasks: BackgroundTasks, session: SessionDep
 ) -> FileResponse:
-    result = pop_export_token(token)
+    result = await pop_export_token(session, token)
     if result is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, detail="Invalid or expired token"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,7 @@ from pydantic import (
     BeforeValidator,
     Field,
     PostgresDsn,
+    SecretStr,
     computed_field,
     model_validator,
 )
@@ -54,6 +55,14 @@ class Settings(BaseSettings):
     ENVIRONMENT: Literal["local", "production"] = "local"
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     APP_VERSION: str | None = None
+
+    DBOS_APP_NAME: str = "wanderbound"
+    DBOS_SYSTEM_DATABASE_URI: SecretStr | None = None
+    DBOS_EXECUTOR_ID: str | None = None
+    DBOS_ADMIN_PORT: int = 3001
+    DBOS_RUN_ADMIN_SERVER: bool = True
+    DBOS_HEARTBEAT_TTL_SECONDS: float = 60.0
+    DBOS_RECOVERY_INTERVAL_SECONDS: float = 10.0
 
     SENTRY_DSN: str | None = None
     SENTRY_TRACES_SAMPLE_RATE: float = Field(default=0.1, ge=0, le=1)

--- a/backend/app/core/locks.py
+++ b/backend/app/core/locks.py
@@ -22,7 +22,8 @@ async def try_advisory_lock(key: str) -> AsyncIterator[bool]:
     against the engine pool (size=10, max_overflow=10). Callers should
     release the lock quickly or scale the pool accordingly.
     """
-    async with get_engine().connect() as conn:
+    async with get_engine().connect() as raw_conn:
+        conn = await raw_conn.execution_options(isolation_level="AUTOCOMMIT")
         lock = create_async_sadlock(conn, key)
         acquired = await lock.acquire(block=False)
         try:

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -5,18 +5,21 @@ import secrets
 import shutil
 import tempfile
 from collections.abc import AsyncGenerator, Callable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
+from app.core.db import get_engine
 from app.models.processing import ArtifactToken
 
 if TYPE_CHECKING:
-    from sqlmodel.ext.asyncio.session import AsyncSession
+    from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = structlog.get_logger(__name__)
 
@@ -100,11 +103,13 @@ class ArtifactTokenStore:
         ttl: int,
         label: str,
         on_evict: Callable[[dict[str, str]], None] | None = None,
+        cleanup_interval: float = 60.0,
     ) -> None:
         self._dir_name = dir_name
         self._ttl = ttl
         self._label = label
         self._on_evict = on_evict
+        self._cleanup_interval = cleanup_interval
 
     @property
     def _dir(self) -> Path:
@@ -118,9 +123,29 @@ class ArtifactTokenStore:
         shutil.rmtree(self._dir, ignore_errors=True)
 
     @asynccontextmanager
-    async def lifespan(self) -> AsyncGenerator[None]:
+    async def lifespan(
+        self, *, engine: AsyncEngine | None = None
+    ) -> AsyncGenerator[None]:
         self._files_dir.mkdir(parents=True, exist_ok=True)
-        yield
+        task = asyncio.create_task(self._cleanup_loop(engine))
+        try:
+            yield
+        finally:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+    async def _cleanup_loop(self, engine: AsyncEngine | None) -> None:
+        while True:
+            await asyncio.sleep(self._cleanup_interval)
+            try:
+                async with AsyncSession(
+                    engine or get_engine(), expire_on_commit=False
+                ) as session:
+                    await self.cleanup_expired(session)
+                    await session.commit()
+            except Exception:
+                logger.exception("token.cleanup_failed", token_label=self._label)
 
     def make_dest(self, suffix: str) -> Path:
         self._files_dir.mkdir(parents=True, exist_ok=True)
@@ -153,6 +178,18 @@ class ArtifactTokenStore:
             return None
         await session.commit()
         return data
+
+    async def cleanup_expired(self, session: AsyncSession) -> None:
+        rows = (
+            await session.exec(
+                select(ArtifactToken)
+                .where(col(ArtifactToken.namespace) == self._dir_name)
+                .where(col(ArtifactToken.expires_at) <= _now())
+            )
+        ).all()
+        for row in rows:
+            await session.delete(row)
+            self._evict(row.payload)
 
     def _evict(self, data: dict[str, str]) -> None:
         if self._on_evict is not None:

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 import asyncio
-import contextlib
-import json
 import secrets
 import shutil
 import tempfile
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from time import time
-from typing import Any
+from typing import TYPE_CHECKING
 
 import structlog
 
 from app.core.config import get_settings
+from app.models.processing import ArtifactToken
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = structlog.get_logger(__name__)
 
@@ -80,7 +84,15 @@ class TokenStore[T]:
             )
 
 
-class FileTokenStore:
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+class ArtifactTokenStore:
     def __init__(
         self,
         *,
@@ -102,97 +114,47 @@ class FileTokenStore:
     def _files_dir(self) -> Path:
         return self._dir / "files"
 
-    @property
-    def _manifests_dir(self) -> Path:
-        return self._dir / "manifests"
-
     def cleanup(self) -> None:
-        self._evict_all()
         shutil.rmtree(self._dir, ignore_errors=True)
 
     @asynccontextmanager
     async def lifespan(self) -> AsyncGenerator[None]:
         self._files_dir.mkdir(parents=True, exist_ok=True)
-        self._manifests_dir.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(self._cleanup_expired)
-        task = asyncio.create_task(self._cleanup_loop())
-        try:
-            yield
-        finally:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-            await asyncio.to_thread(self._cleanup_expired)
+        yield
 
     def make_dest(self, suffix: str) -> Path:
         self._files_dir.mkdir(parents=True, exist_ok=True)
         return self._files_dir / f"{secrets.token_hex(16)}{suffix}"
 
-    def store(self, data: dict[str, str]) -> str:
-        self._manifests_dir.mkdir(parents=True, exist_ok=True)
+    async def store(self, session: AsyncSession, data: dict[str, str]) -> str:
         token = secrets.token_urlsafe()
-        payload: dict[str, Any] = {
-            "data": data,
-            "expires_at": time() + self._ttl,
-        }
-        path = self._manifest_path(token)
-        tmp_path = path.with_name(f"{path.name}.{secrets.token_hex(8)}.tmp")
-        with tmp_path.open("w", encoding="utf-8") as f:
-            json.dump(payload, f, sort_keys=True)
-        tmp_path.replace(path)
+        row = ArtifactToken(
+            token=token,
+            namespace=self._dir_name,
+            path=data["path"],
+            payload=data,
+            expires_at=_now() + timedelta(seconds=self._ttl),
+        )
+        session.add(row)
+        await session.commit()
         return token
 
-    def pop(self, token: str) -> dict[str, str] | None:
-        try:
-            path = self._manifest_path(token)
-            payload = self._read_payload(path)
-            path.unlink()
-        except OSError, TypeError, ValueError, KeyError:
+    async def pop(self, session: AsyncSession, token: str) -> dict[str, str] | None:
+        if not token or "/" in token or "\\" in token or token.startswith("."):
             return None
-
-        data = {str(k): str(v) for k, v in dict(payload["data"]).items()}
-        if float(payload["expires_at"]) <= time():
+        row = await session.get(ArtifactToken, token)
+        if row is None or row.namespace != self._dir_name:
+            return None
+        await session.delete(row)
+        data = row.payload
+        if _aware(row.expires_at) <= _now():
+            await session.commit()
             self._evict(data)
             return None
+        await session.commit()
         return data
-
-    def _cleanup_expired(self) -> None:
-        now = time()
-        for path in self._manifests_dir.glob("*.json"):
-            with contextlib.suppress(OSError, TypeError, ValueError, KeyError):
-                payload = self._read_payload(path)
-                if float(payload["expires_at"]) <= now:
-                    path.unlink(missing_ok=True)
-                    data = {str(k): str(v) for k, v in dict(payload["data"]).items()}
-                    self._evict(data)
-
-    def _evict_all(self) -> None:
-        for path in self._manifests_dir.glob("*.json"):
-            with contextlib.suppress(OSError, TypeError, ValueError, KeyError):
-                payload = self._read_payload(path)
-                path.unlink(missing_ok=True)
-                data = {str(k): str(v) for k, v in dict(payload["data"]).items()}
-                self._evict(data)
 
     def _evict(self, data: dict[str, str]) -> None:
         if self._on_evict is not None:
             self._on_evict(data)
         logger.debug("token.expired", token_label=self._label)
-
-    async def _cleanup_loop(self) -> None:
-        while True:
-            await asyncio.sleep(min(self._ttl, 60))
-            await asyncio.to_thread(self._cleanup_expired)
-
-    def _manifest_path(self, token: str) -> Path:
-        if not token or "/" in token or "\\" in token or token.startswith("."):
-            raise ValueError("invalid token")
-        return self._manifests_dir / f"{token}.json"
-
-    @staticmethod
-    def _read_payload(path: Path) -> dict[str, Any]:
-        with path.open("r", encoding="utf-8") as f:
-            payload = json.load(f)
-        if not isinstance(payload, dict):
-            raise TypeError("invalid token payload")
-        return payload

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
+from sqlalchemy import delete
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -167,12 +168,20 @@ class ArtifactTokenStore:
     async def pop(self, session: AsyncSession, token: str) -> dict[str, str] | None:
         if not token or "/" in token or "\\" in token or token.startswith("."):
             return None
-        row = await session.get(ArtifactToken, token)
-        if row is None or row.namespace != self._dir_name:
+        result = await session.exec(
+            delete(ArtifactToken)
+            .where(col(ArtifactToken.token) == token)
+            .where(col(ArtifactToken.namespace) == self._dir_name)
+            .returning(
+                col(ArtifactToken.payload),
+                col(ArtifactToken.expires_at),
+            )
+        )
+        row = result.one_or_none()
+        if row is None:
             return None
-        await session.delete(row)
-        data = row.payload
-        if _aware(row.expires_at) <= _now():
+        data, expires_at = row
+        if _aware(expires_at) <= _now():
             await session.commit()
             self._evict(data)
             return None

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -1,12 +1,18 @@
 import asyncio
+import contextlib
+import json
 import secrets
 import shutil
 import tempfile
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
+from time import time
+from typing import Any
 
 import structlog
+
+from app.core.config import get_settings
 
 logger = structlog.get_logger(__name__)
 
@@ -72,3 +78,121 @@ class TokenStore[T]:
                 token_label=self._label,
                 token_prefix=token[:8],
             )
+
+
+class FileTokenStore:
+    def __init__(
+        self,
+        *,
+        dir_name: str,
+        ttl: int,
+        label: str,
+        on_evict: Callable[[dict[str, str]], None] | None = None,
+    ) -> None:
+        self._dir_name = dir_name
+        self._ttl = ttl
+        self._label = label
+        self._on_evict = on_evict
+
+    @property
+    def _dir(self) -> Path:
+        return get_settings().DATA_FOLDER / "tokens" / self._dir_name
+
+    @property
+    def _files_dir(self) -> Path:
+        return self._dir / "files"
+
+    @property
+    def _manifests_dir(self) -> Path:
+        return self._dir / "manifests"
+
+    def cleanup(self) -> None:
+        self._evict_all()
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    @asynccontextmanager
+    async def lifespan(self) -> AsyncGenerator[None]:
+        self._files_dir.mkdir(parents=True, exist_ok=True)
+        self._manifests_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._cleanup_expired)
+        task = asyncio.create_task(self._cleanup_loop())
+        try:
+            yield
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await asyncio.to_thread(self._cleanup_expired)
+
+    def make_dest(self, suffix: str) -> Path:
+        self._files_dir.mkdir(parents=True, exist_ok=True)
+        return self._files_dir / f"{secrets.token_hex(16)}{suffix}"
+
+    def store(self, data: dict[str, str]) -> str:
+        self._manifests_dir.mkdir(parents=True, exist_ok=True)
+        token = secrets.token_urlsafe()
+        payload: dict[str, Any] = {
+            "data": data,
+            "expires_at": time() + self._ttl,
+        }
+        path = self._manifest_path(token)
+        tmp_path = path.with_name(f"{path.name}.{secrets.token_hex(8)}.tmp")
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, sort_keys=True)
+        tmp_path.replace(path)
+        return token
+
+    def pop(self, token: str) -> dict[str, str] | None:
+        try:
+            path = self._manifest_path(token)
+            payload = self._read_payload(path)
+            path.unlink()
+        except OSError, TypeError, ValueError, KeyError:
+            return None
+
+        data = {str(k): str(v) for k, v in dict(payload["data"]).items()}
+        if float(payload["expires_at"]) <= time():
+            self._evict(data)
+            return None
+        return data
+
+    def _cleanup_expired(self) -> None:
+        now = time()
+        for path in self._manifests_dir.glob("*.json"):
+            with contextlib.suppress(OSError, TypeError, ValueError, KeyError):
+                payload = self._read_payload(path)
+                if float(payload["expires_at"]) <= now:
+                    path.unlink(missing_ok=True)
+                    data = {str(k): str(v) for k, v in dict(payload["data"]).items()}
+                    self._evict(data)
+
+    def _evict_all(self) -> None:
+        for path in self._manifests_dir.glob("*.json"):
+            with contextlib.suppress(OSError, TypeError, ValueError, KeyError):
+                payload = self._read_payload(path)
+                path.unlink(missing_ok=True)
+                data = {str(k): str(v) for k, v in dict(payload["data"]).items()}
+                self._evict(data)
+
+    def _evict(self, data: dict[str, str]) -> None:
+        if self._on_evict is not None:
+            self._on_evict(data)
+        logger.debug("token.expired", token_label=self._label)
+
+    async def _cleanup_loop(self) -> None:
+        while True:
+            await asyncio.sleep(min(self._ttl, 60))
+            await asyncio.to_thread(self._cleanup_expired)
+
+    def _manifest_path(self, token: str) -> Path:
+        if not token or "/" in token or "\\" in token or token.startswith("."):
+            raise ValueError("invalid token")
+        return self._manifests_dir / f"{token}.json"
+
+    @staticmethod
+    def _read_payload(path: Path) -> dict[str, Any]:
+        with path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+        if not isinstance(payload, dict):
+            raise TypeError("invalid token payload")
+        return payload

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -13,13 +13,15 @@ from typing import TYPE_CHECKING, BinaryIO
 import anyio
 import structlog
 from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
+from app.core.db import get_engine
 from app.core.observability import start_span
 from app.models.processing import UploadSession
 
 if TYPE_CHECKING:
-    from sqlmodel.ext.asyncio.session import AsyncSession
+    from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = structlog.get_logger(__name__)
 
@@ -71,12 +73,32 @@ class UploadStore:
         self._locks: dict[str, asyncio.Lock] = {}
 
     @asynccontextmanager
-    async def lifespan(self) -> AsyncGenerator[None]:
+    async def lifespan(
+        self, *, engine: AsyncEngine | None = None
+    ) -> AsyncGenerator[None]:
         self._base = (
             self._base_override or get_settings().DATA_FOLDER / "chunked-uploads"
         )
         self._base.mkdir(parents=True, exist_ok=True)
-        yield
+        task = asyncio.create_task(self._cleanup_loop(engine))
+        try:
+            yield
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def _cleanup_loop(self, engine: AsyncEngine | None) -> None:
+        while True:
+            await asyncio.sleep(self._cleanup_interval)
+            try:
+                async with AsyncSession(
+                    engine or get_engine(), expire_on_commit=False
+                ) as session:
+                    await self.cleanup_expired(session)
+                    await session.commit()
+            except Exception:
+                logger.exception("upload.cleanup_failed")
 
     async def create(self, session: AsyncSession, max_bytes: int, *, owner: str) -> str:
         """Start a new upload session. Returns an opaque upload_id."""

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -1,20 +1,25 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
-import fcntl
-import json
 import secrets
 import shutil
-from collections.abc import AsyncGenerator, AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from time import time
-from typing import BinaryIO, TypedDict
+from typing import TYPE_CHECKING, BinaryIO
 
 import anyio
 import structlog
+from sqlmodel import col, select
 
 from app.core.config import get_settings
 from app.core.observability import start_span
+from app.models.processing import UploadSession
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = structlog.get_logger(__name__)
 
@@ -22,20 +27,17 @@ _UPLOAD_TTL = 3600  # 1 hour
 _CHUNK_LIMIT = 80 * 1024 * 1024 + 1024  # 80 MiB + 1 KiB margin
 _FLUSH_AT = 1024 * 1024  # flush buffer to disk every 1 MiB
 _CLEANUP_INTERVAL = 60
-_MANIFEST_NAME = "upload.json"
-_LOCK_NAME = "upload.lock"
 _UPLOAD_ID_CHARS = frozenset(
     "-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 
-class _Manifest(TypedDict):
-    max_bytes: int
-    max_chunks: int
-    owner: str
-    accumulated_bytes: int
-    chunks_written: list[int]
-    expires_at: float
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
 
 async def _stream_to_file(path: Path, stream: AsyncIterator[bytes], index: int) -> int:
@@ -58,7 +60,7 @@ async def _stream_to_file(path: Path, stream: AsyncIterator[bytes], index: int) 
 
 
 class UploadStore:
-    """Manages in-progress chunked uploads with automatic TTL eviction."""
+    """Manages in-progress chunked uploads with DB-backed session metadata."""
 
     def __init__(
         self, base: Path | None = None, *, cleanup_interval: float = _CLEANUP_INTERVAL
@@ -66,8 +68,7 @@ class UploadStore:
         self._base_override = base
         self._cleanup_interval = cleanup_interval
         self._base: Path  # resolved in lifespan()
-
-    # -- lifecycle --------------------------------------------------------
+        self._locks: dict[str, asyncio.Lock] = {}
 
     @asynccontextmanager
     async def lifespan(self) -> AsyncGenerator[None]:
@@ -75,139 +76,128 @@ class UploadStore:
             self._base_override or get_settings().DATA_FOLDER / "chunked-uploads"
         )
         self._base.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(self._cleanup_expired)
-        cleanup_task = asyncio.create_task(self._cleanup_loop())
-        try:
-            yield
-        finally:
-            cleanup_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await cleanup_task
+        yield
 
-    # -- public API -------------------------------------------------------
-
-    def create(self, max_bytes: int, *, owner: str) -> str:
+    async def create(self, session: AsyncSession, max_bytes: int, *, owner: str) -> str:
         """Start a new upload session. Returns an opaque upload_id."""
         upload_id = secrets.token_urlsafe()
         upload_dir = self._upload_dir(upload_id)
         upload_dir.mkdir(parents=True, exist_ok=True)
-        max_chunks = max_bytes // _CHUNK_LIMIT + 2  # +2 for rounding and final runt
-        self._write_manifest(
-            upload_dir,
-            {
-                "max_bytes": max_bytes,
-                "max_chunks": max_chunks,
-                "owner": owner,
-                "accumulated_bytes": 0,
-                "chunks_written": [],
-                "expires_at": time() + _UPLOAD_TTL,
-            },
+        row = UploadSession(
+            upload_id=upload_id,
+            max_bytes=max_bytes,
+            max_chunks=max_bytes // _CHUNK_LIMIT + 2,
+            owner=owner,
+            accumulated_bytes=0,
+            chunks_written=[],
+            expires_at=_now() + timedelta(seconds=_UPLOAD_TTL),
         )
+        session.add(row)
+        await session.flush()
         logger.info("upload.session_created", upload_id_prefix=upload_id[:8])
         return upload_id
 
     async def write_chunk_stream(
-        self, upload_id: str, index: int, stream: AsyncIterator[bytes]
+        self,
+        session: AsyncSession,
+        upload_id: str,
+        index: int,
+        stream: AsyncIterator[bytes],
     ) -> None:
-        """Stream a chunk body to disk without buffering it in memory.
-
-        Raises KeyError if session not found, ValueError on bad input,
-        OverflowError if accumulated size exceeds max_bytes.
-        """
-        upload_dir = self._existing_upload_dir(upload_id)
+        """Stream a chunk body to disk without buffering it in memory."""
+        upload_dir = await self._existing_upload_dir(session, upload_id)
         if not 0 <= index < 10_000:
             msg = f"Chunk index out of range: {index}"
             raise ValueError(msg)
 
-        with self._upload_lock(upload_dir):
-            manifest = self._read_manifest(upload_dir)
-            chunks_written = set(manifest["chunks_written"])
-            if (
-                index not in chunks_written
-                and len(chunks_written) >= manifest["max_chunks"]
-            ):
-                msg = f"Too many chunks (limit {manifest['max_chunks']})"
+        lock = self._locks.setdefault(upload_id, asyncio.Lock())
+        async with lock:
+            row = await self._get_session_for_update(session, upload_id)
+            chunks_written = set(row.chunks_written)
+            if index not in chunks_written and len(chunks_written) >= row.max_chunks:
+                msg = f"Too many chunks (limit {row.max_chunks})"
                 raise ValueError(msg)
 
-        tmp_path = upload_dir / f"{index:04d}.{secrets.token_hex(8)}.part"
-        try:
-            written = await _stream_to_file(tmp_path, stream, index)
-            with self._upload_lock(upload_dir):
-                self._commit_stream_chunk(upload_dir, index, tmp_path, written)
-        except Exception:
-            if not upload_dir.exists():
-                raise KeyError(upload_id) from None
-            raise
-        finally:
-            with contextlib.suppress(OSError):
-                tmp_path.unlink(missing_ok=True)
+            tmp_path = upload_dir / f"{index:04d}.{secrets.token_hex(8)}.part"
+            try:
+                written = await _stream_to_file(tmp_path, stream, index)
+                await self._commit_stream_chunk(session, row, index, tmp_path, written)
+            except Exception:
+                if not upload_dir.exists():
+                    raise KeyError(upload_id) from None
+                raise
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
 
-    def _commit_stream_chunk(
-        self, upload_dir: Path, index: int, tmp_path: Path, written: int
+    async def _commit_stream_chunk(
+        self,
+        session: AsyncSession,
+        row: UploadSession,
+        index: int,
+        tmp_path: Path,
+        written: int,
     ) -> None:
-        """Atomically promote tmp_path to the final chunk path under the lock."""
-        manifest = self._read_manifest(upload_dir)
-        chunks_written = set(manifest["chunks_written"])
+        upload_dir = self._upload_dir(row.upload_id)
         final_path = upload_dir / f"{index:04d}"
-        effective = manifest["accumulated_bytes"]
+        chunks_written = set(row.chunks_written)
+        effective = row.accumulated_bytes
         if index in chunks_written:
             with contextlib.suppress(OSError):
                 effective -= final_path.stat().st_size
 
-        if effective + written > manifest["max_bytes"]:
+        if effective + written > row.max_bytes:
             raise OverflowError("Upload exceeds maximum size")
 
-        tmp_path.rename(final_path)
-        manifest["accumulated_bytes"] = effective + written
+        await anyio.Path(tmp_path).rename(final_path)
         chunks_written.add(index)
-        manifest["chunks_written"] = sorted(chunks_written)
-        self._write_manifest(upload_dir, manifest)
+        row.accumulated_bytes = effective + written
+        row.chunks_written = sorted(chunks_written)
+        row.updated_at = _now()
+        session.add(row)
+        await session.flush()
 
-    def assemble(self, upload_id: str, *, owner: str) -> tuple[BinaryIO, Path]:
-        """Concatenate all chunks into a single seekable file.
+    async def assemble(
+        self, session: AsyncSession, upload_id: str, *, owner: str
+    ) -> tuple[BinaryIO, Path]:
+        """Concatenate all chunks into a single seekable file."""
+        upload_dir = await self._existing_upload_dir(session, upload_id)
+        row = await self._get_session_for_update(session, upload_id)
+        if row.owner != owner:
+            raise PermissionError("Upload session belongs to a different user")
 
-        Returns ``(file, session_dir)``.  The caller owns both and must
-        clean them up (close the file, then ``shutil.rmtree`` the dir).
+        chunks_written = set(row.chunks_written)
+        if not chunks_written:
+            await self._delete_row_and_dir(session, row)
+            msg = "No chunks uploaded"
+            raise ValueError(msg)
 
-        Raises PermissionError if *owner* doesn't match the session creator.
-        """
-        upload_dir = self._existing_upload_dir(upload_id)
-        with self._upload_lock(upload_dir):
-            manifest = self._read_manifest(upload_dir)
-            if manifest["owner"] != owner:
-                raise PermissionError("Upload session belongs to a different user")
+        expected = set(range(len(chunks_written)))
+        if chunks_written != expected:
+            await self._delete_row_and_dir(session, row)
+            msg = "Chunks are not contiguous from 0"
+            raise ValueError(msg)
 
-            chunks_written = set(manifest["chunks_written"])
-            if not chunks_written:
-                shutil.rmtree(upload_dir, ignore_errors=True)
-                msg = "No chunks uploaded"
-                raise ValueError(msg)
-
-            expected = set(range(len(chunks_written)))
-            if chunks_written != expected:
-                shutil.rmtree(upload_dir, ignore_errors=True)
-                msg = "Chunks are not contiguous from 0"
-                raise ValueError(msg)
-
-            chunks = [upload_dir / f"{index:04d}" for index in sorted(chunks_written)]
-            assembled = upload_dir / "assembled.zip"
-            with start_span(
-                "upload.assemble",
-                "Assemble chunked upload",
-                **{
-                    "app.workflow": "upload",
-                    "chunk.count": len(chunks),
-                    "size.bytes": manifest["accumulated_bytes"],
-                },
-            ):
-                with assembled.open("wb") as out:
-                    for chunk_path in chunks:
-                        with chunk_path.open("rb") as src:
-                            shutil.copyfileobj(src, out)
-
+        chunks = [upload_dir / f"{index:04d}" for index in sorted(chunks_written)]
+        assembled = upload_dir / "assembled.zip"
+        with start_span(
+            "upload.assemble",
+            "Assemble chunked upload",
+            **{
+                "app.workflow": "upload",
+                "chunk.count": len(chunks),
+                "size.bytes": row.accumulated_bytes,
+            },
+        ):
+            with assembled.open("wb") as out:
                 for chunk_path in chunks:
-                    chunk_path.unlink()
-                (upload_dir / _MANIFEST_NAME).unlink(missing_ok=True)
+                    with chunk_path.open("rb") as src:
+                        shutil.copyfileobj(src, out)
+
+            for chunk_path in chunks:
+                chunk_path.unlink()
+            await session.delete(row)
+            await session.flush()
 
         try:
             return assembled.open("rb"), upload_dir
@@ -215,76 +205,55 @@ class UploadStore:
             shutil.rmtree(upload_dir, ignore_errors=True)
             raise
 
-    # -- internals --------------------------------------------------------
+    async def cleanup_expired(self, session: AsyncSession) -> None:
+        rows = (
+            await session.exec(
+                select(UploadSession).where(col(UploadSession.expires_at) <= _now())
+            )
+        ).all()
+        for row in rows:
+            await self._delete_row_and_dir(session, row)
 
-    def _evict(self, upload_id: str) -> None:
-        upload_dir = self._upload_dir(upload_id)
-        if not upload_dir.exists():
+    async def _evict(self, session: AsyncSession, upload_id: str) -> None:
+        row = await session.get(UploadSession, upload_id)
+        if row is None:
             return
-        shutil.rmtree(upload_dir, ignore_errors=True)
+        await self._delete_row_and_dir(session, row)
         logger.info("upload.session_expired", upload_id_prefix=upload_id[:8])
 
-    def _cleanup_expired(self) -> None:
-        now = time()
-        for upload_dir in self._base.iterdir():
-            if not upload_dir.is_dir():
-                continue
-            with contextlib.suppress(KeyError, OSError):
-                manifest = self._read_manifest(upload_dir)
-                if manifest["expires_at"] < now:
-                    shutil.rmtree(upload_dir, ignore_errors=True)
+    async def _delete_row_and_dir(
+        self, session: AsyncSession, row: UploadSession
+    ) -> None:
+        shutil.rmtree(self._upload_dir(row.upload_id), ignore_errors=True)
+        await session.delete(row)
+        await session.flush()
 
-    async def _cleanup_loop(self) -> None:
-        while True:
-            await asyncio.sleep(self._cleanup_interval)
-            await asyncio.to_thread(self._cleanup_expired)
+    async def _existing_upload_dir(self, session: AsyncSession, upload_id: str) -> Path:
+        upload_dir = self._upload_dir(upload_id)
+        row = await session.get(UploadSession, upload_id)
+        if row is None or not upload_dir.exists() or _aware(row.expires_at) <= _now():
+            if row is not None:
+                await self._delete_row_and_dir(session, row)
+            raise KeyError(upload_id)
+        return upload_dir
+
+    async def _get_session_for_update(
+        self, session: AsyncSession, upload_id: str
+    ) -> UploadSession:
+        result = await session.exec(
+            select(UploadSession)
+            .where(col(UploadSession.upload_id) == upload_id)
+            .with_for_update()
+        )
+        row = result.one_or_none()
+        if row is None:
+            raise KeyError(upload_id)
+        return row
 
     def _upload_dir(self, upload_id: str) -> Path:
         if not upload_id or any(char not in _UPLOAD_ID_CHARS for char in upload_id):
             raise KeyError(upload_id)
         return self._base / upload_id
-
-    def _existing_upload_dir(self, upload_id: str) -> Path:
-        upload_dir = self._upload_dir(upload_id)
-        if not (upload_dir / _MANIFEST_NAME).exists():
-            raise KeyError(upload_id)
-        return upload_dir
-
-    @contextlib.contextmanager
-    def _upload_lock(self, upload_dir: Path) -> Iterator[None]:
-        try:
-            lock_file = (upload_dir / _LOCK_NAME).open("a+b")
-        except OSError as exc:
-            raise KeyError(upload_dir.name) from exc
-        try:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-            yield
-        finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            lock_file.close()
-
-    @staticmethod
-    def _read_manifest(upload_dir: Path) -> _Manifest:
-        try:
-            with (upload_dir / _MANIFEST_NAME).open("rb") as f:
-                data = json.load(f)
-        except OSError as exc:
-            raise KeyError(upload_dir.name) from exc
-        return _Manifest(
-            max_bytes=int(data["max_bytes"]),
-            max_chunks=int(data["max_chunks"]),
-            owner=str(data["owner"]),
-            accumulated_bytes=int(data["accumulated_bytes"]),
-            chunks_written=[int(index) for index in data["chunks_written"]],
-            expires_at=float(data["expires_at"]),
-        )
-
-    @staticmethod
-    def _write_manifest(upload_dir: Path, manifest: _Manifest) -> None:
-        tmp_path = upload_dir / f"{_MANIFEST_NAME}.{secrets.token_hex(8)}.tmp"
-        with tmp_path.open("w", encoding="utf-8") as f:
-            json.dump(manifest, f, sort_keys=True)
-        tmp_path.replace(upload_dir / _MANIFEST_NAME)
 
 
 upload_store = UploadStore()

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -1,13 +1,14 @@
 import asyncio
 import contextlib
+import fcntl
+import json
 import secrets
 import shutil
-import threading
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import BinaryIO
+from time import time
+from typing import BinaryIO, TypedDict
 
 import anyio
 import structlog
@@ -20,18 +21,20 @@ logger = structlog.get_logger(__name__)
 _UPLOAD_TTL = 3600  # 1 hour
 _CHUNK_LIMIT = 80 * 1024 * 1024 + 1024  # 80 MiB + 1 KiB margin
 _FLUSH_AT = 1024 * 1024  # flush buffer to disk every 1 MiB
+_MANIFEST_NAME = "upload.json"
+_LOCK_NAME = "upload.lock"
+_UPLOAD_ID_CHARS = frozenset(
+    "-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
 
 
-@dataclass
-class _Session:
-    dir: Path
-    timer: asyncio.TimerHandle
+class _Manifest(TypedDict):
     max_bytes: int
     max_chunks: int
     owner: str
-    lock: threading.Lock = field(default_factory=threading.Lock)
-    accumulated_bytes: int = 0
-    chunks_written: set[int] = field(default_factory=set)
+    accumulated_bytes: int
+    chunks_written: list[int]
+    expires_at: float
 
 
 async def _stream_to_file(path: Path, stream: AsyncIterator[bytes], index: int) -> int:
@@ -59,7 +62,6 @@ class UploadStore:
     def __init__(self, base: Path | None = None) -> None:
         self._base_override = base
         self._base: Path  # resolved in lifespan()
-        self._sessions: dict[str, _Session] = {}
 
     # -- lifecycle --------------------------------------------------------
 
@@ -68,33 +70,28 @@ class UploadStore:
         self._base = (
             self._base_override or get_settings().DATA_FOLDER / "chunked-uploads"
         )
-        shutil.rmtree(self._base, ignore_errors=True)
         self._base.mkdir(parents=True, exist_ok=True)
-        try:
-            yield
-        finally:
-            for session in self._sessions.values():
-                session.timer.cancel()
-                shutil.rmtree(session.dir, ignore_errors=True)
-            self._sessions.clear()
+        await asyncio.to_thread(self._cleanup_expired)
+        yield
 
     # -- public API -------------------------------------------------------
 
     def create(self, max_bytes: int, *, owner: str) -> str:
         """Start a new upload session. Returns an opaque upload_id."""
         upload_id = secrets.token_urlsafe()
-        upload_dir = self._base / secrets.token_hex(16)
+        upload_dir = self._upload_dir(upload_id)
         upload_dir.mkdir(parents=True, exist_ok=True)
-        timer = asyncio.get_running_loop().call_later(
-            _UPLOAD_TTL, self._evict, upload_id
-        )
         max_chunks = max_bytes // _CHUNK_LIMIT + 2  # +2 for rounding and final runt
-        self._sessions[upload_id] = _Session(
-            dir=upload_dir,
-            timer=timer,
-            max_bytes=max_bytes,
-            max_chunks=max_chunks,
-            owner=owner,
+        self._write_manifest(
+            upload_dir,
+            {
+                "max_bytes": max_bytes,
+                "max_chunks": max_chunks,
+                "owner": owner,
+                "accumulated_bytes": 0,
+                "chunks_written": [],
+                "expires_at": time() + _UPLOAD_TTL,
+            },
         )
         logger.info("upload.session_created", upload_id_prefix=upload_id[:8])
         return upload_id
@@ -107,52 +104,54 @@ class UploadStore:
         Raises KeyError if session not found, ValueError on bad input,
         OverflowError if accumulated size exceeds max_bytes.
         """
-        session = self._sessions.get(upload_id)
-        if session is None:
-            raise KeyError(upload_id)
+        upload_dir = self._existing_upload_dir(upload_id)
         if not 0 <= index < 10_000:
             msg = f"Chunk index out of range: {index}"
             raise ValueError(msg)
 
-        # Pre-check the chunk-count limit for *new* indices (under lock).
-        with session.lock:
+        with self._upload_lock(upload_dir):
+            manifest = self._read_manifest(upload_dir)
+            chunks_written = set(manifest["chunks_written"])
             if (
-                index not in session.chunks_written
-                and len(session.chunks_written) >= session.max_chunks
+                index not in chunks_written
+                and len(chunks_written) >= manifest["max_chunks"]
             ):
-                msg = f"Too many chunks (limit {session.max_chunks})"
+                msg = f"Too many chunks (limit {manifest['max_chunks']})"
                 raise ValueError(msg)
 
-        tmp_path = session.dir / f"{index:04d}.{secrets.token_hex(8)}.part"
+        tmp_path = upload_dir / f"{index:04d}.{secrets.token_hex(8)}.part"
         try:
             written = await _stream_to_file(tmp_path, stream, index)
-            self._commit_stream_chunk(session, index, tmp_path, written)
+            with self._upload_lock(upload_dir):
+                self._commit_stream_chunk(upload_dir, index, tmp_path, written)
         except Exception:
-            if upload_id not in self._sessions:
+            if not upload_dir.exists():
                 raise KeyError(upload_id) from None
             raise
         finally:
             with contextlib.suppress(OSError):
                 tmp_path.unlink(missing_ok=True)
 
-    @staticmethod
     def _commit_stream_chunk(
-        session: _Session, index: int, tmp_path: Path, written: int
+        self, upload_dir: Path, index: int, tmp_path: Path, written: int
     ) -> None:
         """Atomically promote tmp_path to the final chunk path under the lock."""
-        final_path = session.dir / f"{index:04d}"
-        with session.lock:
-            effective = session.accumulated_bytes
-            if index in session.chunks_written:
-                with contextlib.suppress(OSError):
-                    effective -= final_path.stat().st_size
+        manifest = self._read_manifest(upload_dir)
+        chunks_written = set(manifest["chunks_written"])
+        final_path = upload_dir / f"{index:04d}"
+        effective = manifest["accumulated_bytes"]
+        if index in chunks_written:
+            with contextlib.suppress(OSError):
+                effective -= final_path.stat().st_size
 
-            if effective + written > session.max_bytes:
-                raise OverflowError("Upload exceeds maximum size")
+        if effective + written > manifest["max_bytes"]:
+            raise OverflowError("Upload exceeds maximum size")
 
-            tmp_path.rename(final_path)
-            session.accumulated_bytes = effective + written
-            session.chunks_written.add(index)
+        tmp_path.rename(final_path)
+        manifest["accumulated_bytes"] = effective + written
+        chunks_written.add(index)
+        manifest["chunks_written"] = sorted(chunks_written)
+        self._write_manifest(upload_dir, manifest)
 
     def assemble(self, upload_id: str, *, owner: str) -> tuple[BinaryIO, Path]:
         """Concatenate all chunks into a single seekable file.
@@ -162,60 +161,115 @@ class UploadStore:
 
         Raises PermissionError if *owner* doesn't match the session creator.
         """
-        session = self._sessions.get(upload_id)
-        if session is None:
-            raise KeyError(upload_id)
-        if session.owner != owner:
-            raise PermissionError("Upload session belongs to a different user")
-        self._sessions.pop(upload_id)
-        session.timer.cancel()
+        upload_dir = self._existing_upload_dir(upload_id)
+        with self._upload_lock(upload_dir):
+            manifest = self._read_manifest(upload_dir)
+            if manifest["owner"] != owner:
+                raise PermissionError("Upload session belongs to a different user")
 
-        if not session.chunks_written:
-            shutil.rmtree(session.dir, ignore_errors=True)
-            msg = "No chunks uploaded"
-            raise ValueError(msg)
+            chunks_written = set(manifest["chunks_written"])
+            if not chunks_written:
+                shutil.rmtree(upload_dir, ignore_errors=True)
+                msg = "No chunks uploaded"
+                raise ValueError(msg)
 
-        expected = set(range(len(session.chunks_written)))
-        if session.chunks_written != expected:
-            shutil.rmtree(session.dir, ignore_errors=True)
-            msg = "Chunks are not contiguous from 0"
-            raise ValueError(msg)
+            expected = set(range(len(chunks_written)))
+            if chunks_written != expected:
+                shutil.rmtree(upload_dir, ignore_errors=True)
+                msg = "Chunks are not contiguous from 0"
+                raise ValueError(msg)
 
-        chunks = sorted(session.dir.glob("[0-9][0-9][0-9][0-9]"))
-        assembled = session.dir / "assembled.zip"
-        with start_span(
-            "upload.assemble",
-            "Assemble chunked upload",
-            **{
-                "app.workflow": "upload",
-                "chunk.count": len(chunks),
-                "size.bytes": session.accumulated_bytes,
-            },
-        ):
-            with assembled.open("wb") as out:
+            chunks = sorted(upload_dir.glob("[0-9][0-9][0-9][0-9]"))
+            assembled = upload_dir / "assembled.zip"
+            with start_span(
+                "upload.assemble",
+                "Assemble chunked upload",
+                **{
+                    "app.workflow": "upload",
+                    "chunk.count": len(chunks),
+                    "size.bytes": manifest["accumulated_bytes"],
+                },
+            ):
+                with assembled.open("wb") as out:
+                    for chunk_path in chunks:
+                        with chunk_path.open("rb") as src:
+                            shutil.copyfileobj(src, out)
+
                 for chunk_path in chunks:
-                    with chunk_path.open("rb") as src:
-                        shutil.copyfileobj(src, out)
-
-            for chunk_path in chunks:
-                chunk_path.unlink()
+                    chunk_path.unlink()
+                (upload_dir / _MANIFEST_NAME).unlink(missing_ok=True)
 
         try:
-            return assembled.open("rb"), session.dir
+            return assembled.open("rb"), upload_dir
         except OSError:
-            shutil.rmtree(session.dir, ignore_errors=True)
+            shutil.rmtree(upload_dir, ignore_errors=True)
             raise
 
     # -- internals --------------------------------------------------------
 
     def _evict(self, upload_id: str) -> None:
-        session = self._sessions.pop(upload_id, None)
-        if session is None:
+        upload_dir = self._upload_dir(upload_id)
+        if not upload_dir.exists():
             return
-        asyncio.get_running_loop().run_in_executor(
-            None, lambda: shutil.rmtree(session.dir, ignore_errors=True)
-        )
+        shutil.rmtree(upload_dir, ignore_errors=True)
         logger.info("upload.session_expired", upload_id_prefix=upload_id[:8])
+
+    def _cleanup_expired(self) -> None:
+        now = time()
+        for upload_dir in self._base.iterdir():
+            if not upload_dir.is_dir():
+                continue
+            with contextlib.suppress(KeyError, OSError):
+                manifest = self._read_manifest(upload_dir)
+                if manifest["expires_at"] < now:
+                    shutil.rmtree(upload_dir, ignore_errors=True)
+
+    def _upload_dir(self, upload_id: str) -> Path:
+        if not upload_id or any(char not in _UPLOAD_ID_CHARS for char in upload_id):
+            raise KeyError(upload_id)
+        return self._base / upload_id
+
+    def _existing_upload_dir(self, upload_id: str) -> Path:
+        upload_dir = self._upload_dir(upload_id)
+        if not (upload_dir / _MANIFEST_NAME).exists():
+            raise KeyError(upload_id)
+        return upload_dir
+
+    @contextlib.contextmanager
+    def _upload_lock(self, upload_dir: Path) -> Iterator[None]:
+        try:
+            lock_file = (upload_dir / _LOCK_NAME).open("a+b")
+        except OSError as exc:
+            raise KeyError(upload_dir.name) from exc
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            lock_file.close()
+
+    @staticmethod
+    def _read_manifest(upload_dir: Path) -> _Manifest:
+        try:
+            with (upload_dir / _MANIFEST_NAME).open("rb") as f:
+                data = json.load(f)
+        except OSError as exc:
+            raise KeyError(upload_dir.name) from exc
+        return _Manifest(
+            max_bytes=int(data["max_bytes"]),
+            max_chunks=int(data["max_chunks"]),
+            owner=str(data["owner"]),
+            accumulated_bytes=int(data["accumulated_bytes"]),
+            chunks_written=[int(index) for index in data["chunks_written"]],
+            expires_at=float(data["expires_at"]),
+        )
+
+    @staticmethod
+    def _write_manifest(upload_dir: Path, manifest: _Manifest) -> None:
+        tmp_path = upload_dir / f"{_MANIFEST_NAME}.{secrets.token_hex(8)}.tmp"
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(manifest, f, sort_keys=True)
+        tmp_path.replace(upload_dir / _MANIFEST_NAME)
 
 
 upload_store = UploadStore()

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -189,7 +189,7 @@ class UploadStore:
                 msg = "Chunks are not contiguous from 0"
                 raise ValueError(msg)
 
-            chunks = sorted(upload_dir.glob("[0-9][0-9][0-9][0-9]"))
+            chunks = [upload_dir / f"{index:04d}" for index in sorted(chunks_written)]
             assembled = upload_dir / "assembled.zip"
             with start_span(
                 "upload.assemble",

--- a/backend/app/logic/chunked_upload.py
+++ b/backend/app/logic/chunked_upload.py
@@ -21,6 +21,7 @@ logger = structlog.get_logger(__name__)
 _UPLOAD_TTL = 3600  # 1 hour
 _CHUNK_LIMIT = 80 * 1024 * 1024 + 1024  # 80 MiB + 1 KiB margin
 _FLUSH_AT = 1024 * 1024  # flush buffer to disk every 1 MiB
+_CLEANUP_INTERVAL = 60
 _MANIFEST_NAME = "upload.json"
 _LOCK_NAME = "upload.lock"
 _UPLOAD_ID_CHARS = frozenset(
@@ -59,8 +60,11 @@ async def _stream_to_file(path: Path, stream: AsyncIterator[bytes], index: int) 
 class UploadStore:
     """Manages in-progress chunked uploads with automatic TTL eviction."""
 
-    def __init__(self, base: Path | None = None) -> None:
+    def __init__(
+        self, base: Path | None = None, *, cleanup_interval: float = _CLEANUP_INTERVAL
+    ) -> None:
         self._base_override = base
+        self._cleanup_interval = cleanup_interval
         self._base: Path  # resolved in lifespan()
 
     # -- lifecycle --------------------------------------------------------
@@ -72,7 +76,13 @@ class UploadStore:
         )
         self._base.mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(self._cleanup_expired)
-        yield
+        cleanup_task = asyncio.create_task(self._cleanup_loop())
+        try:
+            yield
+        finally:
+            cleanup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await cleanup_task
 
     # -- public API -------------------------------------------------------
 
@@ -223,6 +233,11 @@ class UploadStore:
                 manifest = self._read_manifest(upload_dir)
                 if manifest["expires_at"] < now:
                     shutil.rmtree(upload_dir, ignore_errors=True)
+
+    async def _cleanup_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._cleanup_interval)
+            await asyncio.to_thread(self._cleanup_expired)
 
     def _upload_dir(self, upload_id: str) -> Path:
         if not upload_id or any(char not in _UPLOAD_ID_CHARS for char in upload_id):

--- a/backend/app/logic/export.py
+++ b/backend/app/logic/export.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 from sqlmodel import col, select
 
 from app.core.observability import start_span
-from app.core.tokens import FileTokenStore
+from app.core.tokens import ArtifactTokenStore
 from app.logic.layout.media import MEDIA_EXTENSIONS
 from app.logic.step_media import read_steps_with_media
 from app.models.album import Album
@@ -62,7 +62,7 @@ ExportEvent = Annotated[
 
 class _ExportTokens:
     def __init__(self) -> None:
-        self._store = FileTokenStore(
+        self._store = ArtifactTokenStore(
             dir_name=_EXPORT_NAME,
             ttl=300,
             label="export",
@@ -75,11 +75,11 @@ class _ExportTokens:
     def make_dest(self, suffix: str) -> Path:
         return self._store.make_dest(suffix)
 
-    def store(self, path: Path) -> str:
-        return self._store.store({"path": str(path)})
+    async def store(self, session: AsyncSession, path: Path) -> str:
+        return await self._store.store(session, {"path": str(path)})
 
-    def pop(self, token: str) -> Path | None:
-        data = self._store.pop(token)
+    async def pop(self, session: AsyncSession, token: str) -> Path | None:
+        data = await self._store.pop(session, token)
         return None if data is None else Path(data["path"])
 
     def lifespan(self) -> AbstractAsyncContextManager[None]:
@@ -187,6 +187,7 @@ async def _drain_queue(
 
 
 async def _run_zip_thread(
+    session: AsyncSession,
     spec: _ZipSpec,
     files_total: int,
 ) -> AsyncGenerator[ExportEvent]:
@@ -210,7 +211,7 @@ async def _run_zip_thread(
         async for event in _drain_queue(queue, files_total):
             yield event
 
-        token = _tokens.store(spec.dest)
+        token = await _tokens.store(session, spec.dest)
         logger.info("export.ready", files_total=files_total)
         yield ExportDone(token=token)
     except Exception:
@@ -293,5 +294,5 @@ async def export_user_data(
         media_by_album=media_by_album,
     )
 
-    async for event in _run_zip_thread(spec, files_total):
+    async for event in _run_zip_thread(session, spec, files_total):
         yield event

--- a/backend/app/logic/export.py
+++ b/backend/app/logic/export.py
@@ -6,6 +6,7 @@ import json
 import threading
 import zipfile
 from collections.abc import AsyncGenerator, Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
@@ -15,7 +16,7 @@ from pydantic import BaseModel, Field
 from sqlmodel import col, select
 
 from app.core.observability import start_span
-from app.core.tokens import TokenStore
+from app.core.tokens import FileTokenStore
 from app.logic.layout.media import MEDIA_EXTENSIONS
 from app.logic.step_media import read_steps_with_media
 from app.models.album import Album
@@ -58,12 +59,34 @@ ExportEvent = Annotated[
     Field(discriminator="type"),
 ]
 
-_tokens: TokenStore[Path] = TokenStore(
-    dir_name=_EXPORT_NAME,
-    ttl=300,
-    label="export",
-    on_evict=lambda p: p.unlink(missing_ok=True),
-)
+
+class _ExportTokens:
+    def __init__(self) -> None:
+        self._store = FileTokenStore(
+            dir_name=_EXPORT_NAME,
+            ttl=300,
+            label="export",
+            on_evict=lambda data: Path(data["path"]).unlink(missing_ok=True),
+        )
+
+    def cleanup(self) -> None:
+        self._store.cleanup()
+
+    def make_dest(self, suffix: str) -> Path:
+        return self._store.make_dest(suffix)
+
+    def store(self, path: Path) -> str:
+        return self._store.store({"path": str(path)})
+
+    def pop(self, token: str) -> Path | None:
+        data = self._store.pop(token)
+        return None if data is None else Path(data["path"])
+
+    def lifespan(self) -> AbstractAsyncContextManager[None]:
+        return self._store.lifespan()
+
+
+_tokens = _ExportTokens()
 
 pop_export_token = _tokens.pop
 lifespan = _tokens.lifespan

--- a/backend/app/logic/external_media/undo.py
+++ b/backend/app/logic/external_media/undo.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import shutil
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,12 +22,26 @@ from app.core.worker_threads import run_sync
 from app.logic.layout.media import Media, delete_thumbnails, extract_frame, is_video
 from app.models.album import Album
 from app.models.album_media import AlbumMedia, AlbumMediaUndoSnapshot
+from app.models.user import User
 
 UNDO_DIR = ".undo"
 UNDO_TTL = timedelta(minutes=5)
+UNDO_CLEANUP_INTERVAL = 60.0
 
 logger = structlog.get_logger(__name__)
 _undo_prune_tasks: set[asyncio.Task[None]] = set()
+
+
+@asynccontextmanager
+async def lifespan() -> AsyncGenerator[None]:
+    await _prune_all_expired_undo_snapshots_once()
+    task = asyncio.create_task(_prune_all_expired_undo_snapshots_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -218,3 +235,44 @@ async def prune_expired_undo_snapshots(
         await session.delete(row)
     await session.flush()
     return len(rows)
+
+
+async def prune_all_expired_undo_snapshots(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+) -> int:
+    now = now or datetime.now(UTC)
+    rows = (
+        await session.exec(
+            select(AlbumMediaUndoSnapshot).where(
+                AlbumMediaUndoSnapshot.expires_at <= _as_utc(now)
+            )
+        )
+    ).all()
+    removed = 0
+    for row in rows:
+        user = await session.get(User, row.uid)
+        if user is not None:
+            await _unlink_snapshot(user.trips_folder / row.aid / row.snapshot_path)
+        await session.delete(row)
+        removed += 1
+    await session.flush()
+    return removed
+
+
+async def _prune_all_expired_undo_snapshots_once() -> None:
+    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+        removed = await prune_all_expired_undo_snapshots(session)
+        await session.commit()
+    if removed:
+        logger.info("external_media.undo_pruned", count=removed)
+
+
+async def _prune_all_expired_undo_snapshots_loop() -> None:
+    while True:
+        await asyncio.sleep(UNDO_CLEANUP_INTERVAL)
+        try:
+            await _prune_all_expired_undo_snapshots_once()
+        except SQLAlchemyError, OSError:
+            logger.debug("external_media.undo_prune_failed", exc_info=True)

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -1,7 +1,12 @@
 import asyncio
 import base64
 from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import aclosing, asynccontextmanager, suppress
+from contextlib import (
+    AbstractAsyncContextManager,
+    aclosing,
+    asynccontextmanager,
+    suppress,
+)
 from pathlib import Path
 from typing import Annotated, ClassVar, Literal
 
@@ -10,9 +15,10 @@ from playwright.async_api import Browser, Page, Playwright, async_playwright
 from pydantic import BaseModel, Field
 
 from app.core.config import get_settings
+from app.core.locks import try_advisory_lock
 from app.core.observability import set_span_data, start_span
 from app.core.resources import MiB, detect_memory_mb
-from app.core.tokens import TokenStore
+from app.core.tokens import FileTokenStore
 
 logger = structlog.get_logger(__name__)
 
@@ -22,11 +28,10 @@ _PER_RENDER_MB = 768
 _memory_mb = detect_memory_mb()
 _max_concurrent = max(1, (_memory_mb - _PDF_BASELINE_MB) // _PER_RENDER_MB)
 
-_render_sem = asyncio.Semaphore(_max_concurrent)
-
 _QUEUE_TIMEOUT = 120
 _RENDER_TIMEOUT = 300
 _PROGRESS_CHUNK_BYTES = 512 * 1024
+_RENDER_SLOT_POLL_INTERVAL = 0.25
 
 
 class PdfQueued(BaseModel):
@@ -55,12 +60,35 @@ PdfEvent = Annotated[
     Field(discriminator="type"),
 ]
 
-_tokens: TokenStore[tuple[Path, str]] = TokenStore(
-    dir_name="wanderbound-pdf",
-    ttl=60,
-    label="PDF",
-    on_evict=lambda d: d[0].unlink(missing_ok=True),
-)
+
+class _PdfTokens:
+    def __init__(self) -> None:
+        self._store = FileTokenStore(
+            dir_name="wanderbound-pdf",
+            ttl=60,
+            label="PDF",
+            on_evict=lambda data: Path(data["path"]).unlink(missing_ok=True),
+        )
+
+    def cleanup(self) -> None:
+        self._store.cleanup()
+
+    def make_dest(self, suffix: str) -> Path:
+        return self._store.make_dest(suffix)
+
+    def store(self, data: tuple[Path, str]) -> str:
+        path, aid = data
+        return self._store.store({"path": str(path), "aid": aid})
+
+    def pop(self, token: str) -> tuple[Path, str] | None:
+        data = self._store.pop(token)
+        return None if data is None else (Path(data["path"]), data["aid"])
+
+    def lifespan(self) -> AbstractAsyncContextManager[None]:
+        return self._store.lifespan()
+
+
+_tokens = _PdfTokens()
 
 
 class BrowserManager:
@@ -120,6 +148,27 @@ def store_pdf_token(path: Path, aid: str) -> str:
 
 
 pop_pdf_token = _tokens.pop
+
+
+@asynccontextmanager
+async def _render_slot() -> AsyncGenerator[None]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _QUEUE_TIMEOUT
+    while True:
+        for slot in range(_max_concurrent):
+            lock = try_advisory_lock(f"pdf-render:{slot}")
+            acquired = await lock.__aenter__()
+            if acquired:
+                try:
+                    yield
+                finally:
+                    await lock.__aexit__(None, None, None)
+                return
+            await lock.__aexit__(None, None, None)
+
+        if loop.time() >= deadline:
+            raise TimeoutError
+        await asyncio.sleep(_RENDER_SLOT_POLL_INTERVAL)
 
 
 async def _stream_pdf_to_file(page: Page, dest: Path) -> AsyncGenerator[int]:
@@ -290,8 +339,8 @@ async def render_album_pdf_stream(
             "Wait for PDF render slot",
             **{"app.workflow": "pdf", "album.id": aid},
         ):
-            async with asyncio.timeout(_QUEUE_TIMEOUT):
-                await _render_sem.acquire()
+            slot = _render_slot()
+            await slot.__aenter__()
     except TimeoutError:
         logger.warning(
             "pdf.queue_timeout",
@@ -351,4 +400,4 @@ async def render_album_pdf_stream(
     finally:
         if not owned:
             dest.unlink(missing_ok=True)
-        _render_sem.release()
+        await slot.__aexit__(None, None, None)

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import base64
 from collections.abc import AsyncGenerator, AsyncIterator
@@ -8,7 +10,7 @@ from contextlib import (
     suppress,
 )
 from pathlib import Path
-from typing import Annotated, ClassVar, Literal
+from typing import TYPE_CHECKING, Annotated, ClassVar, Literal
 
 import structlog
 from playwright.async_api import Browser, Page, Playwright, async_playwright
@@ -18,7 +20,10 @@ from app.core.config import get_settings
 from app.core.locks import try_advisory_lock
 from app.core.observability import set_span_data, start_span
 from app.core.resources import MiB, detect_memory_mb
-from app.core.tokens import FileTokenStore
+from app.core.tokens import ArtifactTokenStore
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = structlog.get_logger(__name__)
 
@@ -63,7 +68,7 @@ PdfEvent = Annotated[
 
 class _PdfTokens:
     def __init__(self) -> None:
-        self._store = FileTokenStore(
+        self._store = ArtifactTokenStore(
             dir_name="wanderbound-pdf",
             ttl=60,
             label="PDF",
@@ -76,12 +81,12 @@ class _PdfTokens:
     def make_dest(self, suffix: str) -> Path:
         return self._store.make_dest(suffix)
 
-    def store(self, data: tuple[Path, str]) -> str:
+    async def store(self, session: AsyncSession, data: tuple[Path, str]) -> str:
         path, aid = data
-        return self._store.store({"path": str(path), "aid": aid})
+        return await self._store.store(session, {"path": str(path), "aid": aid})
 
-    def pop(self, token: str) -> tuple[Path, str] | None:
-        data = self._store.pop(token)
+    async def pop(self, session: AsyncSession, token: str) -> tuple[Path, str] | None:
+        data = await self._store.pop(session, token)
         return None if data is None else (Path(data["path"]), data["aid"])
 
     def lifespan(self) -> AbstractAsyncContextManager[None]:
@@ -143,8 +148,8 @@ async def lifespan() -> AsyncGenerator[BrowserManager]:
             logger.info("playwright.browser_closed")
 
 
-def store_pdf_token(path: Path, aid: str) -> str:
-    return _tokens.store((path, aid))
+async def store_pdf_token(session: AsyncSession, path: Path, aid: str) -> str:
+    return await _tokens.store(session, (path, aid))
 
 
 pop_pdf_token = _tokens.pop
@@ -324,6 +329,7 @@ async def _render_pdf(  # noqa: C901, PLR0915
 
 async def render_album_pdf_stream(
     browser: Browser,
+    session: AsyncSession,
     aid: str,
     *,
     session_cookie: str,
@@ -383,7 +389,7 @@ async def render_album_pdf_stream(
         if size == 0:
             yield PdfError(detail="PDF generation produced no output.")
             return
-        token = store_pdf_token(dest, aid)
+        token = await store_pdf_token(session, dest, aid)
         owned = True
         yield PdfDone(token=token)
 

--- a/backend/app/logic/processing_operations.py
+++ b/backend/app/logic/processing_operations.py
@@ -116,6 +116,18 @@ async def processing_operation_is_active(
     return status in _ACTIVE_STATUSES
 
 
+async def processing_operation_is_active_for_update(
+    session: AsyncSession, operation_id: str
+) -> bool:
+    result = await session.exec(
+        select(ProcessingOperation)
+        .where(col(ProcessingOperation.operation_id) == operation_id)
+        .with_for_update()
+    )
+    operation = result.one_or_none()
+    return operation is not None and operation.status in _ACTIVE_STATUSES
+
+
 async def append_processing_event(
     session: AsyncSession,
     operation: ProcessingOperation,

--- a/backend/app/logic/processing_operations.py
+++ b/backend/app/logic/processing_operations.py
@@ -1,0 +1,173 @@
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
+
+from pydantic import TypeAdapter
+from sqlalchemy import func, update
+from sqlmodel import col, select
+
+from app.logic.trip_processing import ProcessingEvent
+from app.models.processing import (
+    ProcessingEventRow,
+    ProcessingOperation,
+    ProcessingOperationStatus,
+)
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+_EVENT_ADAPTER = TypeAdapter(ProcessingEvent)
+_TERMINAL_STATUSES: set[ProcessingOperationStatus] = {
+    "succeeded",
+    "failed",
+    "cancelled",
+    "stale",
+}
+_ACTIVE_STATUSES: set[ProcessingOperationStatus] = {"queued", "running"}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def workflow_id_for_operation(operation_id: str) -> str:
+    return f"processing:{operation_id}"
+
+
+async def create_processing_operation(
+    session: AsyncSession, *, uid: int, upload_generation: int
+) -> ProcessingOperation:
+    operation = ProcessingOperation(
+        uid=uid,
+        upload_generation=upload_generation,
+        workflow_id="",
+    )
+    operation.workflow_id = workflow_id_for_operation(operation.operation_id)
+    session.add(operation)
+    await session.flush()
+    return operation
+
+
+async def latest_processing_operation(
+    session: AsyncSession, *, uid: int
+) -> ProcessingOperation | None:
+    result = await session.exec(
+        select(ProcessingOperation)
+        .where(col(ProcessingOperation.uid) == uid)
+        .order_by(col(ProcessingOperation.created_at).desc())
+    )
+    return result.first()
+
+
+async def latest_active_processing_operation(
+    session: AsyncSession, *, uid: int, upload_generation: int
+) -> ProcessingOperation | None:
+    result = await session.exec(
+        select(ProcessingOperation)
+        .where(col(ProcessingOperation.uid) == uid)
+        .where(col(ProcessingOperation.upload_generation) == upload_generation)
+        .where(col(ProcessingOperation.status).notin_(_TERMINAL_STATUSES))
+        .order_by(col(ProcessingOperation.created_at).desc())
+    )
+    return result.first()
+
+
+async def mark_processing_operation_running(
+    session: AsyncSession,
+    operation: ProcessingOperation,
+    *,
+    executor_id: str | None = None,
+) -> None:
+    now = _now()
+    operation.status = "running"
+    operation.started_by_executor_id = executor_id
+    operation.started_at = operation.started_at or now
+    operation.updated_at = now
+    session.add(operation)
+    await session.flush()
+
+
+async def complete_processing_operation(
+    session: AsyncSession,
+    operation: ProcessingOperation,
+    *,
+    status: ProcessingOperationStatus,
+    error_code: str | None = None,
+) -> None:
+    if status not in _TERMINAL_STATUSES:
+        msg = f"{status!r} is not a terminal processing status"
+        raise ValueError(msg)
+    now = _now()
+    operation.status = status
+    operation.error_code = error_code
+    operation.completed_at = now
+    operation.updated_at = now
+    session.add(operation)
+    await session.flush()
+
+
+async def processing_operation_is_active(
+    session: AsyncSession, operation_id: str
+) -> bool:
+    status = await session.scalar(
+        select(ProcessingOperation.status).where(
+            col(ProcessingOperation.operation_id) == operation_id
+        )
+    )
+    return status in _ACTIVE_STATUSES
+
+
+async def append_processing_event(
+    session: AsyncSession,
+    operation: ProcessingOperation,
+    event: ProcessingEvent,
+) -> ProcessingEventRow:
+    next_seq = await _next_event_seq(session, operation.operation_id)
+    payload = _EVENT_ADAPTER.dump_python(event, mode="json")
+    row = ProcessingEventRow(
+        operation_id=operation.operation_id,
+        seq=next_seq,
+        event_type=str(payload["type"]),
+        payload=payload,
+    )
+    operation.updated_at = _now()
+    session.add(row)
+    session.add(operation)
+    await session.flush()
+    return row
+
+
+async def read_processing_events(
+    session: AsyncSession, operation_id: str, *, after_seq: int = -1
+) -> list[ProcessingEvent]:
+    rows = (
+        await session.exec(
+            select(ProcessingEventRow)
+            .where(ProcessingEventRow.operation_id == operation_id)
+            .where(col(ProcessingEventRow.seq) > after_seq)
+            .order_by(col(ProcessingEventRow.seq))
+        )
+    ).all()
+    return [_EVENT_ADAPTER.validate_python(row.payload) for row in rows]
+
+
+async def mark_user_processing_operations_stale(
+    session: AsyncSession, *, uid: int
+) -> int:
+    result = await session.exec(
+        update(ProcessingOperation)
+        .where(col(ProcessingOperation.uid) == uid)
+        .where(col(ProcessingOperation.status).notin_(_TERMINAL_STATUSES))
+        .values(status="stale", updated_at=_now())
+    )
+    await session.flush()
+    return int(result.rowcount or 0)
+
+
+async def _next_event_seq(session: AsyncSession, operation_id: str) -> int:
+    max_seq = await session.exec(
+        select(func.max(ProcessingEventRow.seq)).where(
+            col(ProcessingEventRow.operation_id) == operation_id
+        )
+    )
+    value = cast("int | None", max_seq.one())
+    return (-1 if value is None else value) + 1

--- a/backend/app/logic/processing_operations.py
+++ b/backend/app/logic/processing_operations.py
@@ -200,12 +200,6 @@ async def append_processing_event_once(
     payload = _EVENT_ADAPTER.dump_python(event, mode="json")
     existing = await session.get(ProcessingEventRow, (operation.operation_id, seq))
     if existing is not None:
-        if existing.payload != payload:
-            msg = (
-                "recovered processing event does not match persisted event "
-                f"at seq {seq}"
-            )
-            raise RuntimeError(msg)
         return existing
 
     row = ProcessingEventRow(

--- a/backend/app/logic/processing_operations.py
+++ b/backend/app/logic/processing_operations.py
@@ -76,14 +76,22 @@ async def mark_processing_operation_running(
     operation: ProcessingOperation,
     *,
     executor_id: str | None = None,
-) -> None:
+) -> bool:
     now = _now()
-    operation.status = "running"
-    operation.started_by_executor_id = executor_id
-    operation.started_at = operation.started_at or now
-    operation.updated_at = now
-    session.add(operation)
+    result = await session.exec(
+        update(ProcessingOperation)
+        .where(col(ProcessingOperation.operation_id) == operation.operation_id)
+        .where(col(ProcessingOperation.status).in_(_ACTIVE_STATUSES))
+        .values(
+            status="running",
+            started_by_executor_id=executor_id,
+            started_at=func.coalesce(ProcessingOperation.started_at, now),
+            updated_at=now,
+        )
+    )
     await session.flush()
+    await session.refresh(operation)
+    return bool(result.rowcount)
 
 
 async def complete_processing_operation(
@@ -92,17 +100,25 @@ async def complete_processing_operation(
     *,
     status: ProcessingOperationStatus,
     error_code: str | None = None,
-) -> None:
+) -> bool:
     if status not in _TERMINAL_STATUSES:
         msg = f"{status!r} is not a terminal processing status"
         raise ValueError(msg)
     now = _now()
-    operation.status = status
-    operation.error_code = error_code
-    operation.completed_at = now
-    operation.updated_at = now
-    session.add(operation)
+    result = await session.exec(
+        update(ProcessingOperation)
+        .where(col(ProcessingOperation.operation_id) == operation.operation_id)
+        .where(col(ProcessingOperation.status).in_(_ACTIVE_STATUSES))
+        .values(
+            status=status,
+            error_code=error_code,
+            completed_at=now,
+            updated_at=now,
+        )
+    )
     await session.flush()
+    await session.refresh(operation)
+    return bool(result.rowcount)
 
 
 async def processing_operation_is_active(

--- a/backend/app/logic/processing_operations.py
+++ b/backend/app/logic/processing_operations.py
@@ -156,7 +156,7 @@ async def mark_user_processing_operations_stale(
     result = await session.exec(
         update(ProcessingOperation)
         .where(col(ProcessingOperation.uid) == uid)
-        .where(col(ProcessingOperation.status).notin_(_TERMINAL_STATUSES))
+        .where(col(ProcessingOperation.status) != "stale")
         .values(status="stale", updated_at=_now())
     )
     await session.flush()

--- a/backend/app/logic/processing_operations.py
+++ b/backend/app/logic/processing_operations.py
@@ -121,6 +121,32 @@ async def complete_processing_operation(
     return bool(result.rowcount)
 
 
+async def complete_processing_operation_by_id(
+    session: AsyncSession,
+    operation_id: str,
+    *,
+    status: ProcessingOperationStatus,
+    error_code: str | None = None,
+) -> bool:
+    if status not in _TERMINAL_STATUSES:
+        msg = f"{status!r} is not a terminal processing status"
+        raise ValueError(msg)
+    now = _now()
+    result = await session.exec(
+        update(ProcessingOperation)
+        .where(col(ProcessingOperation.operation_id) == operation_id)
+        .where(col(ProcessingOperation.status).in_(_ACTIVE_STATUSES))
+        .values(
+            status=status,
+            error_code=error_code,
+            completed_at=now,
+            updated_at=now,
+        )
+    )
+    await session.flush()
+    return bool(result.rowcount)
+
+
 async def processing_operation_is_active(
     session: AsyncSession, operation_id: str
 ) -> bool:
@@ -162,6 +188,55 @@ async def append_processing_event(
     session.add(operation)
     await session.flush()
     return row
+
+
+async def append_processing_event_once(
+    session: AsyncSession,
+    operation: ProcessingOperation,
+    event: ProcessingEvent,
+    *,
+    seq: int,
+) -> ProcessingEventRow:
+    payload = _EVENT_ADAPTER.dump_python(event, mode="json")
+    existing = await session.get(ProcessingEventRow, (operation.operation_id, seq))
+    if existing is not None:
+        if existing.payload != payload:
+            msg = (
+                "recovered processing event does not match persisted event "
+                f"at seq {seq}"
+            )
+            raise RuntimeError(msg)
+        return existing
+
+    row = ProcessingEventRow(
+        operation_id=operation.operation_id,
+        seq=seq,
+        event_type=str(payload["type"]),
+        payload=payload,
+    )
+    operation.updated_at = _now()
+    session.add(row)
+    session.add(operation)
+    await session.flush()
+    return row
+
+
+async def append_processing_event_unless_last_matches(
+    session: AsyncSession,
+    operation: ProcessingOperation,
+    event: ProcessingEvent,
+) -> ProcessingEventRow:
+    payload = _EVENT_ADAPTER.dump_python(event, mode="json")
+    last = (
+        await session.exec(
+            select(ProcessingEventRow)
+            .where(ProcessingEventRow.operation_id == operation.operation_id)
+            .order_by(col(ProcessingEventRow.seq).desc())
+        )
+    ).first()
+    if last is not None and last.payload == payload:
+        return last
+    return await append_processing_event(session, operation, event)
 
 
 async def read_processing_events(

--- a/backend/app/logic/segment_routes.py
+++ b/backend/app/logic/segment_routes.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
+from dbos import DBOS, SetWorkflowID
 from sqlalchemy import String, cast, or_, update
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -29,7 +29,7 @@ logger = structlog.get_logger(__name__)
 type SegmentKey = tuple[int, str, float, float]
 type SegmentSnapshot = tuple[SegmentKey, list[tuple[float, float]], str]
 
-_route_tasks: set[asyncio.Task[None]] = set()
+_route_http_clients: list[HttpClients] = []
 
 
 @dataclass
@@ -60,13 +60,57 @@ def enqueue_album_route_enrichment(
     uid: int,
     aid: str,
 ) -> None:
-    background_tasks.add_task(match_album_segment_routes, http, uid, aid)
+    background_tasks.add_task(start_album_route_enrichment, uid, aid)
 
 
 def schedule_album_route_enrichment(http: HttpClients, uid: int, aid: str) -> None:
-    task = asyncio.create_task(match_album_segment_routes(http, uid, aid))
-    _route_tasks.add(task)
-    task.add_done_callback(_route_tasks.discard)
+    start_album_route_enrichment(uid, aid)
+
+
+def set_route_enrichment_http_clients(http: HttpClients | None) -> None:
+    _route_http_clients.clear()
+    if http is not None:
+        _route_http_clients.append(http)
+
+
+def get_route_enrichment_http_clients() -> HttpClients:
+    if not _route_http_clients:
+        msg = "route enrichment HTTP clients have not been initialized"
+        raise RuntimeError(msg)
+    return _route_http_clients[0]
+
+
+def route_enrichment_workflow_id(uid: int, aid: str) -> str:
+    return f"route-enrichment:{uid}:{aid}"
+
+
+def route_enrichment_payload(uid: int, aid: str) -> dict[str, Any]:
+    return {"uid": uid, "aid": aid}
+
+
+@DBOS.workflow(name="route.enrich_album")
+async def album_route_enrichment_workflow(payload: dict[str, Any]) -> dict[str, Any]:
+    uid = int(payload["uid"])
+    aid = str(payload["aid"])
+    await match_album_segment_routes(get_route_enrichment_http_clients(), uid, aid)
+    return route_enrichment_payload(uid, aid)
+
+
+def start_album_route_enrichment(uid: int, aid: str) -> object:
+    try:
+        with SetWorkflowID(route_enrichment_workflow_id(uid, aid)):
+            return DBOS.start_workflow(
+                album_route_enrichment_workflow,
+                route_enrichment_payload(uid, aid),
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "route_enrichment.schedule_failed",
+            user_id=uid,
+            album_id=aid,
+            error_type=type(exc).__name__,
+        )
+        return None
 
 
 async def match_album_segment_routes(http: HttpClients, uid: int, aid: str) -> None:

--- a/backend/app/logic/segment_routes.py
+++ b/backend/app/logic/segment_routes.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import structlog
 from dbos import DBOS, SetWorkflowID
@@ -81,7 +82,7 @@ def get_route_enrichment_http_clients() -> HttpClients:
 
 
 def route_enrichment_workflow_id(uid: int, aid: str) -> str:
-    return f"route-enrichment:{uid}:{aid}"
+    return f"route-enrichment:{uid}:{aid}:{uuid4().hex}"
 
 
 def route_enrichment_payload(uid: int, aid: str) -> dict[str, Any]:

--- a/backend/app/logic/session.py
+++ b/backend/app/logic/session.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 import structlog
+from sqlmodel import col, select
 
 from app.core.http_clients import HttpClients
 from app.logic.processing_operations import (
@@ -210,6 +211,7 @@ async def _persisted_process_stream(
 async def _operation_for_process_request(
     db_session: AsyncSession, user: User
 ) -> ProcessingOperation:
+    await lock_user_for_processing_request(db_session, uid=user.id)
     latest = await latest_processing_operation(db_session, uid=user.id)
     if latest is None:
         return await create_processing_operation(
@@ -220,6 +222,12 @@ async def _operation_for_process_request(
     return await create_processing_operation(
         db_session, uid=user.id, upload_generation=latest.upload_generation + 1
     )
+
+
+async def lock_user_for_processing_request(
+    db_session: AsyncSession, *, uid: int
+) -> None:
+    await db_session.exec(select(User).where(col(User.id) == uid).with_for_update())
 
 
 async def _poll_persisted_operation(

--- a/backend/app/logic/session.py
+++ b/backend/app/logic/session.py
@@ -7,47 +7,81 @@ enabling reconnection without restarting work.
 
 import asyncio
 from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
 
 import structlog
 
 from app.core.http_clients import HttpClients
+from app.logic.processing_operations import (
+    append_processing_event,
+    complete_processing_operation,
+    create_processing_operation,
+    latest_processing_operation,
+    mark_processing_operation_running,
+    read_processing_events,
+)
 from app.logic.segment_routes import schedule_album_route_enrichment
 from app.logic.trip_pipeline import run_processing
 from app.logic.trip_processing import ErrorData, ProcessingEvent
+from app.logic.workflows.processing import start_processing_workflow
+from app.models.processing import ProcessingOperation
 from app.models.user import User
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = structlog.get_logger(__name__)
 
 _SESSION_TTL = 300  # seconds before a completed session is evicted
+_DB_POLL_INTERVAL = 0.05
 
 
 class ProcessingSession:
     """Runs processing in a background task; clients subscribe to events."""
 
-    def __init__(self, http: HttpClients, user: User) -> None:
+    def __init__(
+        self,
+        http: HttpClients,
+        user: User,
+        *,
+        db_session: AsyncSession | None = None,
+        operation: ProcessingOperation | None = None,
+    ) -> None:
         self._events: list[ProcessingEvent] = []
         self._done = False
         self._notify = asyncio.Event()
         self._uid = user.id
+        self._db_session = db_session
+        self._operation = operation
         self._task = asyncio.create_task(self._run(http, user))
 
     async def _run(self, http: HttpClients, user: User) -> None:
         saw_error = False
         try:
+            if self._db_session is not None and self._operation is not None:
+                await mark_processing_operation_running(
+                    self._db_session, self._operation
+                )
+                await self._db_session.commit()
             async for event in run_processing(http, user):
                 if isinstance(event, ErrorData):
                     saw_error = True
-                self._events.append(event)
-                self._notify.set()
+                await self._record_event(event)
             if not saw_error:
                 for aid in user.album_ids:
                     schedule_album_route_enrichment(http, self._uid, aid)
         except Exception:
             logger.exception("processing.task_crashed", user_id=self._uid)
-            # Surface the crash to subscribers; without this the stream ends
-            # silently and the UI can't distinguish success from failure.
-            self._events.append(ErrorData())
+            saw_error = True
+            await self._record_event(ErrorData())
         finally:
+            if self._db_session is not None and self._operation is not None:
+                await complete_processing_operation(
+                    self._db_session,
+                    self._operation,
+                    status="failed" if saw_error else "succeeded",
+                )
+                await self._db_session.commit()
             self._done = True
             self._notify.set()
             # Schedule cleanup so abandoned sessions don't leak memory.
@@ -58,6 +92,13 @@ class ProcessingSession:
                 self._uid,
                 self,
             )
+
+    async def _record_event(self, event: ProcessingEvent) -> None:
+        if self._db_session is not None and self._operation is not None:
+            await append_processing_event(self._db_session, self._operation, event)
+            await self._db_session.commit()
+        self._events.append(event)
+        self._notify.set()
 
     @property
     def is_done(self) -> bool:
@@ -110,7 +151,7 @@ def cancel_session(uid: int) -> None:
 
 
 async def process_stream(
-    http: HttpClients, user: User
+    http: HttpClients, user: User, db_session: AsyncSession | None = None
 ) -> AsyncIterator[ProcessingEvent]:
     """Start or reconnect to a user's processing session.
 
@@ -118,6 +159,11 @@ async def process_stream(
     user can retry without re-uploading. A finished session that succeeded is
     replayed so a browser refresh still works.
     """
+    if db_session is not None:
+        async for event in _persisted_process_stream(http, user, db_session):
+            yield event
+        return
+
     session = _sessions.get(user.id)
 
     if session is not None and not (session.is_done and session.had_error):
@@ -135,3 +181,67 @@ async def process_stream(
 
     async for event in session.subscribe():
         yield event
+
+
+async def _persisted_process_stream(
+    http: HttpClients, user: User, db_session: AsyncSession
+) -> AsyncIterator[ProcessingEvent]:
+    operation = await _operation_for_process_request(db_session, user)
+    await db_session.commit()
+
+    if operation.status == "succeeded":
+        for event in await read_processing_events(db_session, operation.operation_id):
+            yield event
+        return
+
+    session = _sessions.get(user.id)
+    if session is not None and not (session.is_done and session.had_error):
+        async for event in session.subscribe():
+            yield event
+        return
+
+    if operation.status != "running":
+        start_processing_workflow(operation, user)
+
+    async for event in _poll_persisted_operation(db_session, operation):
+        yield event
+
+
+async def _operation_for_process_request(
+    db_session: AsyncSession, user: User
+) -> ProcessingOperation:
+    latest = await latest_processing_operation(db_session, uid=user.id)
+    if latest is None:
+        return await create_processing_operation(
+            db_session, uid=user.id, upload_generation=1
+        )
+    if latest.status in {"queued", "running", "succeeded"}:
+        return latest
+    return await create_processing_operation(
+        db_session, uid=user.id, upload_generation=latest.upload_generation + 1
+    )
+
+
+async def _poll_persisted_operation(
+    db_session: AsyncSession, operation: ProcessingOperation
+) -> AsyncIterator[ProcessingEvent]:
+    after_seq = -1
+    while True:
+        events = await read_processing_events(
+            db_session, operation.operation_id, after_seq=after_seq
+        )
+        for event in events:
+            after_seq += 1
+            yield event
+
+        await db_session.refresh(operation)
+        if operation.status not in {"queued", "running"}:
+            events = await read_processing_events(
+                db_session, operation.operation_id, after_seq=after_seq
+            )
+            for event in events:
+                after_seq += 1
+                yield event
+            return
+
+        await asyncio.sleep(_DB_POLL_INTERVAL)

--- a/backend/app/logic/session.py
+++ b/backend/app/logic/session.py
@@ -204,7 +204,7 @@ async def _persisted_process_stream(
     if operation.status != "running":
         start_processing_workflow(operation, user)
 
-    async for event in _poll_persisted_operation(db_session, operation):
+    async for event in _poll_persisted_operation(db_session, operation.operation_id):
         yield event
 
 
@@ -231,21 +231,25 @@ async def lock_user_for_processing_request(
 
 
 async def _poll_persisted_operation(
-    db_session: AsyncSession, operation: ProcessingOperation
+    db_session: AsyncSession, operation_id: str
 ) -> AsyncIterator[ProcessingEvent]:
     after_seq = -1
     while True:
         events = await read_processing_events(
-            db_session, operation.operation_id, after_seq=after_seq
+            db_session, operation_id, after_seq=after_seq
         )
         for event in events:
             after_seq += 1
             yield event
 
-        await db_session.refresh(operation)
-        if operation.status not in {"queued", "running"}:
+        status = await db_session.scalar(
+            select(ProcessingOperation.status).where(
+                col(ProcessingOperation.operation_id) == operation_id
+            )
+        )
+        if status not in {"queued", "running"}:
             events = await read_processing_events(
-                db_session, operation.operation_id, after_seq=after_seq
+                db_session, operation_id, after_seq=after_seq
             )
             for event in events:
                 after_seq += 1

--- a/backend/app/logic/trip_pipeline.py
+++ b/backend/app/logic/trip_pipeline.py
@@ -43,6 +43,7 @@ from app.models.user import User
 logger = structlog.get_logger(__name__)
 
 _POLARSTEPS_METADATA = {"trip.json", "locations.json"}
+SaveGuard = Callable[[AsyncSession], Awaitable[bool]]
 
 
 def _cleanup_metadata(user_folder: Path, trip_dirs: list[Path]) -> None:
@@ -176,7 +177,9 @@ async def _load_existing(
 async def _save_new(
     uid: int,
     objects: list[DbRow],
-) -> None:
+    *,
+    save_guard: SaveGuard | None = None,
+) -> bool:
     with start_span(
         "processing.db_save",
         "Save processing results",
@@ -188,6 +191,9 @@ async def _save_new(
         },
     ):
         async with AsyncSession(get_engine()) as session:
+            if save_guard is not None and not await save_guard(session):
+                logger.info("processing.stale_during_save", user_id=uid)
+                return False
             for layer in _db_save_layers(objects):
                 session.add_all(layer)
                 await session.flush()
@@ -198,15 +204,18 @@ async def _save_new(
         object_count=len(objects),
         new_user=True,
     )
+    return True
 
 
-async def _save_reupload(
+async def _save_reupload(  # noqa: PLR0913
     uid: int,
     objects: list[DbRow],
     reconciled_aids: set[str],
     existing_albums: dict[str, Album],
     trip_dirs: list[Path],
-) -> None:
+    *,
+    save_guard: SaveGuard | None = None,
+) -> bool:
     with start_span(
         "processing.db_save",
         "Save processing results",
@@ -220,6 +229,9 @@ async def _save_reupload(
         },
     ):
         async with AsyncSession(get_engine()) as session:
+            if save_guard is not None and not await save_guard(session):
+                logger.info("processing.stale_during_save", user_id=uid)
+                return False
             if reconciled_aids:
                 await session.exec(
                     delete(StepPageMedia)
@@ -268,6 +280,7 @@ async def _save_reupload(
         object_count=len(objects),
         new_user=False,
     )
+    return True
 
 
 def _db_save_layers(objects: list[DbRow]) -> list[list[DbRow]]:
@@ -316,6 +329,7 @@ async def run_processing(  # noqa: C901
     user: User,
     *,
     should_continue: Callable[[], Awaitable[bool]] | None = None,
+    save_guard: SaveGuard | None = None,
 ) -> AsyncIterator[ProcessingEvent]:
     t0 = time.monotonic()
     trip_dirs = sorted(user.trips_folder.iterdir())
@@ -375,13 +389,21 @@ async def run_processing(  # noqa: C901
 
         try:
             if existing_albums:
-                await _save_reupload(
-                    user.id, all_objects, reconciled_aids, existing_albums, trip_dirs
+                saved = await _save_reupload(
+                    user.id,
+                    all_objects,
+                    reconciled_aids,
+                    existing_albums,
+                    trip_dirs,
+                    save_guard=save_guard,
                 )
             else:
-                await _save_new(user.id, all_objects)
+                saved = await _save_new(user.id, all_objects, save_guard=save_guard)
         except SQLAlchemyError:
             logger.exception("processing.db_save_failed", user_id=user.id)
+            yield ErrorData()
+            return
+        if not saved:
             yield ErrorData()
             return
         with start_span(

--- a/backend/app/logic/trip_pipeline.py
+++ b/backend/app/logic/trip_pipeline.py
@@ -2,7 +2,7 @@ import asyncio
 import shutil
 import time
 from collections import defaultdict
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 import structlog
@@ -302,8 +302,20 @@ def _apply_demo_i18n(user: User, all_objects: list[DbRow]) -> None:
     logger.info("demo.i18n_overlay_applied", user_id=user.id, locale=user.locale)
 
 
-async def run_processing(
-    http: HttpClients, user: User
+async def _processing_should_continue(
+    user: User, should_continue: Callable[[], Awaitable[bool]] | None
+) -> bool:
+    if should_continue is None or await should_continue():
+        return True
+    logger.info("processing.stale_before_save", user_id=user.id)
+    return False
+
+
+async def run_processing(  # noqa: C901
+    http: HttpClients,
+    user: User,
+    *,
+    should_continue: Callable[[], Awaitable[bool]] | None = None,
 ) -> AsyncIterator[ProcessingEvent]:
     t0 = time.monotonic()
     trip_dirs = sorted(user.trips_folder.iterdir())
@@ -356,6 +368,10 @@ async def run_processing(
             return
 
         _apply_demo_i18n(user, all_objects)
+
+        if not await _processing_should_continue(user, should_continue):
+            yield ErrorData()
+            return
 
         try:
             if existing_albums:

--- a/backend/app/logic/trip_pipeline.py
+++ b/backend/app/logic/trip_pipeline.py
@@ -194,9 +194,7 @@ async def _save_new(
             if save_guard is not None and not await save_guard(session):
                 logger.info("processing.stale_during_save", user_id=uid)
                 return False
-            for layer in _db_save_layers(objects):
-                session.add_all(layer)
-                await session.flush()
+            await _add_new_objects(session, objects)
             await session.commit()
     logger.info(
         "processing.db_saved",
@@ -205,6 +203,14 @@ async def _save_new(
         new_user=True,
     )
     return True
+
+
+async def _add_new_objects(session: AsyncSession, objects: list[DbRow]) -> None:
+    for model in (Album, AlbumMedia, Step, StepPageMedia, StepUnusedMedia, Segment):
+        rows = [obj for obj in objects if isinstance(obj, model)]
+        if rows:
+            session.add_all(rows)
+            await session.flush()
 
 
 async def _save_reupload(  # noqa: PLR0913
@@ -269,10 +275,7 @@ async def _save_reupload(  # noqa: PLR0913
                 )
             await session.flush()
 
-            for layer in _db_save_layers(objects):
-                for obj in layer:
-                    await session.merge(obj)
-                await session.flush()
+            await _merge_objects(session, objects)
             await session.commit()
     logger.info(
         "processing.db_saved",
@@ -283,15 +286,13 @@ async def _save_reupload(  # noqa: PLR0913
     return True
 
 
-def _db_save_layers(objects: list[DbRow]) -> list[list[DbRow]]:
-    albums: list[DbRow] = [obj for obj in objects if isinstance(obj, Album)]
-    media: list[DbRow] = [obj for obj in objects if isinstance(obj, AlbumMedia)]
-    steps: list[DbRow] = [obj for obj in objects if isinstance(obj, Step)]
-    step_media: list[DbRow] = [
-        obj for obj in objects if isinstance(obj, StepPageMedia | StepUnusedMedia)
-    ]
-    segments: list[DbRow] = [obj for obj in objects if isinstance(obj, Segment)]
-    return [layer for layer in [albums, media, steps, step_media, segments] if layer]
+async def _merge_objects(session: AsyncSession, objects: list[DbRow]) -> None:
+    for model in (Album, AlbumMedia, Step, StepPageMedia, StepUnusedMedia, Segment):
+        rows = [obj for obj in objects if isinstance(obj, model)]
+        for obj in rows:
+            await session.merge(obj)
+        if rows:
+            await session.flush()
 
 
 def _apply_demo_i18n(user: User, all_objects: list[DbRow]) -> None:

--- a/backend/app/logic/workflows/__init__.py
+++ b/backend/app/logic/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Workflow orchestration adapters."""

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -8,11 +8,12 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
 from app.logic.processing_operations import (
-    append_processing_event,
+    append_processing_event_once,
+    append_processing_event_unless_last_matches,
     complete_processing_operation,
+    complete_processing_operation_by_id,
     mark_processing_operation_running,
     processing_operation_is_active,
-    processing_operation_is_active_for_update,
 )
 from app.logic.segment_routes import schedule_album_route_enrichment
 from app.logic.trip_pipeline import run_processing
@@ -94,12 +95,18 @@ async def run_processing_workflow_payload(
         )
         return await fail_active_processing_operation(session, operation, exc)
 
-    status = "failed" if saw_error else "succeeded"
-    if not await complete_processing_operation(session, operation, status=status):
+    await session.refresh(operation)
+    if operation.status == "succeeded":
+        status = "succeeded"
+    else:
+        status = "failed" if saw_error else "succeeded"
+    if operation.status != status and not await complete_processing_operation(
+        session, operation, status=status
+    ):
         return {"operation_id": operation.operation_id, "status": operation.status}
     await session.commit()
 
-    if not saw_error:
+    if status == "succeeded":
         for aid in user.album_ids:
             schedule_album_route_enrichment(http, user.id, aid)
 
@@ -117,7 +124,7 @@ async def fail_active_processing_operation(
     if not await processing_operation_is_active(session, current.operation_id):
         return {"operation_id": current.operation_id, "status": current.status}
 
-    await append_processing_event(session, current, ErrorData())
+    await append_processing_event_unless_last_matches(session, current, ErrorData())
     if not await complete_processing_operation(
         session,
         current,
@@ -139,18 +146,20 @@ async def run_and_persist_processing_events(
         return await processing_operation_is_active(session, operation.operation_id)
 
     async def save_guard(save_session: AsyncSession) -> bool:
-        return await processing_operation_is_active_for_update(
-            save_session, operation.operation_id
+        return await complete_processing_operation_by_id(
+            save_session, operation.operation_id, status="succeeded"
         )
 
     saw_error = False
+    seq = 0
     async for event in run_processing(
         http, user, should_continue=should_continue, save_guard=save_guard
     ):
         if isinstance(event, ErrorData):
             saw_error = True
-        await append_processing_event(session, operation, event)
+        await append_processing_event_once(session, operation, event, seq=seq)
         await session.commit()
+        seq += 1
     return saw_error
 
 

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -66,18 +66,13 @@ async def run_processing_workflow_payload(
         msg = "processing workflow references missing user or operation"
         raise RuntimeError(msg)
 
+    if not await processing_operation_is_active(session, operation.operation_id):
+        return {"operation_id": operation.operation_id, "status": operation.status}
+
     await mark_processing_operation_running(session, operation)
     await session.commit()
 
-    async def should_continue() -> bool:
-        return await processing_operation_is_active(session, operation.operation_id)
-
-    saw_error = False
-    async for event in run_processing(http, user, should_continue=should_continue):
-        if isinstance(event, ErrorData):
-            saw_error = True
-        await append_processing_event(session, operation, event)
-        await session.commit()
+    saw_error = await run_and_persist_processing_events(http, user, operation, session)
 
     await session.refresh(operation)
     if operation.status == "stale":
@@ -92,6 +87,24 @@ async def run_processing_workflow_payload(
             schedule_album_route_enrichment(http, user.id, aid)
 
     return {"operation_id": operation.operation_id, "status": status}
+
+
+async def run_and_persist_processing_events(
+    http: HttpClients,
+    user: User,
+    operation: ProcessingOperation,
+    session: AsyncSession,
+) -> bool:
+    async def should_continue() -> bool:
+        return await processing_operation_is_active(session, operation.operation_id)
+
+    saw_error = False
+    async for event in run_processing(http, user, should_continue=should_continue):
+        if isinstance(event, ErrorData):
+            saw_error = True
+        await append_processing_event(session, operation, event)
+        await session.commit()
+    return saw_error
 
 
 @DBOS.workflow(name="processing.upload")

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -5,6 +5,7 @@ from dbos import DBOS, SetWorkflowID
 from pydantic import BaseModel, Field
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.config import get_settings
 from app.core.db import get_engine
 from app.core.http_clients import HttpClients
 from app.logic.processing_operations import (
@@ -18,6 +19,7 @@ from app.logic.processing_operations import (
 from app.logic.segment_routes import schedule_album_route_enrichment
 from app.logic.trip_pipeline import run_processing
 from app.logic.trip_processing import ErrorData
+from app.logic.workflows.recovery import workflow_executor_id
 from app.models.processing import ProcessingOperation
 from app.models.user import User
 
@@ -77,7 +79,9 @@ async def run_processing_workflow_payload(
         )
         return {"operation_id": params.operation_id, "status": "cancelled"}
 
-    if not await mark_processing_operation_running(session, operation):
+    if not await mark_processing_operation_running(
+        session, operation, executor_id=workflow_executor_id(get_settings())
+    ):
         return {"operation_id": operation.operation_id, "status": operation.status}
     await session.commit()
 

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -67,8 +67,14 @@ async def run_processing_workflow_payload(
     user = await session.get(User, params.uid)
     operation = await session.get(ProcessingOperation, params.operation_id)
     if user is None or operation is None:
-        msg = "processing workflow references missing user or operation"
-        raise RuntimeError(msg)
+        logger.info(
+            "processing_workflow.cancelled_missing_rows",
+            operation_id=params.operation_id,
+            user_id=params.uid,
+            missing_user=user is None,
+            missing_operation=operation is None,
+        )
+        return {"operation_id": params.operation_id, "status": "cancelled"}
 
     if not await processing_operation_is_active(session, operation.operation_id):
         return {"operation_id": operation.operation_id, "status": operation.status}

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import structlog
 from dbos import DBOS, SetWorkflowID
 from pydantic import BaseModel, Field
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -17,6 +18,8 @@ from app.logic.trip_pipeline import run_processing
 from app.logic.trip_processing import ErrorData
 from app.models.processing import ProcessingOperation
 from app.models.user import User
+
+logger = structlog.get_logger(__name__)
 
 
 class ProcessingWorkflowPayload(BaseModel):
@@ -72,7 +75,19 @@ async def run_processing_workflow_payload(
     await mark_processing_operation_running(session, operation)
     await session.commit()
 
-    saw_error = await run_and_persist_processing_events(http, user, operation, session)
+    try:
+        saw_error = await run_and_persist_processing_events(
+            http, user, operation, session
+        )
+    except Exception as exc:
+        await session.rollback()
+        logger.exception(
+            "processing_workflow.failed",
+            operation_id=operation.operation_id,
+            user_id=user.id,
+            error_type=type(exc).__name__,
+        )
+        return await fail_active_processing_operation(session, operation, exc)
 
     await session.refresh(operation)
     if operation.status == "stale":
@@ -87,6 +102,28 @@ async def run_processing_workflow_payload(
             schedule_album_route_enrichment(http, user.id, aid)
 
     return {"operation_id": operation.operation_id, "status": status}
+
+
+async def fail_active_processing_operation(
+    session: AsyncSession,
+    operation: ProcessingOperation,
+    exc: Exception,
+) -> dict[str, str]:
+    current = await session.get(ProcessingOperation, operation.operation_id)
+    if current is None:
+        raise exc
+    if not await processing_operation_is_active(session, current.operation_id):
+        return {"operation_id": current.operation_id, "status": current.status}
+
+    await append_processing_event(session, current, ErrorData())
+    await complete_processing_operation(
+        session,
+        current,
+        status="failed",
+        error_code=type(exc).__name__,
+    )
+    await session.commit()
+    return {"operation_id": current.operation_id, "status": "failed"}
 
 
 async def run_and_persist_processing_events(

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -12,6 +12,7 @@ from app.logic.processing_operations import (
     complete_processing_operation,
     mark_processing_operation_running,
     processing_operation_is_active,
+    processing_operation_is_active_for_update,
 )
 from app.logic.segment_routes import schedule_album_route_enrichment
 from app.logic.trip_pipeline import run_processing
@@ -135,8 +136,15 @@ async def run_and_persist_processing_events(
     async def should_continue() -> bool:
         return await processing_operation_is_active(session, operation.operation_id)
 
+    async def save_guard(save_session: AsyncSession) -> bool:
+        return await processing_operation_is_active_for_update(
+            save_session, operation.operation_id
+        )
+
     saw_error = False
-    async for event in run_processing(http, user, should_continue=should_continue):
+    async for event in run_processing(
+        http, user, should_continue=should_continue, save_guard=save_guard
+    ):
         if isinstance(event, ErrorData):
             saw_error = True
         await append_processing_event(session, operation, event)

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -76,10 +76,8 @@ async def run_processing_workflow_payload(
         )
         return {"operation_id": params.operation_id, "status": "cancelled"}
 
-    if not await processing_operation_is_active(session, operation.operation_id):
+    if not await mark_processing_operation_running(session, operation):
         return {"operation_id": operation.operation_id, "status": operation.status}
-
-    await mark_processing_operation_running(session, operation)
     await session.commit()
 
     try:
@@ -96,12 +94,9 @@ async def run_processing_workflow_payload(
         )
         return await fail_active_processing_operation(session, operation, exc)
 
-    await session.refresh(operation)
-    if operation.status == "stale":
-        return {"operation_id": operation.operation_id, "status": "stale"}
-
     status = "failed" if saw_error else "succeeded"
-    await complete_processing_operation(session, operation, status=status)
+    if not await complete_processing_operation(session, operation, status=status):
+        return {"operation_id": operation.operation_id, "status": operation.status}
     await session.commit()
 
     if not saw_error:
@@ -123,12 +118,13 @@ async def fail_active_processing_operation(
         return {"operation_id": current.operation_id, "status": current.status}
 
     await append_processing_event(session, current, ErrorData())
-    await complete_processing_operation(
+    if not await complete_processing_operation(
         session,
         current,
         status="failed",
         error_code=type(exc).__name__,
-    )
+    ):
+        return {"operation_id": current.operation_id, "status": current.status}
     await session.commit()
     return {"operation_id": current.operation_id, "status": "failed"}
 

--- a/backend/app/logic/workflows/processing.py
+++ b/backend/app/logic/workflows/processing.py
@@ -1,0 +1,110 @@
+from typing import Any
+
+from dbos import DBOS, SetWorkflowID
+from pydantic import BaseModel, Field
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.db import get_engine
+from app.core.http_clients import HttpClients
+from app.logic.processing_operations import (
+    append_processing_event,
+    complete_processing_operation,
+    mark_processing_operation_running,
+    processing_operation_is_active,
+)
+from app.logic.segment_routes import schedule_album_route_enrichment
+from app.logic.trip_pipeline import run_processing
+from app.logic.trip_processing import ErrorData
+from app.models.processing import ProcessingOperation
+from app.models.user import User
+
+
+class ProcessingWorkflowPayload(BaseModel):
+    operation_id: str
+    uid: int
+    upload_generation: int
+    trips_folder: str
+    album_ids: tuple[str, ...] = Field(default_factory=tuple)
+
+
+def processing_workflow_payload(
+    operation: ProcessingOperation, user: User
+) -> dict[str, Any]:
+    payload = ProcessingWorkflowPayload(
+        operation_id=operation.operation_id,
+        uid=operation.uid,
+        upload_generation=operation.upload_generation,
+        trips_folder=str(user.trips_folder),
+        album_ids=tuple(user.album_ids),
+    )
+    return payload.model_dump(mode="json")
+
+
+_workflow_http_clients: list[HttpClients] = []
+
+
+def set_processing_workflow_http_clients(http: HttpClients | None) -> None:
+    _workflow_http_clients.clear()
+    if http is not None:
+        _workflow_http_clients.append(http)
+
+
+def get_processing_workflow_http_clients() -> HttpClients:
+    if not _workflow_http_clients:
+        msg = "processing workflow HTTP clients have not been initialized"
+        raise RuntimeError(msg)
+    return _workflow_http_clients[0]
+
+
+async def run_processing_workflow_payload(
+    payload: dict[str, Any], http: HttpClients, session: AsyncSession
+) -> dict[str, str]:
+    params = ProcessingWorkflowPayload.model_validate(payload)
+    user = await session.get(User, params.uid)
+    operation = await session.get(ProcessingOperation, params.operation_id)
+    if user is None or operation is None:
+        msg = "processing workflow references missing user or operation"
+        raise RuntimeError(msg)
+
+    await mark_processing_operation_running(session, operation)
+    await session.commit()
+
+    async def should_continue() -> bool:
+        return await processing_operation_is_active(session, operation.operation_id)
+
+    saw_error = False
+    async for event in run_processing(http, user, should_continue=should_continue):
+        if isinstance(event, ErrorData):
+            saw_error = True
+        await append_processing_event(session, operation, event)
+        await session.commit()
+
+    await session.refresh(operation)
+    if operation.status == "stale":
+        return {"operation_id": operation.operation_id, "status": "stale"}
+
+    status = "failed" if saw_error else "succeeded"
+    await complete_processing_operation(session, operation, status=status)
+    await session.commit()
+
+    if not saw_error:
+        for aid in user.album_ids:
+            schedule_album_route_enrichment(http, user.id, aid)
+
+    return {"operation_id": operation.operation_id, "status": status}
+
+
+@DBOS.workflow(name="processing.upload")
+async def processing_upload_workflow(payload: dict[str, Any]) -> dict[str, str]:
+    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+        return await run_processing_workflow_payload(
+            payload, get_processing_workflow_http_clients(), session
+        )
+
+
+def start_processing_workflow(operation: ProcessingOperation, user: User) -> object:
+    with SetWorkflowID(operation.workflow_id):
+        return DBOS.start_workflow(
+            processing_upload_workflow,
+            processing_workflow_payload(operation, user),
+        )

--- a/backend/app/logic/workflows/recovery.py
+++ b/backend/app/logic/workflows/recovery.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import os
 import socket
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Protocol
 from urllib.parse import urlparse
@@ -14,11 +16,17 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.db import get_engine
+from app.core.locks import try_advisory_lock
 from app.models.processing import WorkflowExecutorHeartbeat
 
 logger = structlog.get_logger(__name__)
 
 WORKFLOW_RECOVERY_PATH = "/dbos-workflow-recovery"
+
+
+@dataclass
+class WorkflowAdminState:
+    has_admin_server: bool = False
 
 
 class WorkflowRecoverySettings(Protocol):
@@ -123,19 +131,84 @@ async def workflow_heartbeat_once(
 
 
 async def workflow_heartbeat_loop(
-    settings: WorkflowRecoverySettings, *, has_admin_server: bool
+    settings: WorkflowRecoverySettings, *, has_admin_server: bool | Callable[[], bool]
 ) -> None:
     while True:
         try:
             async with AsyncSession(get_engine(), expire_on_commit=False) as session:
                 await workflow_heartbeat_once(
-                    session, settings, has_admin_server=has_admin_server
+                    session,
+                    settings,
+                    has_admin_server=(
+                        has_admin_server()
+                        if callable(has_admin_server)
+                        else has_admin_server
+                    ),
                 )
                 await session.commit()
         except asyncio.CancelledError:
             raise
         except OSError, SQLAlchemyError, TimeoutError, ValueError:
             logger.warning("workflow.heartbeat_failed", exc_info=True)
+        await asyncio.sleep(settings.DBOS_RECOVERY_INTERVAL_SECONDS)
+
+
+async def workflow_admin_election_once(
+    state: WorkflowAdminState,
+    *,
+    lock_acquired: bool,
+    promote_to_admin: Callable[[], Awaitable[None]],
+    recover_once: Callable[[], Awaitable[None]],
+) -> None:
+    if not lock_acquired:
+        return
+    if not state.has_admin_server:
+        await promote_to_admin()
+        state.has_admin_server = True
+    await recover_once()
+
+
+async def workflow_admin_election_loop(
+    settings: WorkflowRecoverySettings,
+    state: WorkflowAdminState,
+    *,
+    promote_to_admin: Callable[[], Awaitable[None]],
+) -> None:
+    async def recover_once() -> None:
+        async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+            recovered = await recover_dead_workflow_executors(session, settings)
+            await session.commit()
+            if recovered:
+                logger.info(
+                    "workflow.recovered", recovered_workflow_count=len(recovered)
+                )
+
+    while True:
+        try:
+            async with try_advisory_lock("dbos-admin") as acquired:
+                if acquired:
+                    await workflow_admin_election_once(
+                        state,
+                        lock_acquired=True,
+                        promote_to_admin=promote_to_admin,
+                        recover_once=recover_once,
+                    )
+                    while True:
+                        await asyncio.sleep(settings.DBOS_RECOVERY_INTERVAL_SECONDS)
+                        await workflow_admin_election_once(
+                            state,
+                            lock_acquired=True,
+                            promote_to_admin=promote_to_admin,
+                            recover_once=recover_once,
+                        )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "workflow.admin_election_failed",
+                error_type=type(exc).__name__,
+                exc_info=True,
+            )
         await asyncio.sleep(settings.DBOS_RECOVERY_INTERVAL_SECONDS)
 
 

--- a/backend/app/logic/workflows/recovery.py
+++ b/backend/app/logic/workflows/recovery.py
@@ -114,7 +114,9 @@ async def recover_dead_workflow_executors(
     )
     if not dead_executor_ids:
         return []
-    return recover_workflows_via_admin(admin_base_url, dead_executor_ids)
+    return await asyncio.to_thread(
+        recover_workflows_via_admin, admin_base_url, dead_executor_ids
+    )
 
 
 async def workflow_heartbeat_once(

--- a/backend/app/logic/workflows/recovery.py
+++ b/backend/app/logic/workflows/recovery.py
@@ -1,0 +1,156 @@
+import asyncio
+import json
+import os
+import socket
+from datetime import UTC, datetime, timedelta
+from typing import Protocol
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+import structlog
+from sqlalchemy import update
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.db import get_engine
+from app.models.processing import WorkflowExecutorHeartbeat
+
+logger = structlog.get_logger(__name__)
+
+WORKFLOW_RECOVERY_PATH = "/dbos-workflow-recovery"
+
+
+class WorkflowRecoverySettings(Protocol):
+    DBOS_EXECUTOR_ID: str | None
+    DBOS_ADMIN_PORT: int
+    DBOS_HEARTBEAT_TTL_SECONDS: float
+    DBOS_RECOVERY_INTERVAL_SECONDS: float
+
+
+def workflow_admin_base_url(settings: WorkflowRecoverySettings) -> str:
+    return f"http://127.0.0.1:{settings.DBOS_ADMIN_PORT}"
+
+
+def workflow_executor_id(settings: WorkflowRecoverySettings) -> str:
+    if settings.DBOS_EXECUTOR_ID:
+        return settings.DBOS_EXECUTOR_ID
+    return f"{socket.gethostname()}-{os.getpid()}"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+async def record_workflow_executor_heartbeat(
+    session: AsyncSession, *, executor_id: str, admin_base_url: str | None
+) -> None:
+    row = await session.get(WorkflowExecutorHeartbeat, executor_id)
+    if row is None:
+        row = WorkflowExecutorHeartbeat(
+            executor_id=executor_id, admin_base_url=admin_base_url or ""
+        )
+    row.admin_base_url = admin_base_url or ""
+    row.status = "active"
+    row.last_seen_at = _now()
+    session.add(row)
+    await session.flush()
+
+
+async def list_dead_workflow_executors(
+    session: AsyncSession, *, stale_after: timedelta
+) -> list[str]:
+    cutoff = _now() - stale_after
+    rows = (
+        await session.exec(
+            select(WorkflowExecutorHeartbeat)
+            .where(col(WorkflowExecutorHeartbeat.status) == "active")
+            .where(col(WorkflowExecutorHeartbeat.last_seen_at) < cutoff)
+            .order_by(col(WorkflowExecutorHeartbeat.executor_id))
+        )
+    ).all()
+    executor_ids = [row.executor_id for row in rows]
+    if executor_ids:
+        await session.exec(
+            update(WorkflowExecutorHeartbeat)
+            .where(col(WorkflowExecutorHeartbeat.executor_id).in_(executor_ids))
+            .values(status="dead")
+        )
+        await session.flush()
+    return executor_ids
+
+
+def recover_workflows_via_admin(
+    admin_base_url: str, executor_ids: list[str]
+) -> list[str]:
+    parsed_url = urlparse(admin_base_url)
+    if parsed_url.scheme not in {"http", "https"}:
+        msg = "DBOS admin URL must use http or https"
+        raise ValueError(msg)
+    request = Request(  # noqa: S310
+        f"{admin_base_url.rstrip('/')}{WORKFLOW_RECOVERY_PATH}",
+        data=json.dumps(executor_ids).encode(),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urlopen(request, timeout=30) as response:  # noqa: S310
+        return list(json.loads(response.read().decode()))
+
+
+async def recover_dead_workflow_executors(
+    session: AsyncSession, settings: WorkflowRecoverySettings
+) -> list[str]:
+    admin_base_url = workflow_admin_base_url(settings)
+    dead_executor_ids = await list_dead_workflow_executors(
+        session, stale_after=timedelta(seconds=settings.DBOS_HEARTBEAT_TTL_SECONDS)
+    )
+    if not dead_executor_ids:
+        return []
+    return recover_workflows_via_admin(admin_base_url, dead_executor_ids)
+
+
+async def workflow_heartbeat_once(
+    session: AsyncSession,
+    settings: WorkflowRecoverySettings,
+    *,
+    has_admin_server: bool,
+) -> None:
+    await record_workflow_executor_heartbeat(
+        session,
+        executor_id=workflow_executor_id(settings),
+        admin_base_url=workflow_admin_base_url(settings) if has_admin_server else None,
+    )
+
+
+async def workflow_heartbeat_loop(
+    settings: WorkflowRecoverySettings, *, has_admin_server: bool
+) -> None:
+    while True:
+        try:
+            async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+                await workflow_heartbeat_once(
+                    session, settings, has_admin_server=has_admin_server
+                )
+                await session.commit()
+        except asyncio.CancelledError:
+            raise
+        except OSError, SQLAlchemyError, TimeoutError, ValueError:
+            logger.warning("workflow.heartbeat_failed", exc_info=True)
+        await asyncio.sleep(settings.DBOS_RECOVERY_INTERVAL_SECONDS)
+
+
+async def workflow_recovery_loop(settings: WorkflowRecoverySettings) -> None:
+    while True:
+        try:
+            async with AsyncSession(get_engine(), expire_on_commit=False) as session:
+                recovered = await recover_dead_workflow_executors(session, settings)
+                await session.commit()
+                if recovered:
+                    logger.info(
+                        "workflow.recovered", recovered_workflow_count=len(recovered)
+                    )
+        except asyncio.CancelledError:
+            raise
+        except OSError, SQLAlchemyError, TimeoutError, ValueError:
+            logger.warning("workflow.recovery_failed", exc_info=True)
+        await asyncio.sleep(settings.DBOS_RECOVERY_INTERVAL_SECONDS)

--- a/backend/app/logic/workflows/runtime.py
+++ b/backend/app/logic/workflows/runtime.py
@@ -1,0 +1,44 @@
+from typing import Any, cast
+
+from dbos import DBOS
+from pydantic import SecretStr
+
+from app.logic.workflows.recovery import workflow_executor_id
+
+
+def _database_url(value: object) -> str:
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return str(value)
+
+
+def dbos_config(
+    settings: Any, *, run_admin_server: bool | None = None
+) -> dict[str, Any]:
+    system_database_url = (
+        settings.DBOS_SYSTEM_DATABASE_URI
+        if settings.DBOS_SYSTEM_DATABASE_URI is not None
+        else settings.SQLALCHEMY_DATABASE_URI
+    )
+    config: dict[str, Any] = {
+        "name": settings.DBOS_APP_NAME,
+        "system_database_url": _database_url(system_database_url),
+        "run_admin_server": (
+            settings.DBOS_RUN_ADMIN_SERVER
+            if run_admin_server is None
+            else run_admin_server
+        ),
+        "admin_port": settings.DBOS_ADMIN_PORT,
+        "log_level": settings.LOG_LEVEL,
+    }
+    config["executor_id"] = workflow_executor_id(settings)
+    return config
+
+
+def launch_dbos(settings: Any, *, run_admin_server: bool | None = None) -> None:
+    DBOS(config=cast("Any", dbos_config(settings, run_admin_server=run_admin_server)))
+    DBOS.launch()
+
+
+def destroy_dbos() -> None:
+    DBOS.destroy(workflow_completion_timeout_sec=5)

--- a/backend/app/logic/workflows/runtime.py
+++ b/backend/app/logic/workflows/runtime.py
@@ -12,13 +12,19 @@ def _database_url(value: object) -> str:
     return str(value)
 
 
+def _database_url_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    url = _database_url(value)
+    return url or None
+
+
 def dbos_config(
     settings: Any, *, run_admin_server: bool | None = None
 ) -> dict[str, Any]:
     system_database_url = (
-        settings.DBOS_SYSTEM_DATABASE_URI
-        if settings.DBOS_SYSTEM_DATABASE_URI is not None
-        else settings.SQLALCHEMY_DATABASE_URI
+        _database_url_or_none(settings.DBOS_SYSTEM_DATABASE_URI)
+        or settings.SQLALCHEMY_DATABASE_URI
     )
     config: dict[str, Any] = {
         "name": settings.DBOS_APP_NAME,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,8 +20,10 @@ from app.core.logging import setup_logging
 from app.core.sentry import setup_sentry
 from app.logic.chunked_upload import upload_store
 from app.logic.export import lifespan as export_lifespan
+from app.logic.external_media.undo import lifespan as undo_lifespan
 from app.logic.media_upgrade.pipeline import cleanup_orphaned_tmp
 from app.logic.pdf import lifespan as pdf_lifespan
+from app.logic.segment_routes import set_route_enrichment_http_clients
 from app.logic.session import cancel_all_sessions
 from app.logic.workflows.processing import set_processing_workflow_http_clients
 from app.logic.workflows.recovery import workflow_heartbeat_loop, workflow_recovery_loop
@@ -69,15 +71,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             async with (
                 pdf_lifespan() as browser_manager,
                 export_lifespan(),
+                undo_lifespan(),
                 upload_store.lifespan(),
                 lifespan_clients() as http,
             ):
                 app.state.browser_manager = browser_manager
                 app.state.http = http
                 set_processing_workflow_http_clients(http)
+                set_route_enrichment_http_clients(http)
                 try:
                     yield
                 finally:
+                    set_route_enrichment_http_clients(None)
                     set_processing_workflow_http_clients(None)
                     cancel_all_sessions()
         finally:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
+import asyncio
 import shutil
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING
 
 import structlog
@@ -14,6 +15,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from app.api.v1.router import router as v1_router
 from app.core.config import get_settings
 from app.core.http_clients import lifespan_clients
+from app.core.locks import try_advisory_lock
 from app.core.logging import setup_logging
 from app.core.sentry import setup_sentry
 from app.logic.chunked_upload import upload_store
@@ -21,6 +23,9 @@ from app.logic.export import lifespan as export_lifespan
 from app.logic.media_upgrade.pipeline import cleanup_orphaned_tmp
 from app.logic.pdf import lifespan as pdf_lifespan
 from app.logic.session import cancel_all_sessions
+from app.logic.workflows.processing import set_processing_workflow_http_clients
+from app.logic.workflows.recovery import workflow_heartbeat_loop, workflow_recovery_loop
+from app.logic.workflows.runtime import destroy_dbos, launch_dbos
 
 if TYPE_CHECKING:
     from fastapi.routing import APIRoute
@@ -49,18 +54,41 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     else:
         logger.warning("ffmpeg.missing")
 
-    async with (
-        pdf_lifespan() as browser_manager,
-        export_lifespan(),
-        upload_store.lifespan(),
-        lifespan_clients() as http,
-    ):
-        app.state.browser_manager = browser_manager
-        app.state.http = http
+    async with try_advisory_lock("dbos-admin") as admin_lock_acquired:
+        has_admin_server = settings.DBOS_RUN_ADMIN_SERVER and admin_lock_acquired
+        launch_dbos(settings, run_admin_server=has_admin_server)
+        heartbeat_task = asyncio.create_task(
+            workflow_heartbeat_loop(settings, has_admin_server=has_admin_server)
+        )
+        recovery_task = (
+            asyncio.create_task(workflow_recovery_loop(settings))
+            if has_admin_server
+            else None
+        )
         try:
-            yield
+            async with (
+                pdf_lifespan() as browser_manager,
+                export_lifespan(),
+                upload_store.lifespan(),
+                lifespan_clients() as http,
+            ):
+                app.state.browser_manager = browser_manager
+                app.state.http = http
+                set_processing_workflow_http_clients(http)
+                try:
+                    yield
+                finally:
+                    set_processing_workflow_http_clients(None)
+                    cancel_all_sessions()
         finally:
-            cancel_all_sessions()
+            heartbeat_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await heartbeat_task
+            if recovery_task is not None:
+                recovery_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await recovery_task
+            destroy_dbos()
 
 
 app = FastAPI(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,12 @@ from app.logic.pdf import lifespan as pdf_lifespan
 from app.logic.segment_routes import set_route_enrichment_http_clients
 from app.logic.session import cancel_all_sessions
 from app.logic.workflows.processing import set_processing_workflow_http_clients
-from app.logic.workflows.recovery import workflow_heartbeat_loop, workflow_recovery_loop
+from app.logic.workflows.recovery import (
+    WorkflowAdminState,
+    workflow_admin_election_loop,
+    workflow_heartbeat_loop,
+    workflow_recovery_loop,
+)
 from app.logic.workflows.runtime import destroy_dbos, launch_dbos
 
 if TYPE_CHECKING:
@@ -57,14 +62,35 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         logger.warning("ffmpeg.missing")
 
     async with try_advisory_lock("dbos-admin") as admin_lock_acquired:
-        has_admin_server = settings.DBOS_RUN_ADMIN_SERVER and admin_lock_acquired
-        launch_dbos(settings, run_admin_server=has_admin_server)
+        admin_state = WorkflowAdminState(
+            has_admin_server=settings.DBOS_RUN_ADMIN_SERVER and admin_lock_acquired
+        )
+        launch_dbos(settings, run_admin_server=admin_state.has_admin_server)
+
+        async def promote_to_admin() -> None:
+            logger.info("workflow.admin_promoted")
+            destroy_dbos()
+            launch_dbos(settings, run_admin_server=True)
+
         heartbeat_task = asyncio.create_task(
-            workflow_heartbeat_loop(settings, has_admin_server=has_admin_server)
+            workflow_heartbeat_loop(
+                settings, has_admin_server=lambda: admin_state.has_admin_server
+            )
         )
         recovery_task = (
             asyncio.create_task(workflow_recovery_loop(settings))
-            if has_admin_server
+            if admin_state.has_admin_server
+            else None
+        )
+        election_task = (
+            asyncio.create_task(
+                workflow_admin_election_loop(
+                    settings,
+                    admin_state,
+                    promote_to_admin=promote_to_admin,
+                )
+            )
+            if settings.DBOS_RUN_ADMIN_SERVER and not admin_state.has_admin_server
             else None
         )
         try:
@@ -93,6 +119,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 recovery_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await recovery_task
+            if election_task is not None:
+                election_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await election_task
             destroy_dbos()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,69 +61,73 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     else:
         logger.warning("ffmpeg.missing")
 
-    async with try_advisory_lock("dbos-admin") as admin_lock_acquired:
-        admin_state = WorkflowAdminState(
-            has_admin_server=settings.DBOS_RUN_ADMIN_SERVER and admin_lock_acquired
-        )
-        launch_dbos(settings, run_admin_server=admin_state.has_admin_server)
-
-        async def promote_to_admin() -> None:
-            logger.info("workflow.admin_promoted")
-            destroy_dbos()
-            launch_dbos(settings, run_admin_server=True)
-
-        heartbeat_task = asyncio.create_task(
-            workflow_heartbeat_loop(
-                settings, has_admin_server=lambda: admin_state.has_admin_server
-            )
-        )
-        recovery_task = (
-            asyncio.create_task(workflow_recovery_loop(settings))
-            if admin_state.has_admin_server
-            else None
-        )
-        election_task = (
-            asyncio.create_task(
-                workflow_admin_election_loop(
-                    settings,
-                    admin_state,
-                    promote_to_admin=promote_to_admin,
-                )
-            )
-            if settings.DBOS_RUN_ADMIN_SERVER and not admin_state.has_admin_server
-            else None
-        )
+    async with (
+        pdf_lifespan() as browser_manager,
+        export_lifespan(),
+        undo_lifespan(),
+        upload_store.lifespan(),
+        lifespan_clients() as http,
+    ):
+        app.state.browser_manager = browser_manager
+        app.state.http = http
+        set_processing_workflow_http_clients(http)
+        set_route_enrichment_http_clients(http)
         try:
-            async with (
-                pdf_lifespan() as browser_manager,
-                export_lifespan(),
-                undo_lifespan(),
-                upload_store.lifespan(),
-                lifespan_clients() as http,
-            ):
-                app.state.browser_manager = browser_manager
-                app.state.http = http
-                set_processing_workflow_http_clients(http)
-                set_route_enrichment_http_clients(http)
+            async with try_advisory_lock("dbos-admin") as admin_lock_acquired:
+                admin_state = WorkflowAdminState(
+                    has_admin_server=(
+                        settings.DBOS_RUN_ADMIN_SERVER and admin_lock_acquired
+                    )
+                )
+                launch_dbos(settings, run_admin_server=admin_state.has_admin_server)
+
+                async def promote_to_admin() -> None:
+                    logger.info("workflow.admin_promoted")
+                    destroy_dbos()
+                    launch_dbos(settings, run_admin_server=True)
+
+                heartbeat_task = asyncio.create_task(
+                    workflow_heartbeat_loop(
+                        settings,
+                        has_admin_server=lambda: admin_state.has_admin_server,
+                    )
+                )
+                recovery_task = (
+                    asyncio.create_task(workflow_recovery_loop(settings))
+                    if admin_state.has_admin_server
+                    else None
+                )
+                election_task = (
+                    asyncio.create_task(
+                        workflow_admin_election_loop(
+                            settings,
+                            admin_state,
+                            promote_to_admin=promote_to_admin,
+                        )
+                    )
+                    if settings.DBOS_RUN_ADMIN_SERVER
+                    and not admin_state.has_admin_server
+                    else None
+                )
                 try:
                     yield
                 finally:
-                    set_route_enrichment_http_clients(None)
-                    set_processing_workflow_http_clients(None)
-                    cancel_all_sessions()
+                    heartbeat_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await heartbeat_task
+                    if recovery_task is not None:
+                        recovery_task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await recovery_task
+                    if election_task is not None:
+                        election_task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await election_task
+                    destroy_dbos()
         finally:
-            heartbeat_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await heartbeat_task
-            if recovery_task is not None:
-                recovery_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await recovery_task
-            if election_task is not None:
-                election_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await election_task
-            destroy_dbos()
+            set_route_enrichment_http_clients(None)
+            set_processing_workflow_http_clients(None)
+            cancel_all_sessions()
 
 
 app = FastAPI(

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,11 @@ from app.models.album_media import (
     StepPageMedia as StepPageMedia,
     StepUnusedMedia as StepUnusedMedia,
 )
+from app.models.processing import (
+    ProcessingEventRow as ProcessingEventRow,
+    ProcessingOperation as ProcessingOperation,
+    WorkflowExecutorHeartbeat as WorkflowExecutorHeartbeat,
+)
 from app.models.segment import Segment as Segment
 from app.models.step import Step as Step
 from app.models.user import User as User

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,8 +7,10 @@ from app.models.album_media import (
     StepUnusedMedia as StepUnusedMedia,
 )
 from app.models.processing import (
+    ArtifactToken as ArtifactToken,
     ProcessingEventRow as ProcessingEventRow,
     ProcessingOperation as ProcessingOperation,
+    UploadSession as UploadSession,
     WorkflowExecutorHeartbeat as WorkflowExecutorHeartbeat,
 )
 from app.models.segment import Segment as Segment

--- a/backend/app/models/processing.py
+++ b/backend/app/models/processing.py
@@ -93,3 +93,47 @@ class WorkflowExecutorHeartbeat(SQLModel, table=True):
         default_factory=_now,
         sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
     )
+
+
+class UploadSession(SQLModel, table=True):
+    __tablename__ = "upload_session"
+
+    upload_id: str = Field(primary_key=True, max_length=255)
+    owner: str = Field(max_length=255, index=True)
+    max_bytes: int
+    max_chunks: int
+    accumulated_bytes: int = 0
+    chunks_written: list[int] = Field(
+        default_factory=list,
+        sa_column=Column(PydanticJSON(list[int]), nullable=False),
+    )
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True)
+    )
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class ArtifactToken(SQLModel, table=True):
+    __tablename__ = "artifact_token"
+
+    token: str = Field(primary_key=True, max_length=255)
+    namespace: str = Field(max_length=100, index=True)
+    path: str
+    payload: dict[str, str] = Field(
+        default_factory=dict,
+        sa_column=Column(PydanticJSON(dict[str, str]), nullable=False),
+    )
+    expires_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True)
+    )
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/models/processing.py
+++ b/backend/app/models/processing.py
@@ -3,7 +3,7 @@ from typing import Literal
 from uuid import uuid4
 
 import sqlalchemy as sa
-from sqlalchemy import Column, DateTime, String
+from sqlalchemy import BigInteger, Column, DateTime, String
 from sqlmodel import Field, SQLModel
 
 from app.core.db import PydanticJSON
@@ -100,9 +100,11 @@ class UploadSession(SQLModel, table=True):
 
     upload_id: str = Field(primary_key=True, max_length=255)
     owner: str = Field(max_length=255, index=True)
-    max_bytes: int
+    max_bytes: int = Field(sa_column=Column(BigInteger, nullable=False))
     max_chunks: int
-    accumulated_bytes: int = 0
+    accumulated_bytes: int = Field(
+        default=0, sa_column=Column(BigInteger, nullable=False)
+    )
     chunks_written: list[int] = Field(
         default_factory=list,
         sa_column=Column(PydanticJSON(list[int]), nullable=False),

--- a/backend/app/models/processing.py
+++ b/backend/app/models/processing.py
@@ -1,0 +1,95 @@
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import Column, DateTime, String
+from sqlmodel import Field, SQLModel
+
+from app.core.db import PydanticJSON
+
+ProcessingOperationStatus = Literal[
+    "queued", "running", "succeeded", "failed", "cancelled", "stale"
+]
+WorkflowExecutorStatus = Literal["active", "draining", "dead"]
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def new_operation_id() -> str:
+    return uuid4().hex
+
+
+class ProcessingOperation(SQLModel, table=True):
+    __tablename__ = "processing_operation"
+    __table_args__ = (
+        sa.Index(
+            "ix_processing_operation_uid_generation_created",
+            "uid",
+            "upload_generation",
+            "created_at",
+        ),
+    )
+
+    operation_id: str = Field(default_factory=new_operation_id, primary_key=True)
+    uid: int = Field(foreign_key="user.id", index=True, ondelete="CASCADE")
+    upload_generation: int = Field(index=True)
+    workflow_id: str = Field(unique=True, index=True, max_length=255)
+    status: ProcessingOperationStatus = Field(
+        default="queued",
+        sa_column=Column(String(20), nullable=False, index=True),
+    )
+    started_by_executor_id: str | None = Field(default=None, max_length=255)
+    error_code: str | None = Field(default=None, max_length=100)
+    started_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class ProcessingEventRow(SQLModel, table=True):
+    __tablename__ = "processing_event"
+
+    operation_id: str = Field(
+        foreign_key="processing_operation.operation_id",
+        primary_key=True,
+        ondelete="CASCADE",
+    )
+    seq: int = Field(primary_key=True)
+    event_type: str = Field(max_length=50, index=True)
+    payload: dict[str, object] = Field(
+        sa_column=Column(PydanticJSON(dict), nullable=False)
+    )
+    created_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class WorkflowExecutorHeartbeat(SQLModel, table=True):
+    __tablename__ = "workflow_executor_heartbeat"
+
+    executor_id: str = Field(primary_key=True, max_length=255)
+    admin_base_url: str = Field(max_length=500)
+    status: WorkflowExecutorStatus = Field(
+        default="active",
+        sa_column=Column(String(20), nullable=False, index=True),
+    )
+    last_seen_at: datetime = Field(
+        default_factory=_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )

--- a/backend/app/services/open_meteo.py
+++ b/backend/app/services/open_meteo.py
@@ -10,9 +10,8 @@ from itertools import batched
 from typing import Protocol
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
-from app.core.async_helpers import yield_completed
 from app.models.polarsteps import HasLatLon
 from app.models.weather import Weather, WeatherData
 
@@ -37,6 +36,8 @@ class _ElevationResult(BaseModel):
 
 
 OPEN_METEO_MAX_PER_REQUEST = 100
+OPEN_METEO_WEATHER_MAX_PER_REQUEST = 100
+OPEN_METEO_WEATHER_MAX_DAYS = 14
 
 
 async def elevations(
@@ -118,6 +119,9 @@ class _LocationResult(BaseModel):
     daily: _DailyData
 
 
+_LOCATION_RESULTS = TypeAdapter(list[_LocationResult])
+
+
 def _weather_from_result(step: _StepLike, loc: _LocationResult) -> Weather | None:
     """Extract weather for a specific step's date from a location result."""
     date_str = str(step.datetime.date())
@@ -140,41 +144,90 @@ def _weather_from_result(step: _StepLike, loc: _LocationResult) -> Weather | Non
     )
 
 
-async def _fetch_one(client: httpx.AsyncClient, step: _StepLike) -> Weather:
-    """Fetch weather for a single step.  Raises on failure."""
-    date_str = str(step.datetime.date())
+async def _fetch_batch(
+    client: httpx.AsyncClient, steps: Sequence[_StepLike]
+) -> list[Weather]:
+    start_date = min(step.datetime.date() for step in steps)
+    end_date = max(step.datetime.date() for step in steps)
     try:
         response = await client.get(
             "https://archive-api.open-meteo.com/v1/archive",
             params={
-                "latitude": round(step.location.lat, 2),
-                "longitude": round(step.location.lon, 2),
-                "start_date": date_str,
-                "end_date": date_str,
+                "latitude": ",".join(
+                    str(round(step.location.lat, 2)) for step in steps
+                ),
+                "longitude": ",".join(
+                    str(round(step.location.lon, 2)) for step in steps
+                ),
+                "start_date": str(start_date),
+                "end_date": str(end_date),
                 "daily": _DAILY_FIELDS,
                 "timezone": "auto",
             },
         )
         response.raise_for_status()
     except httpx.HTTPError as e:
-        msg = f"Weather API error for {step.location.detail}"
+        locations = ", ".join(step.location.detail for step in steps)
+        msg = f"Weather API error for {locations}"
         raise RuntimeError(msg) from e
-    result = _LocationResult.model_validate_json(response.content)
-    weather = _weather_from_result(step, result)
-    if weather is None:
-        msg = f"No weather data for {step.location.detail} on {date_str}"
-        raise RuntimeError(msg)
-    return weather
+
+    if len(steps) == 1:
+        results = [_LocationResult.model_validate_json(response.content)]
+    else:
+        results = _LOCATION_RESULTS.validate_json(response.content)
+
+    weathers: list[Weather] = []
+    for step, result in zip(steps, results, strict=True):
+        weather = _weather_from_result(step, result)
+        if weather is None:
+            msg = (
+                f"No weather data for {step.location.detail} on {step.datetime.date()}"
+            )
+            raise RuntimeError(msg)
+        weathers.append(weather)
+    return weathers
 
 
 async def build_weathers(
     client: httpx.AsyncClient,
     steps: Sequence[_StepLike],
 ) -> AsyncIterator[tuple[int, Weather]]:
-    """Yield (index, weather) as each completes (concurrent, unordered)."""
+    """Yield (index, weather) using bounded Open-Meteo archive batches."""
+    for indexed_batch in _weather_batches(steps):
+        weathers = await _fetch_batch(client, [step for _idx, step in indexed_batch])
+        for (idx, _step), weather in zip(indexed_batch, weathers, strict=True):
+            yield idx, weather
 
-    async def _one(idx: int, step: _StepLike) -> tuple[int, Weather]:
-        return idx, await _fetch_one(client, step)
 
-    async for result in yield_completed(_one(i, s) for i, s in enumerate(steps)):
-        yield result
+def _weather_batches(
+    steps: Sequence[_StepLike],
+) -> list[list[tuple[int, _StepLike]]]:
+    batches: list[list[tuple[int, _StepLike]]] = []
+    batch: list[tuple[int, _StepLike]] = []
+    batch_start = batch_end = None
+
+    for idx, step in enumerate(steps):
+        step_date = step.datetime.date()
+        if batch_start is None or batch_end is None:
+            batch = [(idx, step)]
+            batch_start = batch_end = step_date
+            continue
+
+        next_start = min(batch_start, step_date)
+        next_end = max(batch_end, step_date)
+        date_count = (next_end - next_start).days + 1
+        if (
+            len(batch) >= OPEN_METEO_WEATHER_MAX_PER_REQUEST
+            or date_count > OPEN_METEO_WEATHER_MAX_DAYS
+        ):
+            batches.append(batch)
+            batch = [(idx, step)]
+            batch_start = batch_end = step_date
+        else:
+            batch.append((idx, step))
+            batch_start = next_start
+            batch_end = next_end
+
+    if batch:
+        batches.append(batch)
+    return batches

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "anyio~=4.13",
     "structlog~=25.0",
     "asgi-correlation-id~=5.0",
+    "dbos>=2.22.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -407,7 +407,7 @@ class TestDownloadPdf:
 
         with patch(
             "app.api.v1.routes.albums.pop_pdf_token",
-            return_value=(pdf_path, "my-album"),
+            new=AsyncMock(return_value=(pdf_path, "my-album")),
         ):
             resp = await album_routes.download_pdf("valid-token")
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from app.core.config import get_settings
+from app.logic.processing_operations import create_processing_operation
 from app.logic.upload import TripMeta
 
 from .factories import (
@@ -16,6 +18,9 @@ from .factories import (
     mock_jwt,
 )
 from .helpers.users import UserRoutes
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 @pytest.mark.parametrize(
@@ -126,6 +131,25 @@ class TestUpload:
         assert resp.status_code == 200
         user = resp.json()["user"]
         assert user["first_name"] == "Zip"
+
+    @pytest.mark.usefixtures("uploaded_user")
+    async def test_reupload_marks_active_processing_stale(
+        self,
+        user_routes: UserRoutes,
+        users_dir: Path,
+        session: AsyncSession,
+        uploaded_user: dict,
+    ) -> None:
+        operation = await create_processing_operation(
+            session, uid=uploaded_user["id"], upload_generation=1
+        )
+        await session.flush()
+
+        resp = await user_routes.upload_with_extract(users_dir)
+
+        assert resp.status_code == 200
+        await session.refresh(operation)
+        assert operation.status == "stale"
 
     @pytest.mark.usefixtures("uploaded_user")
     async def test_reupload_updates_trips(

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -205,6 +205,16 @@ class TestAssemble:
 
         assert _assembled_bytes(store, upload_id) == b"real"
 
+    async def test_assemble_ignores_uncommitted_final_chunk(
+        self, store: UploadStore
+    ) -> None:
+        upload_id = store.create(MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(upload_id, 0, _one(b"committed"))
+        session_dir = store._upload_dir(upload_id)
+        (session_dir / "0001").write_bytes(b"STALE")
+
+        assert _assembled_bytes(store, upload_id) == b"committed"
+
 
 class TestEviction:
     async def test_expired_session_is_cleaned_up(self, tmp_path: Path) -> None:

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -2,11 +2,17 @@ import asyncio
 import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.requests import ClientDisconnect
 
 from app.logic.chunked_upload import UploadStore
+from app.models.processing import UploadSession
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
 
 MAX_BYTES = 1024 * 1024
 OWNER = "test"
@@ -21,8 +27,10 @@ async def _chunks(count: int, size: int = 1024 * 1024) -> AsyncIterator[bytes]:
         yield b"\x00" * size
 
 
-def _assembled_bytes(store: UploadStore, upload_id: str) -> bytes:
-    assembled, _ = store.assemble(upload_id, owner=OWNER)
+async def _assembled_bytes(
+    store: UploadStore, session: AsyncSession, upload_id: str
+) -> bytes:
+    assembled, _ = await store.assemble(session, upload_id, owner=OWNER)
     try:
         return assembled.read()
     finally:
@@ -38,222 +46,272 @@ async def store(tmp_path: Path) -> AsyncIterator[UploadStore]:
 
 class TestWriteChunkStream:
     async def test_chunks_can_continue_on_another_store_instance(
-        self, tmp_path: Path
+        self, tmp_path: Path, session: AsyncSession
     ) -> None:
         base = tmp_path / "chunked-uploads"
         first = UploadStore(base=base)
         second = UploadStore(base=base)
 
         async with first.lifespan(), second.lifespan():
-            upload_id = first.create(MAX_BYTES, owner=OWNER)
-            await second.write_chunk_stream(upload_id, 0, _one(b"hello"))
+            upload_id = await first.create(session, MAX_BYTES, owner=OWNER)
+            await second.write_chunk_stream(session, upload_id, 0, _one(b"hello"))
 
-            assert _assembled_bytes(second, upload_id) == b"hello"
+            assert await _assembled_bytes(second, session, upload_id) == b"hello"
 
-    async def test_writes_stream_to_disk(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+    async def test_writes_stream_to_disk(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
 
-        await store.write_chunk_stream(upload_id, 0, _one(b"hello world"))
-        assert _assembled_bytes(store, upload_id) == b"hello world"
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"hello world"))
+        assert await _assembled_bytes(store, session, upload_id) == b"hello world"
+
+    async def test_upload_metadata_is_stored_in_db_not_json_manifest(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"hello"))
+
+        row = await session.get(UploadSession, upload_id)
+        assert row is not None
+        assert row.owner == OWNER
+        assert row.chunks_written == [0]
+        assert not (store._upload_dir(upload_id) / "upload.json").exists()
 
     @pytest.mark.parametrize("index", [-1, 10_000])
     async def test_rejects_out_of_range_index(
-        self, store: UploadStore, index: int
+        self, store: UploadStore, session: AsyncSession, index: int
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
         with pytest.raises(ValueError, match="out of range"):
-            await store.write_chunk_stream(upload_id, index, _one(b"x"))
+            await store.write_chunk_stream(session, upload_id, index, _one(b"x"))
 
     async def test_rejects_chunk_exceeding_limit_mid_stream(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
 
         with pytest.raises(ValueError, match="exceeds"):
-            await store.write_chunk_stream(upload_id, 0, _chunks(81))
+            await store.write_chunk_stream(session, upload_id, 0, _chunks(81))
 
-    async def test_tempfile_cleaned_up_on_error(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+    async def test_tempfile_cleaned_up_on_error(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
 
         with pytest.raises(ValueError, match="exceeds"):
-            await store.write_chunk_stream(upload_id, 0, _chunks(81))
+            await store.write_chunk_stream(session, upload_id, 0, _chunks(81))
 
         session_dir = store._upload_dir(upload_id)
         assert list(session_dir.glob("*.part")) == []
 
-    async def test_rejects_accumulated_overflow(self, store: UploadStore) -> None:
-        upload_id = store.create(100, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
+    async def test_rejects_accumulated_overflow(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, 100, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"\x00" * 90))
 
         with pytest.raises(OverflowError):
-            await store.write_chunk_stream(upload_id, 1, _one(b"\x00" * 20))
+            await store.write_chunk_stream(session, upload_id, 1, _one(b"\x00" * 20))
 
-    async def test_rejects_too_many_chunks(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"a"))
-        await store.write_chunk_stream(upload_id, 1, _one(b"b"))
+    async def test_rejects_too_many_chunks(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"a"))
+        await store.write_chunk_stream(session, upload_id, 1, _one(b"b"))
         with pytest.raises(ValueError, match="Too many chunks"):
-            await store.write_chunk_stream(upload_id, 2, _one(b"c"))
+            await store.write_chunk_stream(session, upload_id, 2, _one(b"c"))
 
     async def test_retry_not_falsely_rejected_by_overflow(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession
     ) -> None:
-        upload_id = store.create(100, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 90))
-        await store.write_chunk_stream(upload_id, 0, _one(b"\x00" * 11))
+        upload_id = await store.create(session, 100, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"\x00" * 90))
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"\x00" * 11))
 
-    async def test_idempotent_retry_adjusts_size(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"hello"))
-        await store.write_chunk_stream(upload_id, 0, _one(b"world!"))
-        assert _assembled_bytes(store, upload_id) == b"world!"
+    async def test_idempotent_retry_adjusts_size(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"hello"))
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"world!"))
+        assert await _assembled_bytes(store, session, upload_id) == b"world!"
 
     async def test_idempotent_retry_does_not_count_toward_chunk_limit(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"a"))
-        await store.write_chunk_stream(upload_id, 0, _one(b"a"))
-        await store.write_chunk_stream(upload_id, 1, _one(b"b"))
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"a"))
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"a"))
+        await store.write_chunk_stream(session, upload_id, 1, _one(b"b"))
 
-    async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
+    async def test_unknown_session_raises_key_error(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
         with pytest.raises(KeyError):
-            await store.write_chunk_stream("nonexistent", 0, _one(b"x"))
+            await store.write_chunk_stream(session, "nonexistent", 0, _one(b"x"))
 
-    async def test_client_disconnect_propagates(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+    async def test_client_disconnect_propagates(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
 
         async def gen() -> AsyncIterator[bytes]:
             yield b"partial"
             raise ClientDisconnect
 
         with pytest.raises(ClientDisconnect):
-            await store.write_chunk_stream(upload_id, 0, gen())
+            await store.write_chunk_stream(session, upload_id, 0, gen())
 
         session_dir = store._upload_dir(upload_id)
         assert list(session_dir.glob("*.part")) == []
 
     async def test_concurrent_same_index_writes_do_not_corrupt(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession, engine: AsyncEngine
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await session.commit()
+
+        async def write(data: bytes) -> None:
+            async with AsyncSession(engine, expire_on_commit=False) as write_session:
+                await store.write_chunk_stream(write_session, upload_id, 0, _one(data))
+                await write_session.commit()
 
         await asyncio.gather(
-            store.write_chunk_stream(upload_id, 0, _one(b"AAAA")),
-            store.write_chunk_stream(upload_id, 0, _one(b"BBBB")),
+            write(b"AAAA"),
+            write(b"BBBB"),
         )
 
-        assert _assembled_bytes(store, upload_id) in (b"AAAA", b"BBBB")
+        assert await _assembled_bytes(store, session, upload_id) in (b"AAAA", b"BBBB")
 
-    async def test_concurrent_different_index_writes(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+    async def test_concurrent_different_index_writes(
+        self, store: UploadStore, session: AsyncSession, engine: AsyncEngine
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await session.commit()
+
+        async def write(index: int, data: bytes) -> None:
+            async with AsyncSession(engine, expire_on_commit=False) as write_session:
+                await store.write_chunk_stream(
+                    write_session, upload_id, index, _one(data)
+                )
+                await write_session.commit()
 
         await asyncio.gather(
-            store.write_chunk_stream(upload_id, 0, _one(b"AAA")),
-            store.write_chunk_stream(upload_id, 1, _one(b"BBB")),
-            store.write_chunk_stream(upload_id, 2, _one(b"CCC")),
+            write(0, b"AAA"),
+            write(1, b"BBB"),
         )
 
-        assert _assembled_bytes(store, upload_id) == b"AAABBBCCC"
+        assert await _assembled_bytes(store, session, upload_id) == b"AAABBB"
 
 
 class TestAssemble:
-    async def test_chunks_concatenated_in_order(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 1, _one(b"BBB"))
-        await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
+    async def test_chunks_concatenated_in_order(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 1, _one(b"BBB"))
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"AAA"))
 
-        assert _assembled_bytes(store, upload_id) == b"AAABBB"
+        assert await _assembled_bytes(store, session, upload_id) == b"AAABBB"
 
-    async def test_no_chunks_raises(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+    async def test_no_chunks_raises(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
         with pytest.raises(ValueError, match="No chunks"):
-            store.assemble(upload_id, owner=OWNER)
+            await store.assemble(session, upload_id, owner=OWNER)
 
-    async def test_unknown_session_raises_key_error(self, store: UploadStore) -> None:
+    async def test_unknown_session_raises_key_error(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
         with pytest.raises(KeyError):
-            store.assemble("nonexistent", owner=OWNER)
+            await store.assemble(session, "nonexistent", owner=OWNER)
 
-    async def test_session_removed_after_assemble(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"x"))
-        assembled, _ = store.assemble(upload_id, owner=OWNER)
+    async def test_session_removed_after_assemble(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"x"))
+        assembled, _ = await store.assemble(session, upload_id, owner=OWNER)
         assembled.close()
         with pytest.raises(KeyError):
-            store.assemble(upload_id, owner=OWNER)
+            await store.assemble(session, upload_id, owner=OWNER)
 
     async def test_wrong_owner_raises_permission_error(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner="alice")
-        await store.write_chunk_stream(upload_id, 0, _one(b"x"))
+        upload_id = await store.create(session, MAX_BYTES, owner="alice")
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"x"))
         with pytest.raises(PermissionError, match="different user"):
-            store.assemble(upload_id, owner="bob")
+            await store.assemble(session, upload_id, owner="bob")
 
-    async def test_non_contiguous_chunks_raises(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"AAA"))
-        await store.write_chunk_stream(upload_id, 2, _one(b"CCC"))
+    async def test_non_contiguous_chunks_raises(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"AAA"))
+        await store.write_chunk_stream(session, upload_id, 2, _one(b"CCC"))
         with pytest.raises(ValueError, match="not contiguous"):
-            store.assemble(upload_id, owner=OWNER)
+            await store.assemble(session, upload_id, owner=OWNER)
 
-    async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"real"))
+    async def test_assemble_ignores_orphan_part_files(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"real"))
         session_dir = store._upload_dir(upload_id)
         (session_dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
 
-        assert _assembled_bytes(store, upload_id) == b"real"
+        assert await _assembled_bytes(store, session, upload_id) == b"real"
 
     async def test_assemble_ignores_uncommitted_final_chunk(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
-        await store.write_chunk_stream(upload_id, 0, _one(b"committed"))
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+        await store.write_chunk_stream(session, upload_id, 0, _one(b"committed"))
         session_dir = store._upload_dir(upload_id)
         (session_dir / "0001").write_bytes(b"STALE")
 
-        assert _assembled_bytes(store, upload_id) == b"committed"
+        assert await _assembled_bytes(store, session, upload_id) == b"committed"
 
 
 class TestEviction:
-    async def test_expired_session_is_cleaned_up(self, tmp_path: Path) -> None:
+    async def test_expired_session_is_cleaned_up(
+        self, tmp_path: Path, session: AsyncSession
+    ) -> None:
         store = UploadStore(base=tmp_path / "chunked-uploads")
         async with store.lifespan():
-            upload_id = store.create(MAX_BYTES, owner=OWNER)
-            await store.write_chunk_stream(upload_id, 0, _one(b"data"))
+            upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+            await store.write_chunk_stream(session, upload_id, 0, _one(b"data"))
 
-            store._evict(upload_id)
+            await store._evict(session, upload_id)
 
             with pytest.raises(KeyError):
-                store.assemble(upload_id, owner=OWNER)
+                await store.assemble(session, upload_id, owner=OWNER)
 
-    async def test_abandoned_session_expires_while_backend_keeps_running(
-        self, tmp_path: Path
+    async def test_abandoned_session_expires_when_cleanup_runs(
+        self, tmp_path: Path, session: AsyncSession
     ) -> None:
-        store = UploadStore(
-            base=tmp_path / "chunked-uploads",
-            cleanup_interval=0.01,
-        )
+        store = UploadStore(base=tmp_path / "chunked-uploads")
         async with store.lifespan():
-            upload_id = store.create(MAX_BYTES, owner=OWNER)
-            upload_dir = store._upload_dir(upload_id)
-            manifest = store._read_manifest(upload_dir)
-            manifest["expires_at"] = 0
-            store._write_manifest(upload_dir, manifest)
+            upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+            row = await session.get_one(UploadSession, upload_id)
+            row.expires_at = row.created_at
+            session.add(row)
+            await session.flush()
 
-            for _ in range(10):
-                if not upload_dir.exists():
-                    break
-                await asyncio.sleep(0.01)
+            await store.cleanup_expired(session)
 
             with pytest.raises(KeyError):
-                store.assemble(upload_id, owner=OWNER)
+                await store.assemble(session, upload_id, owner=OWNER)
 
     async def test_eviction_during_write_surfaces_as_key_error(
-        self, store: UploadStore
+        self, store: UploadStore, session: AsyncSession
     ) -> None:
-        upload_id = store.create(MAX_BYTES, owner=OWNER)
+        upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
         session_dir = store._upload_dir(upload_id)
 
         async def gen() -> AsyncIterator[bytes]:
@@ -261,4 +319,4 @@ class TestEviction:
             yield b"doomed"
 
         with pytest.raises(KeyError):
-            await store.write_chunk_stream(upload_id, 0, gen())
+            await store.write_chunk_stream(session, upload_id, 0, gen())

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -37,6 +37,19 @@ async def store(tmp_path: Path) -> AsyncIterator[UploadStore]:
 
 
 class TestWriteChunkStream:
+    async def test_chunks_can_continue_on_another_store_instance(
+        self, tmp_path: Path
+    ) -> None:
+        base = tmp_path / "chunked-uploads"
+        first = UploadStore(base=base)
+        second = UploadStore(base=base)
+
+        async with first.lifespan(), second.lifespan():
+            upload_id = first.create(MAX_BYTES, owner=OWNER)
+            await second.write_chunk_stream(upload_id, 0, _one(b"hello"))
+
+            assert _assembled_bytes(second, upload_id) == b"hello"
+
     async def test_writes_stream_to_disk(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner=OWNER)
 
@@ -65,7 +78,7 @@ class TestWriteChunkStream:
         with pytest.raises(ValueError, match="exceeds"):
             await store.write_chunk_stream(upload_id, 0, _chunks(81))
 
-        session_dir = store._sessions[upload_id].dir
+        session_dir = store._upload_dir(upload_id)
         assert list(session_dir.glob("*.part")) == []
 
     async def test_rejects_accumulated_overflow(self, store: UploadStore) -> None:
@@ -117,7 +130,7 @@ class TestWriteChunkStream:
         with pytest.raises(ClientDisconnect):
             await store.write_chunk_stream(upload_id, 0, gen())
 
-        session_dir = store._sessions[upload_id].dir
+        session_dir = store._upload_dir(upload_id)
         assert list(session_dir.glob("*.part")) == []
 
     async def test_concurrent_same_index_writes_do_not_corrupt(
@@ -187,8 +200,8 @@ class TestAssemble:
     async def test_assemble_ignores_orphan_part_files(self, store: UploadStore) -> None:
         upload_id = store.create(MAX_BYTES, owner=OWNER)
         await store.write_chunk_stream(upload_id, 0, _one(b"real"))
-        session = store._sessions[upload_id]
-        (session.dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
+        session_dir = store._upload_dir(upload_id)
+        (session_dir / f"0000.{'ab' * 8}.part").write_bytes(b"STALE")
 
         assert _assembled_bytes(store, upload_id) == b"real"
 
@@ -209,12 +222,10 @@ class TestEviction:
         self, store: UploadStore
     ) -> None:
         upload_id = store.create(MAX_BYTES, owner=OWNER)
-        session = store._sessions[upload_id]
+        session_dir = store._upload_dir(upload_id)
 
         async def gen() -> AsyncIterator[bytes]:
-            shutil.rmtree(session.dir)
-            store._sessions.pop(upload_id)
-            session.timer.cancel()
+            shutil.rmtree(session_dir)
             yield b"doomed"
 
         with pytest.raises(KeyError):

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -218,6 +218,28 @@ class TestEviction:
             with pytest.raises(KeyError):
                 store.assemble(upload_id, owner=OWNER)
 
+    async def test_abandoned_session_expires_while_backend_keeps_running(
+        self, tmp_path: Path
+    ) -> None:
+        store = UploadStore(
+            base=tmp_path / "chunked-uploads",
+            cleanup_interval=0.01,
+        )
+        async with store.lifespan():
+            upload_id = store.create(MAX_BYTES, owner=OWNER)
+            upload_dir = store._upload_dir(upload_id)
+            manifest = store._read_manifest(upload_dir)
+            manifest["expires_at"] = 0
+            store._write_manifest(upload_dir, manifest)
+
+            for _ in range(10):
+                if not upload_dir.exists():
+                    break
+                await asyncio.sleep(0.01)
+
+            with pytest.raises(KeyError):
+                store.assemble(upload_id, owner=OWNER)
+
     async def test_eviction_during_write_surfaces_as_key_error(
         self, store: UploadStore
     ) -> None:

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from sqlalchemy import BigInteger
 from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.requests import ClientDisconnect
 
@@ -45,6 +46,20 @@ async def store(tmp_path: Path) -> AsyncIterator[UploadStore]:
 
 
 class TestWriteChunkStream:
+    def test_upload_byte_counts_use_bigint_columns(self) -> None:
+        assert isinstance(UploadSession.__table__.c.max_bytes.type, BigInteger)
+        assert isinstance(UploadSession.__table__.c.accumulated_bytes.type, BigInteger)
+
+    async def test_allows_configured_four_gib_upload_limit(
+        self, store: UploadStore, session: AsyncSession
+    ) -> None:
+        four_gib = 4 * 1024 * 1024 * 1024
+
+        upload_id = await store.create(session, four_gib, owner=OWNER)
+        row = await session.get_one(UploadSession, upload_id)
+
+        assert row.max_bytes == four_gib
+
     async def test_chunks_can_continue_on_another_store_instance(
         self, tmp_path: Path, session: AsyncSession
     ) -> None:

--- a/backend/tests/test_chunked_upload.py
+++ b/backend/tests/test_chunked_upload.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 from sqlalchemy import BigInteger
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.requests import ClientDisconnect
 
@@ -322,6 +324,35 @@ class TestEviction:
 
             with pytest.raises(KeyError):
                 await store.assemble(session, upload_id, owner=OWNER)
+
+    async def test_lifespan_periodically_cleans_abandoned_sessions(
+        self, tmp_path: Path
+    ) -> None:
+        engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'cleanup.db'}")
+        store = UploadStore(base=tmp_path / "chunked-uploads", cleanup_interval=0.01)
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(SQLModel.metadata.create_all)
+            async with store.lifespan(engine=engine):
+                async with AsyncSession(engine, expire_on_commit=False) as session:
+                    upload_id = await store.create(session, MAX_BYTES, owner=OWNER)
+                    await store.write_chunk_stream(session, upload_id, 0, _one(b"data"))
+                    row = await session.get_one(UploadSession, upload_id)
+                    row.expires_at = row.created_at
+                    session.add(row)
+                    await session.commit()
+
+                async def wait_until_deleted() -> None:
+                    async with AsyncSession(engine) as poll:
+                        while await poll.get(UploadSession, upload_id) is not None:
+                            await poll.rollback()
+                            await asyncio.sleep(0.01)
+
+                await asyncio.wait_for(wait_until_deleted(), timeout=1)
+
+                assert not store._upload_dir(upload_id).exists()
+        finally:
+            await engine.dispose()
 
     async def test_eviction_during_write_surfaces_as_key_error(
         self, store: UploadStore, session: AsyncSession

--- a/backend/tests/test_chunked_upload_routes.py
+++ b/backend/tests/test_chunked_upload_routes.py
@@ -14,6 +14,8 @@ from .helpers.users import UserRoutes
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
 
 class TestInitChunkedUpload:
     async def test_returns_upload_id(self, user_routes: UserRoutes) -> None:
@@ -29,6 +31,14 @@ class TestInitChunkedUpload:
 class TestUploadChunk:
     async def test_accepts_valid_chunk(self, user_routes: UserRoutes) -> None:
         upload_id = await user_routes.start_chunked_upload()
+        await user_routes.put_chunk_ok(upload_id, 0, b"chunk-data")
+
+    async def test_init_is_committed_before_chunk_request(
+        self, user_routes: UserRoutes, session: AsyncSession
+    ) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        await session.rollback()
+
         await user_routes.put_chunk_ok(upload_id, 0, b"chunk-data")
 
     async def test_rejects_unknown_session(self, user_routes: UserRoutes) -> None:
@@ -87,6 +97,19 @@ class TestCompleteChunkedUpload:
         body = await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)
         assert body["user"]["id"] == 999
         assert len(body["trips"]) == 1
+
+    async def test_chunk_is_committed_before_complete_request(
+        self,
+        user_routes: UserRoutes,
+        users_dir: Path,
+        session: AsyncSession,
+    ) -> None:
+        upload_id = await user_routes.start_chunked_upload()
+        await user_routes.put_chunk_ok(upload_id, 0, b"fake-zip")
+        await session.rollback()
+
+        body = await user_routes.complete_upload_with_extract_ok(upload_id, users_dir)
+        assert body["user"]["id"] == 999
 
     async def test_rejects_unknown_session(self, user_routes: UserRoutes) -> None:
         await user_routes.sign_in()

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -381,7 +381,7 @@ async def test_run_processing_workflow_payload_exits_when_operation_already_stal
     assert run_calls == 0
 
 
-async def test_recovered_processing_run_does_not_duplicate_persisted_events(
+async def test_recovered_processing_run_skips_nondeterministic_persisted_events(
     session: AsyncSession,
 ) -> None:
     user = User(
@@ -398,11 +398,21 @@ async def test_recovered_processing_run_does_not_duplicate_persisted_events(
     operation = await create_processing_operation(session, uid=42, upload_generation=1)
     await session.commit()
 
+    run_count = 0
+
     async def fake_run_processing(
         _http: object, _user: User, **_kwargs: object
     ) -> AsyncIterator[ProcessingEvent]:
+        nonlocal run_count
+        run_count += 1
         yield TripStart(trip_index=0)
-        yield PhaseUpdate(phase="layouts", done=1, total=1)
+        if run_count == 1:
+            yield PhaseUpdate(phase="weather", done=1, total=2)
+            yield PhaseUpdate(phase="elevations", done=1, total=2)
+        else:
+            yield PhaseUpdate(phase="elevations", done=1, total=2)
+            yield PhaseUpdate(phase="weather", done=1, total=2)
+            yield PhaseUpdate(phase="layouts", done=1, total=1)
 
     with patch("app.logic.workflows.processing.run_processing", fake_run_processing):
         await run_and_persist_processing_events(MagicMock(), user, operation, session)
@@ -412,6 +422,8 @@ async def test_recovered_processing_run_does_not_duplicate_persisted_events(
 
     assert events == [
         TripStart(trip_index=0),
+        PhaseUpdate(phase="weather", done=1, total=2),
+        PhaseUpdate(phase="elevations", done=1, total=2),
         PhaseUpdate(phase="layouts", done=1, total=1),
     ]
 

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -132,6 +132,10 @@ async def test_run_processing_workflow_payload_persists_events_and_succeeds(
         patch(
             "app.logic.workflows.processing.schedule_album_route_enrichment"
         ) as schedule,
+        patch(
+            "app.logic.workflows.processing.workflow_executor_id",
+            return_value="worker-test",
+        ),
     ):
         result = await run_processing_workflow_payload(
             processing_workflow_payload(operation, user),
@@ -144,6 +148,7 @@ async def test_run_processing_workflow_payload_persists_events_and_succeeds(
 
     assert result == {"operation_id": operation.operation_id, "status": "succeeded"}
     assert operation.status == "succeeded"
+    assert operation.started_by_executor_id == "worker-test"
     assert events == [
         TripStart(trip_index=0),
         PhaseUpdate(phase="layouts", done=1, total=1),

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -232,3 +232,44 @@ async def test_run_processing_workflow_payload_preserves_stale_operation(
     await session.refresh(operation)
     assert result == {"operation_id": operation.operation_id, "status": "stale"}
     assert operation.status == "stale"
+
+
+async def test_run_processing_workflow_payload_exits_when_operation_already_stale(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    operation.status = "stale"
+    session.add(operation)
+    await session.commit()
+
+    run_calls = 0
+
+    async def fake_run_processing(
+        _http: object, _user: User, **_kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        nonlocal run_calls
+        run_calls += 1
+        yield ErrorData()
+
+    with patch("app.logic.workflows.processing.run_processing", fake_run_processing):
+        result = await run_processing_workflow_payload(
+            processing_workflow_payload(operation, user),
+            MagicMock(),
+            session,
+        )
+
+    await session.refresh(operation)
+    assert result == {"operation_id": operation.operation_id, "status": "stale"}
+    assert operation.status == "stale"
+    assert run_calls == 0

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -1,0 +1,234 @@
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.logic.processing_operations import (
+    create_processing_operation,
+    read_processing_events,
+)
+from app.logic.trip_processing import ErrorData, PhaseUpdate, ProcessingEvent, TripStart
+from app.logic.workflows.processing import (
+    ProcessingWorkflowPayload,
+    processing_upload_workflow,
+    processing_workflow_payload,
+    run_processing_workflow_payload,
+    start_processing_workflow,
+)
+from app.models.processing import ProcessingOperation
+from app.models.user import User
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+def _operation() -> ProcessingOperation:
+    return ProcessingOperation(
+        operation_id="op_123",
+        uid=42,
+        upload_generation=7,
+        workflow_id="processing:op_123",
+    )
+
+
+def _user() -> User:
+    user = AsyncMock(spec=User)
+    user.id = 42
+    user.album_ids = ["trip-b", "trip-a"]
+    user.trips_folder = "/data/users/42/trips"
+    return user
+
+
+def test_processing_workflow_payload_is_json_serializable() -> None:
+    payload = processing_workflow_payload(_operation(), _user())
+
+    assert payload == {
+        "operation_id": "op_123",
+        "uid": 42,
+        "upload_generation": 7,
+        "trips_folder": "/data/users/42/trips",
+        "album_ids": ["trip-b", "trip-a"],
+    }
+    assert ProcessingWorkflowPayload.model_validate(payload).album_ids == (
+        "trip-b",
+        "trip-a",
+    )
+
+
+def test_start_processing_workflow_uses_operation_workflow_id(
+    monkeypatch: Any,
+) -> None:
+    calls: list[tuple[object, dict[str, Any]]] = []
+    workflow_ids: list[str] = []
+    handle = object()
+
+    class FakeSetWorkflowID:
+        def __init__(self, workflow_id: str) -> None:
+            self.workflow_id = workflow_id
+
+        def __enter__(self) -> None:
+            workflow_ids.append(self.workflow_id)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_start_workflow(func: object, payload: dict[str, Any]) -> object:
+        calls.append((func, payload))
+        return handle
+
+    monkeypatch.setattr(
+        "app.logic.workflows.processing.SetWorkflowID", FakeSetWorkflowID
+    )
+    monkeypatch.setattr(
+        "app.logic.workflows.processing.DBOS.start_workflow",
+        fake_start_workflow,
+    )
+
+    result = start_processing_workflow(_operation(), _user())
+
+    assert result is handle
+    assert workflow_ids == ["processing:op_123"]
+    assert calls == [
+        (
+            processing_upload_workflow,
+            {
+                "operation_id": "op_123",
+                "uid": 42,
+                "upload_generation": 7,
+                "trips_folder": "/data/users/42/trips",
+                "album_ids": ["trip-b", "trip-a"],
+            },
+        )
+    ]
+
+
+async def test_run_processing_workflow_payload_persists_events_and_succeeds(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1", "trip-2"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **_kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        yield TripStart(trip_index=0)
+        yield PhaseUpdate(phase="layouts", done=1, total=1)
+
+    http = MagicMock()
+    with (
+        patch("app.logic.workflows.processing.run_processing", fake_run_processing),
+        patch(
+            "app.logic.workflows.processing.schedule_album_route_enrichment"
+        ) as schedule,
+    ):
+        result = await run_processing_workflow_payload(
+            processing_workflow_payload(operation, user),
+            http,
+            session,
+        )
+
+    await session.refresh(operation)
+    events = await read_processing_events(session, operation.operation_id)
+
+    assert result == {"operation_id": operation.operation_id, "status": "succeeded"}
+    assert operation.status == "succeeded"
+    assert events == [
+        TripStart(trip_index=0),
+        PhaseUpdate(phase="layouts", done=1, total=1),
+    ]
+    assert [call.args for call in schedule.call_args_list] == [
+        (http, 42, "trip-1"),
+        (http, 42, "trip-2"),
+    ]
+
+
+async def test_run_processing_workflow_payload_marks_failed_on_error_event(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **_kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        yield ErrorData()
+
+    with (
+        patch("app.logic.workflows.processing.run_processing", fake_run_processing),
+        patch(
+            "app.logic.workflows.processing.schedule_album_route_enrichment"
+        ) as schedule,
+    ):
+        result = await run_processing_workflow_payload(
+            processing_workflow_payload(operation, user),
+            MagicMock(),
+            session,
+        )
+
+    await session.refresh(operation)
+
+    assert result == {"operation_id": operation.operation_id, "status": "failed"}
+    assert operation.status == "failed"
+    schedule.assert_not_called()
+
+
+async def test_run_processing_workflow_payload_preserves_stale_operation(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        operation.status = "stale"
+        session.add(operation)
+        await session.commit()
+        should_continue = cast(
+            "Callable[[], Awaitable[bool]]", kwargs["should_continue"]
+        )
+        assert await should_continue() is False
+        yield ErrorData()
+
+    with patch("app.logic.workflows.processing.run_processing", fake_run_processing):
+        result = await run_processing_workflow_payload(
+            processing_workflow_payload(operation, user),
+            MagicMock(),
+            session,
+        )
+
+    await session.refresh(operation)
+    assert result == {"operation_id": operation.operation_id, "status": "stale"}
+    assert operation.status == "stale"

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -193,6 +193,51 @@ async def test_run_processing_workflow_payload_marks_failed_on_error_event(
     schedule.assert_not_called()
 
 
+async def test_run_processing_workflow_payload_marks_failed_when_processing_raises(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **_kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        yield TripStart(trip_index=0)
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with (
+        patch("app.logic.workflows.processing.run_processing", fake_run_processing),
+        patch(
+            "app.logic.workflows.processing.schedule_album_route_enrichment"
+        ) as schedule,
+    ):
+        result = await run_processing_workflow_payload(
+            processing_workflow_payload(operation, user),
+            MagicMock(),
+            session,
+        )
+
+    await session.refresh(operation)
+    events = await read_processing_events(session, operation.operation_id)
+
+    assert result == {"operation_id": operation.operation_id, "status": "failed"}
+    assert operation.status == "failed"
+    assert events == [TripStart(trip_index=0), ErrorData()]
+    schedule.assert_not_called()
+
+
 async def test_run_processing_workflow_payload_preserves_stale_operation(
     session: AsyncSession,
 ) -> None:

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -238,6 +238,24 @@ async def test_run_processing_workflow_payload_marks_failed_when_processing_rais
     schedule.assert_not_called()
 
 
+async def test_run_processing_workflow_payload_exits_when_user_was_deleted(
+    session: AsyncSession,
+) -> None:
+    result = await run_processing_workflow_payload(
+        {
+            "operation_id": "deleted-operation",
+            "uid": 42,
+            "upload_generation": 1,
+            "trips_folder": "/deleted",
+            "album_ids": [],
+        },
+        MagicMock(),
+        session,
+    )
+
+    assert result == {"operation_id": "deleted-operation", "status": "cancelled"}
+
+
 async def test_run_processing_workflow_payload_preserves_stale_operation(
     session: AsyncSession,
 ) -> None:

--- a/backend/tests/test_dbos_processing_workflow.py
+++ b/backend/tests/test_dbos_processing_workflow.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.logic.processing_operations import (
+    append_processing_event,
     create_processing_operation,
     read_processing_events,
 )
@@ -11,6 +12,7 @@ from app.logic.workflows.processing import (
     ProcessingWorkflowPayload,
     processing_upload_workflow,
     processing_workflow_payload,
+    run_and_persist_processing_events,
     run_processing_workflow_payload,
     start_processing_workflow,
 )
@@ -238,6 +240,47 @@ async def test_run_processing_workflow_payload_marks_failed_when_processing_rais
     schedule.assert_not_called()
 
 
+async def test_recovered_failed_processing_run_does_not_duplicate_error_event(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    operation.status = "running"
+    session.add(operation)
+    await session.flush()
+    await append_processing_event(session, operation, TripStart(trip_index=0))
+    await append_processing_event(session, operation, ErrorData())
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **_kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        yield TripStart(trip_index=0)
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with patch("app.logic.workflows.processing.run_processing", fake_run_processing):
+        await run_processing_workflow_payload(
+            processing_workflow_payload(operation, user),
+            MagicMock(),
+            session,
+        )
+
+    events = await read_processing_events(session, operation.operation_id)
+
+    assert events == [TripStart(trip_index=0), ErrorData()]
+
+
 async def test_run_processing_workflow_payload_exits_when_user_was_deleted(
     session: AsyncSession,
 ) -> None:
@@ -336,3 +379,76 @@ async def test_run_processing_workflow_payload_exits_when_operation_already_stal
     assert result == {"operation_id": operation.operation_id, "status": "stale"}
     assert operation.status == "stale"
     assert run_calls == 0
+
+
+async def test_recovered_processing_run_does_not_duplicate_persisted_events(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **_kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        yield TripStart(trip_index=0)
+        yield PhaseUpdate(phase="layouts", done=1, total=1)
+
+    with patch("app.logic.workflows.processing.run_processing", fake_run_processing):
+        await run_and_persist_processing_events(MagicMock(), user, operation, session)
+        await run_and_persist_processing_events(MagicMock(), user, operation, session)
+
+    events = await read_processing_events(session, operation.operation_id)
+
+    assert events == [
+        TripStart(trip_index=0),
+        PhaseUpdate(phase="layouts", done=1, total=1),
+    ]
+
+
+async def test_processing_save_guard_marks_operation_succeeded_in_save_transaction(
+    session: AsyncSession,
+) -> None:
+    user = User(
+        id=42,
+        google_sub="google-42",
+        first_name="Test",
+        locale="en-US",
+        unit_is_km=True,
+        temperature_is_celsius=True,
+        album_ids=["trip-1"],
+    )
+    session.add(user)
+    await session.flush()
+    operation = await create_processing_operation(session, uid=42, upload_generation=1)
+    await session.commit()
+
+    async def fake_run_processing(
+        _http: object, _user: User, **kwargs: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        yield TripStart(trip_index=0)
+        save_guard = cast(
+            "Callable[[AsyncSession], Awaitable[bool]]", kwargs["save_guard"]
+        )
+        assert await save_guard(session) is True
+        await session.commit()
+
+    with patch("app.logic.workflows.processing.run_processing", fake_run_processing):
+        saw_error = await run_and_persist_processing_events(
+            MagicMock(), user, operation, session
+        )
+
+    await session.refresh(operation)
+
+    assert saw_error is False
+    assert operation.status == "succeeded"

--- a/backend/tests/test_dbos_recovery_check_script.py
+++ b/backend/tests/test_dbos_recovery_check_script.py
@@ -1,0 +1,80 @@
+import importlib.util
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Self
+from urllib.request import Request
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _load_check_module() -> Any:
+    script_path = Path(__file__).parents[2] / "scripts" / "dbos_recovery_check.py"
+    spec = importlib.util.spec_from_file_location("dbos_recovery_check", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalizes_sqlalchemy_psycopg_url_for_psycopg() -> None:
+    module = _load_check_module()
+
+    assert (
+        module.psycopg_url("postgresql+psycopg://postgres:postgres@localhost/app")
+        == "postgresql://postgres:postgres@localhost/app"
+    )
+    assert (
+        module.psycopg_url("postgresql://postgres:postgres@localhost/app")
+        == "postgresql://postgres:postgres@localhost/app"
+    )
+
+
+def test_dbos_config_uses_postgres_system_schema_and_executor_id() -> None:
+    module = _load_check_module()
+
+    config = module.dbos_recovery_config(
+        "postgresql+psycopg://postgres:postgres@localhost/app",
+        executor_id="worker-b",
+    )
+
+    assert config["name"] == "wanderbound-dbos-check"
+    assert (
+        config["system_database_url"]
+        == "postgresql+psycopg://postgres:postgres@localhost/app"
+    )
+    assert config["executor_id"] == "worker-b"
+    assert config["dbos_system_schema"] == "dbos_recovery_check"
+    assert config["run_admin_server"] is False
+
+
+def test_admin_recovery_posts_executor_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_check_module()
+    calls = []
+
+    class FakeResponse:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(["workflow-1"]).encode()
+
+    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+        calls.append((request, timeout))
+        return FakeResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    assert module.recover_workflows_via_admin(
+        "http://127.0.0.1:3001", ["worker-a"]
+    ) == ["workflow-1"]
+    request, timeout = calls[0]
+    assert request.full_url == "http://127.0.0.1:3001/dbos-workflow-recovery"
+    assert request.method == "POST"
+    assert request.data == b'["worker-a"]'
+    assert request.headers["Content-type"] == "application/json"
+    assert timeout == 30

--- a/backend/tests/test_dbos_runtime.py
+++ b/backend/tests/test_dbos_runtime.py
@@ -1,0 +1,72 @@
+from typing import Any
+from unittest.mock import patch
+
+from pydantic import SecretStr
+
+from app.logic.workflows.runtime import dbos_config, destroy_dbos, launch_dbos
+
+
+class _Settings:
+    DBOS_APP_NAME = "wanderbound"
+    DBOS_SYSTEM_DATABASE_URI = None
+    DBOS_EXECUTOR_ID: str | None = "worker-1"
+    DBOS_ADMIN_PORT = 3001
+    DBOS_RUN_ADMIN_SERVER = True
+    DBOS_HEARTBEAT_TTL_SECONDS = 60.0
+    DBOS_RECOVERY_INTERVAL_SECONDS = 10.0
+    SQLALCHEMY_DATABASE_URI = "postgresql+psycopg://app:secret@db/app"
+    LOG_LEVEL = "INFO"
+
+
+def test_dbos_config_uses_app_database_by_default() -> None:
+    assert dbos_config(_Settings()) == {
+        "name": "wanderbound",
+        "system_database_url": "postgresql+psycopg://app:secret@db/app",
+        "run_admin_server": True,
+        "admin_port": 3001,
+        "executor_id": "worker-1",
+        "log_level": "INFO",
+    }
+
+
+def test_dbos_config_accepts_admin_server_override() -> None:
+    assert dbos_config(_Settings(), run_admin_server=False)["run_admin_server"] is False
+
+
+def test_dbos_config_accepts_dedicated_system_database() -> None:
+    settings = _Settings()
+    settings.DBOS_SYSTEM_DATABASE_URI = SecretStr(
+        "postgresql+psycopg://dbos:secret@db/dbos"
+    )
+
+    assert dbos_config(settings)["system_database_url"] == (
+        "postgresql+psycopg://dbos:secret@db/dbos"
+    )
+
+
+def test_launch_and_destroy_dbos_delegate_to_dbos_runtime() -> None:
+    settings = _Settings()
+    with (
+        patch("app.logic.workflows.runtime.DBOS") as dbos,
+        patch(
+            "app.logic.workflows.runtime.dbos_config", return_value={"name": "x"}
+        ) as dbos_config_mock,
+    ):
+        launch_dbos(settings, run_admin_server=False)
+        destroy_dbos()
+
+    dbos_config_mock.assert_called_once_with(settings, run_admin_server=False)
+    dbos.assert_called_once_with(config={"name": "x"})
+    dbos.launch.assert_called_once_with()
+    dbos.destroy.assert_called_once_with(workflow_completion_timeout_sec=5)
+
+
+def test_dbos_config_generates_executor_id_when_unset(monkeypatch: Any) -> None:
+    settings = _Settings()
+    settings.DBOS_EXECUTOR_ID = None
+    monkeypatch.setattr(
+        "app.logic.workflows.recovery.socket.gethostname", lambda: "host"
+    )
+    monkeypatch.setattr("app.logic.workflows.recovery.os.getpid", lambda: 123)
+
+    assert dbos_config(settings)["executor_id"] == "host-123"

--- a/backend/tests/test_dbos_runtime.py
+++ b/backend/tests/test_dbos_runtime.py
@@ -44,6 +44,15 @@ def test_dbos_config_accepts_dedicated_system_database() -> None:
     )
 
 
+def test_dbos_config_treats_blank_system_database_as_unset() -> None:
+    settings = _Settings()
+    settings.DBOS_SYSTEM_DATABASE_URI = SecretStr("")
+
+    assert dbos_config(settings)["system_database_url"] == (
+        "postgresql+psycopg://app:secret@db/app"
+    )
+
+
 def test_launch_and_destroy_dbos_delegate_to_dbos_runtime() -> None:
     settings = _Settings()
     with (

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
+from app.core.tokens import ArtifactTokenStore
 from app.logic.export import (
     _EXPORT_NAME,
     EXPORT_FILENAME,
@@ -31,9 +36,6 @@ from tests.factories import (
     make_user,
 )
 from tests.helpers.users import UserRoutes
-
-if TYPE_CHECKING:
-    from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 def _export_path(*parts: str) -> str:
@@ -92,6 +94,39 @@ class TestTokenManagement:
         assert result == path
 
         assert await pop_export_token(session, token) is None
+
+    async def test_lifespan_periodically_evicts_undownloaded_tokens(
+        self, tmp_path: Path
+    ) -> None:
+        engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'tokens.db'}")
+        removed: list[Path] = []
+        store = ArtifactTokenStore(
+            dir_name="test-artifacts",
+            ttl=0,
+            label="test artifact",
+            cleanup_interval=0.01,
+            on_evict=lambda data: removed.append(Path(data["path"])),
+        )
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(SQLModel.metadata.create_all)
+            async with store.lifespan(engine=engine):
+                path = store.make_dest(".zip")
+                path.write_bytes(b"fake zip")
+                async with AsyncSession(engine, expire_on_commit=False) as session:
+                    token = await store.store(session, {"path": str(path)})
+
+                async def wait_until_deleted() -> None:
+                    async with AsyncSession(engine) as poll:
+                        while await poll.get(ArtifactToken, token) is not None:
+                            await poll.rollback()
+                            await asyncio.sleep(0.01)
+
+                await asyncio.wait_for(wait_until_deleted(), timeout=1)
+
+            assert removed == [path]
+        finally:
+            await engine.dispose()
 
 
 class TestExportUserData:

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from app.core.config import get_settings
+from app.core.tokens import FileTokenStore
 from app.logic.export import (
     _EXPORT_NAME,
     EXPORT_FILENAME,
@@ -70,7 +71,8 @@ def _export_download_token(path: Path | None) -> patch:
 
 class TestTokenManagement:
     @pytest.fixture(autouse=True)
-    def _clean_tokens(self) -> None:
+    def _clean_tokens(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
         export_tokens.cleanup()
 
     async def test_store_and_pop(self, tmp_path: Path) -> None:
@@ -85,6 +87,17 @@ class TestTokenManagement:
         assert result == path
 
         assert pop_export_token(token) is None
+
+    async def test_file_tokens_can_be_popped_by_another_store_instance(self) -> None:
+        first = FileTokenStore(dir_name="shared", ttl=60, label="test")
+        second = FileTokenStore(dir_name="shared", ttl=60, label="test")
+        path = first.make_dest(".bin")
+        path.write_bytes(b"shared")
+
+        token = first.store({"path": str(path)})
+
+        assert second.pop(token) == {"path": str(path)}
+        assert first.pop(token) is None
 
 
 class TestExportUserData:

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -95,6 +95,45 @@ class TestTokenManagement:
 
         assert await pop_export_token(session, token) is None
 
+    async def test_concurrent_pop_only_returns_token_once(
+        self, tmp_path: Path, session: AsyncSession, engine: Any
+    ) -> None:
+        path = tmp_path / "test.zip"
+        path.write_bytes(b"fake zip")
+        token = await export_tokens.store(session, path)
+
+        ready = 0
+        release = asyncio.Event()
+
+        class CoordinatedSession:
+            def __init__(self, inner: AsyncSession) -> None:
+                self._inner = inner
+
+            async def get(self, *args: object, **kwargs: object) -> object:
+                nonlocal ready
+                row = await self._inner.get(*args, **kwargs)
+                ready += 1
+                if ready == 2:
+                    release.set()
+                await release.wait()
+                return row
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._inner, name)
+
+        async def pop_once() -> Path | None:
+            async with AsyncSession(engine, expire_on_commit=False) as inner:
+                return await pop_export_token(
+                    CoordinatedSession(inner),  # type: ignore[arg-type]
+                    token,
+                )
+
+        results = await asyncio.wait_for(
+            asyncio.gather(pop_once(), pop_once()), timeout=1
+        )
+
+        assert sorted(results, key=lambda value: value is None) == [path, None]
+
     async def test_lifespan_periodically_evicts_undownloaded_tokens(
         self, tmp_path: Path
     ) -> None:

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -4,12 +4,11 @@ import json
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.core.config import get_settings
-from app.core.tokens import FileTokenStore
 from app.logic.export import (
     _EXPORT_NAME,
     EXPORT_FILENAME,
@@ -21,6 +20,7 @@ from app.logic.export import (
     export_user_data,
     pop_export_token,
 )
+from app.models.processing import ArtifactToken
 from app.models.user import User
 from tests.factories import (
     AID,
@@ -50,7 +50,7 @@ async def _export_events_and_path(
     user: User, session: AsyncSession
 ) -> tuple[list[ExportEvent], Path]:
     events: list[ExportEvent] = await collect_async(export_user_data(user, session))
-    path = pop_export_token(_done_event(events).token)
+    path = await pop_export_token(session, _done_event(events).token)
     assert path is not None
     return events, path
 
@@ -66,7 +66,10 @@ def _read_zip_json(path: Path, member: str) -> Any:
 
 
 def _export_download_token(path: Path | None) -> patch:
-    return patch("app.api.v1.routes.users.pop_export_token", return_value=path)
+    return patch(
+        "app.api.v1.routes.users.pop_export_token",
+        new=AsyncMock(return_value=path),
+    )
 
 
 class TestTokenManagement:
@@ -75,29 +78,20 @@ class TestTokenManagement:
         monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
         export_tokens.cleanup()
 
-    async def test_store_and_pop(self, tmp_path: Path) -> None:
+    async def test_store_and_pop(self, tmp_path: Path, session: AsyncSession) -> None:
         path = tmp_path / "test.zip"
         path.write_bytes(b"fake zip")
 
-        token = export_tokens.store(path)
+        token = await export_tokens.store(session, path)
         assert isinstance(token, str)
         assert len(token) > 10
+        assert await session.get(ArtifactToken, token) is not None
+        assert not (tmp_path / "tokens" / _EXPORT_NAME / "manifests").exists()
 
-        result = pop_export_token(token)
+        result = await pop_export_token(session, token)
         assert result == path
 
-        assert pop_export_token(token) is None
-
-    async def test_file_tokens_can_be_popped_by_another_store_instance(self) -> None:
-        first = FileTokenStore(dir_name="shared", ttl=60, label="test")
-        second = FileTokenStore(dir_name="shared", ttl=60, label="test")
-        path = first.make_dest(".bin")
-        path.write_bytes(b"shared")
-
-        token = first.store({"path": str(path)})
-
-        assert second.pop(token) == {"path": str(path)}
-        assert first.pop(token) is None
+        assert await pop_export_token(session, token) is None
 
 
 class TestExportUserData:

--- a/backend/tests/test_external_media_operations.py
+++ b/backend/tests/test_external_media_operations.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import BackgroundTasks
 
+from app.core.config import get_settings
 from app.logic.external_media.album_media import replace_album_media_from_saved
 from app.logic.external_media.undo import (
     enqueue_undo_snapshot_prune,
+    prune_all_expired_undo_snapshots,
     restore_undo_snapshot,
     schedule_undo_snapshot_prune,
 )
@@ -26,6 +28,7 @@ from .factories import (
     create_test_jpeg,
     insert_album,
     insert_album_media,
+    make_user,
 )
 
 if TYPE_CHECKING:
@@ -231,6 +234,38 @@ async def test_replace_preserves_media_name_and_creates_undo(
     assert row.upgrade_candidate is False
     snap = await session.get_one(AlbumMediaUndoSnapshot, (uid, AID, VALID_NAME))
     assert snap.expires_at > snap.created_at
+
+
+async def test_prune_all_expired_undo_snapshots_uses_shared_user_folder(
+    session: AsyncSession,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
+    uid = 9091
+    user = make_user(uid)
+    session.add(user)
+    await session.flush()
+    await insert_album(session, uid)
+    await insert_album_media(session, uid, name=VALID_NAME)
+    album_dir = user.trips_folder / AID
+    undo_dir = album_dir / ".undo"
+    undo_dir.mkdir(parents=True)
+    snapshot_path = undo_dir / VALID_NAME
+    snapshot_path.write_bytes(b"snapshot")
+    _add_undo_snapshot(
+        session,
+        uid=uid,
+        media_name=VALID_NAME,
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    await session.flush()
+
+    removed = await prune_all_expired_undo_snapshots(session)
+
+    assert removed == 1
+    assert not snapshot_path.exists()
+    assert await session.get(AlbumMediaUndoSnapshot, (uid, AID, VALID_NAME)) is None
 
 
 async def test_replace_prunes_expired_undo_snapshots(

--- a/backend/tests/test_locks.py
+++ b/backend/tests/test_locks.py
@@ -1,0 +1,51 @@
+from typing import Self
+from unittest.mock import patch
+
+from app.core.locks import try_advisory_lock
+
+
+class _FakeLock:
+    released = False
+
+    async def acquire(self, *, block: bool) -> bool:
+        assert block is False
+        return True
+
+    async def release(self) -> None:
+        self.released = True
+
+
+class _FakeConnection:
+    options: dict[str, object] | None = None
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def execution_options(self, **options: object) -> Self:
+        self.options = options
+        return self
+
+
+class _FakeEngine:
+    connection = _FakeConnection()
+
+    def connect(self) -> _FakeConnection:
+        return self.connection
+
+
+async def test_advisory_lock_connection_uses_autocommit() -> None:
+    engine = _FakeEngine()
+    lock = _FakeLock()
+
+    with (
+        patch("app.core.locks.get_engine", return_value=engine),
+        patch("app.core.locks.create_async_sadlock", return_value=lock),
+    ):
+        async with try_advisory_lock("dbos-admin") as acquired:
+            assert acquired is True
+
+    assert engine.connection.options == {"isolation_level": "AUTOCOMMIT"}
+    assert lock.released is True

--- a/backend/tests/test_main_lifespan.py
+++ b/backend/tests/test_main_lifespan.py
@@ -1,0 +1,65 @@
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from app.logic.segment_routes import get_route_enrichment_http_clients
+from app.logic.workflows.processing import get_processing_workflow_http_clients
+from app.main import lifespan, settings
+
+
+@asynccontextmanager
+async def _yielding(value: object = None) -> AsyncIterator[object]:
+    yield value
+
+
+async def _forever(*_args: object, **_kwargs: object) -> None:
+    await asyncio.Event().wait()
+
+
+async def test_lifespan_initializes_workflow_clients_before_launch(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    http = object()
+    app = SimpleNamespace(state=SimpleNamespace())
+    launch_calls: list[bool | None] = []
+
+    def locked(_key: str) -> object:
+        acquired = True
+        return _yielding(acquired)
+
+    def browser_lifespan() -> object:
+        return _yielding("browser")
+
+    def http_lifespan() -> object:
+        return _yielding(http)
+
+    def launch(_settings: object, *, run_admin_server: bool | None = None) -> None:
+        get_processing_workflow_http_clients()
+        get_route_enrichment_http_clients()
+        launch_calls.append(run_admin_server)
+
+    monkeypatch.setattr(settings, "DATA_FOLDER", tmp_path)
+    monkeypatch.setattr(settings, "DBOS_RUN_ADMIN_SERVER", True)
+    monkeypatch.setattr("app.main.cleanup_orphaned_tmp", _noop_cleanup)
+    monkeypatch.setattr("app.main.try_advisory_lock", locked)
+    monkeypatch.setattr("app.main.pdf_lifespan", browser_lifespan)
+    monkeypatch.setattr("app.main.export_lifespan", _yielding)
+    monkeypatch.setattr("app.main.undo_lifespan", _yielding)
+    monkeypatch.setattr("app.main.upload_store.lifespan", _yielding)
+    monkeypatch.setattr("app.main.lifespan_clients", http_lifespan)
+    monkeypatch.setattr("app.main.launch_dbos", launch)
+    monkeypatch.setattr("app.main.destroy_dbos", lambda: None)
+    monkeypatch.setattr("app.main.workflow_heartbeat_loop", _forever)
+    monkeypatch.setattr("app.main.workflow_recovery_loop", _forever)
+
+    async with lifespan(app):
+        assert app.state.http is http
+
+    assert launch_calls == [True]
+
+
+async def _noop_cleanup(_path: Path) -> None:
+    return None

--- a/backend/tests/test_open_meteo.py
+++ b/backend/tests/test_open_meteo.py
@@ -175,6 +175,93 @@ class TestBuildWeathers:
             night_temp=-2.0,
         )
 
+    async def test_multiple_steps_use_one_archive_request(self) -> None:
+        steps = [
+            _make_step(40.84, 14.25, 1641168000.0),
+            _make_step(40.63, 14.38, 1641254400.0),
+        ]
+        client = async_client(
+            get=json_response(
+                [
+                    _om_response(
+                        ["2022-01-03", "2022-01-04"],
+                        temp_max=[11.0, 12.0],
+                    ),
+                    _om_response(
+                        ["2022-01-03", "2022-01-04"],
+                        temp_max=[13.0, 14.0],
+                    ),
+                ]
+            )
+        )
+
+        result = [w async for w in build_weathers(client, steps)]
+
+        assert [idx for idx, _weather in result] == [0, 1]
+        assert [weather.day.temp for _idx, weather in result] == [11.0, 14.0]
+        client.get.assert_awaited_once()
+        params = client.get.await_args.kwargs["params"]
+        assert params["latitude"] == "40.84,40.63"
+        assert params["longitude"] == "14.25,14.38"
+        assert params["start_date"] == "2022-01-03"
+        assert params["end_date"] == "2022-01-04"
+
+    async def test_long_date_ranges_are_split_into_bounded_batches(self) -> None:
+        steps = [
+            _make_step(40.84, 14.25, datetime(2022, 1, 1, tzinfo=UTC).timestamp()),
+            _make_step(40.63, 14.38, datetime(2022, 1, 14, tzinfo=UTC).timestamp()),
+            _make_step(40.62, 14.57, datetime(2022, 1, 20, tzinfo=UTC).timestamp()),
+        ]
+        client = async_client(
+            get=[
+                json_response(
+                    [
+                        _om_response(["2022-01-01", "2022-01-14"], temp_max=[1, 2]),
+                        _om_response(["2022-01-01", "2022-01-14"], temp_max=[3, 4]),
+                    ]
+                ),
+                json_response(_om_response(["2022-01-20"], temp_max=[5])),
+            ]
+        )
+
+        result = [w async for w in build_weathers(client, steps)]
+
+        assert [idx for idx, _weather in result] == [0, 1, 2]
+        assert [weather.day.temp for _idx, weather in result] == [1, 4, 5]
+        assert client.get.await_count == 2
+        first_params = client.get.await_args_list[0].kwargs["params"]
+        second_params = client.get.await_args_list[1].kwargs["params"]
+        assert first_params["latitude"] == "40.84,40.63"
+        assert first_params["start_date"] == "2022-01-01"
+        assert first_params["end_date"] == "2022-01-14"
+        assert second_params["latitude"] == "40.62"
+        assert second_params["start_date"] == "2022-01-20"
+        assert second_params["end_date"] == "2022-01-20"
+
+    async def test_large_step_sets_are_split_by_location_limit(self) -> None:
+        timestamp = datetime(2022, 1, 1, tzinfo=UTC).timestamp()
+        steps = [_make_step(float(idx), 14.25, timestamp) for idx in range(101)]
+        client = async_client(
+            get=[
+                json_response(
+                    [
+                        _om_response(["2022-01-01"], temp_max=[float(idx)])
+                        for idx in range(100)
+                    ]
+                ),
+                json_response(_om_response(["2022-01-01"], temp_max=[100.0])),
+            ]
+        )
+
+        result = [w async for w in build_weathers(client, steps)]
+
+        assert len(result) == 101
+        assert client.get.await_count == 2
+        first_params = client.get.await_args_list[0].kwargs["params"]
+        second_params = client.get.await_args_list[1].kwargs["params"]
+        assert len(first_params["latitude"].split(",")) == 100
+        assert second_params["latitude"] == "100.0"
+
     async def test_http_error_raises(self) -> None:
         step = _make_step(0, 0, 1704067200.0)
         client = async_client(get=httpx.HTTPError("fail"))

--- a/backend/tests/test_processing_operations.py
+++ b/backend/tests/test_processing_operations.py
@@ -118,3 +118,33 @@ async def test_status_helpers_track_running_terminal_and_active(
     assert operation.completed_at is not None
     active = await processing_operation_is_active(session, operation.operation_id)
     assert active is False
+
+
+async def test_mark_running_does_not_revive_stale_operation(
+    session: AsyncSession,
+) -> None:
+    operation = await create_processing_operation(session, uid=42, upload_generation=3)
+    operation.status = "stale"
+    session.add(operation)
+    await session.flush()
+
+    updated = await mark_processing_operation_running(session, operation)
+
+    assert updated is False
+    assert operation.status == "stale"
+
+
+async def test_complete_operation_does_not_overwrite_stale_operation(
+    session: AsyncSession,
+) -> None:
+    operation = await create_processing_operation(session, uid=42, upload_generation=3)
+    operation.status = "stale"
+    session.add(operation)
+    await session.flush()
+
+    updated = await complete_processing_operation(
+        session, operation, status="succeeded"
+    )
+
+    assert updated is False
+    assert operation.status == "stale"

--- a/backend/tests/test_processing_operations.py
+++ b/backend/tests/test_processing_operations.py
@@ -1,0 +1,120 @@
+from typing import TYPE_CHECKING
+
+from app.logic.processing_operations import (
+    append_processing_event,
+    complete_processing_operation,
+    create_processing_operation,
+    latest_active_processing_operation,
+    latest_processing_operation,
+    mark_processing_operation_running,
+    mark_user_processing_operations_stale,
+    processing_operation_is_active,
+    read_processing_events,
+)
+from app.logic.trip_processing import PhaseUpdate, TripStart
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+async def test_create_operation_uses_app_owned_workflow_id(
+    session: AsyncSession,
+) -> None:
+    operation = await create_processing_operation(session, uid=42, upload_generation=3)
+
+    assert operation.uid == 42
+    assert operation.upload_generation == 3
+    assert operation.status == "queued"
+    assert operation.workflow_id == f"processing:{operation.operation_id}"
+    assert operation.started_at is None
+    assert operation.completed_at is None
+
+
+async def test_latest_active_operation_ignores_terminal_and_stale_rows(
+    session: AsyncSession,
+) -> None:
+    first = await create_processing_operation(session, uid=42, upload_generation=3)
+    first.status = "stale"
+    session.add(first)
+    second = await create_processing_operation(session, uid=42, upload_generation=3)
+    done = await create_processing_operation(session, uid=42, upload_generation=3)
+    done.status = "succeeded"
+    other_generation = await create_processing_operation(
+        session, uid=42, upload_generation=4
+    )
+    session.add_all([done, other_generation])
+    await session.flush()
+
+    assert (
+        await latest_active_processing_operation(session, uid=42, upload_generation=3)
+        == second
+    )
+
+
+async def test_persisted_events_replay_in_sequence(session: AsyncSession) -> None:
+    operation = await create_processing_operation(session, uid=42, upload_generation=3)
+
+    await append_processing_event(session, operation, TripStart(trip_index=0))
+    await append_processing_event(
+        session,
+        operation,
+        PhaseUpdate(phase="weather", done=1, total=2),
+    )
+
+    events = await read_processing_events(session, operation.operation_id)
+
+    assert events == [
+        TripStart(trip_index=0),
+        PhaseUpdate(phase="weather", done=1, total=2),
+    ]
+
+
+async def test_mark_user_processing_operations_stale_only_updates_active_rows(
+    session: AsyncSession,
+) -> None:
+    active = await create_processing_operation(session, uid=42, upload_generation=3)
+    failed = await create_processing_operation(session, uid=42, upload_generation=2)
+    failed.status = "failed"
+    other_user = await create_processing_operation(session, uid=7, upload_generation=1)
+    session.add_all([failed, other_user])
+    await session.flush()
+
+    stale_count = await mark_user_processing_operations_stale(session, uid=42)
+
+    assert stale_count == 1
+    assert active.status == "stale"
+    assert failed.status == "failed"
+    assert other_user.status == "queued"
+
+
+async def test_latest_processing_operation_includes_terminal_rows(
+    session: AsyncSession,
+) -> None:
+    first = await create_processing_operation(session, uid=42, upload_generation=3)
+    await complete_processing_operation(session, first, status="succeeded")
+    second = await create_processing_operation(session, uid=42, upload_generation=4)
+
+    assert await latest_processing_operation(session, uid=42) == second
+
+
+async def test_status_helpers_track_running_terminal_and_active(
+    session: AsyncSession,
+) -> None:
+    operation = await create_processing_operation(session, uid=42, upload_generation=3)
+
+    assert await processing_operation_is_active(session, operation.operation_id) is True
+
+    await mark_processing_operation_running(session, operation, executor_id="worker-1")
+
+    assert operation.status == "running"
+    assert operation.started_by_executor_id == "worker-1"
+    assert operation.started_at is not None
+    assert operation.completed_at is None
+    assert await processing_operation_is_active(session, operation.operation_id) is True
+
+    await complete_processing_operation(session, operation, status="succeeded")
+
+    assert operation.status == "succeeded"
+    assert operation.completed_at is not None
+    active = await processing_operation_is_active(session, operation.operation_id)
+    assert active is False

--- a/backend/tests/test_processing_operations.py
+++ b/backend/tests/test_processing_operations.py
@@ -69,7 +69,7 @@ async def test_persisted_events_replay_in_sequence(session: AsyncSession) -> Non
     ]
 
 
-async def test_mark_user_processing_operations_stale_only_updates_active_rows(
+async def test_mark_user_processing_operations_stale_updates_all_non_stale_rows(
     session: AsyncSession,
 ) -> None:
     active = await create_processing_operation(session, uid=42, upload_generation=3)
@@ -81,9 +81,9 @@ async def test_mark_user_processing_operations_stale_only_updates_active_rows(
 
     stale_count = await mark_user_processing_operations_stale(session, uid=42)
 
-    assert stale_count == 1
+    assert stale_count == 2
     assert active.status == "stale"
-    assert failed.status == "failed"
+    assert failed.status == "stale"
     assert other_user.status == "queued"
 
 

--- a/backend/tests/test_segment_routes.py
+++ b/backend/tests/test_segment_routes.py
@@ -109,7 +109,7 @@ def test_enqueue_album_route_enrichment_adds_background_task() -> None:
     assert task.kwargs == {}
 
 
-def test_start_album_route_enrichment_uses_stable_workflow_id() -> None:
+def test_start_album_route_enrichment_uses_unique_workflow_id_per_run() -> None:
     calls: list[tuple[object, dict[str, object]]] = []
     workflow_ids: list[str] = []
     handle = object()
@@ -135,10 +135,20 @@ def test_start_album_route_enrichment_uses_stable_workflow_id() -> None:
         result = start_album_route_enrichment(123, "album-1")
 
     assert result is handle
-    assert workflow_ids == [route_enrichment_workflow_id(123, "album-1")]
+    assert len(workflow_ids) == 1
+    assert workflow_ids[0].startswith("route-enrichment:123:album-1:")
     assert calls == [
         (album_route_enrichment_workflow, route_enrichment_payload(123, "album-1"))
     ]
+
+
+def test_route_enrichment_workflow_id_is_unique_per_call() -> None:
+    first = route_enrichment_workflow_id(123, "album-1")
+    second = route_enrichment_workflow_id(123, "album-1")
+
+    assert first != second
+    assert first.startswith("route-enrichment:123:album-1:")
+    assert second.startswith("route-enrichment:123:album-1:")
 
 
 async def _route_for(

--- a/backend/tests/test_segment_routes.py
+++ b/backend/tests/test_segment_routes.py
@@ -10,8 +10,12 @@ from fastapi import BackgroundTasks
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.logic.segment_routes import (
+    album_route_enrichment_workflow,
     enqueue_album_route_enrichment,
     match_album_segment_routes,
+    route_enrichment_payload,
+    route_enrichment_workflow_id,
+    start_album_route_enrichment,
 )
 from app.models.segment import Segment, SegmentKind
 
@@ -100,9 +104,41 @@ def test_enqueue_album_route_enrichment_adds_background_task() -> None:
 
     assert len(background_tasks.tasks) == 1
     task = background_tasks.tasks[0]
-    assert task.func is match_album_segment_routes
-    assert task.args == (http, 123, "album-1")
+    assert task.func is start_album_route_enrichment
+    assert task.args == (123, "album-1")
     assert task.kwargs == {}
+
+
+def test_start_album_route_enrichment_uses_stable_workflow_id() -> None:
+    calls: list[tuple[object, dict[str, object]]] = []
+    workflow_ids: list[str] = []
+    handle = object()
+
+    class FakeSetWorkflowID:
+        def __init__(self, workflow_id: str) -> None:
+            self.workflow_id = workflow_id
+
+        def __enter__(self) -> None:
+            workflow_ids.append(self.workflow_id)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_start_workflow(func: object, payload: dict[str, object]) -> object:
+        calls.append((func, payload))
+        return handle
+
+    with (
+        patch("app.logic.segment_routes.SetWorkflowID", FakeSetWorkflowID),
+        patch("app.logic.segment_routes.DBOS.start_workflow", fake_start_workflow),
+    ):
+        result = start_album_route_enrichment(123, "album-1")
+
+    assert result is handle
+    assert workflow_ids == [route_enrichment_workflow_id(123, "album-1")]
+    assert calls == [
+        (album_route_enrichment_workflow, route_enrichment_payload(123, "album-1"))
+    ]
 
 
 async def _route_for(

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -12,9 +12,11 @@ from app.logic.processing_operations import (
     create_processing_operation,
     latest_processing_operation,
     mark_processing_operation_running,
+    mark_user_processing_operations_stale,
 )
 from app.logic.session import (
     ProcessingSession,
+    _operation_for_process_request,
     _sessions,
     process_stream,
 )
@@ -395,3 +397,42 @@ class TestPersistedProcessStream:
             TripStart(trip_index=0),
             PhaseUpdate(phase="layouts", done=1, total=1),
         ]
+
+    async def test_reupload_after_success_creates_new_operation(
+        self, session: AsyncSession
+    ) -> None:
+        user = User(
+            id=987,
+            google_sub="google-987",
+            first_name="Test",
+            locale="en-US",
+            unit_is_km=True,
+            temperature_is_celsius=True,
+            album_ids=["trip-1"],
+        )
+        session.add(user)
+        await session.flush()
+        old = await create_processing_operation(session, uid=987, upload_generation=1)
+        await append_processing_event(session, old, TripStart(trip_index=0))
+        await complete_processing_operation(session, old, status="succeeded")
+        await mark_user_processing_operations_stale(session, uid=987)
+
+        new = await _operation_for_process_request(session, user)
+
+        assert new.operation_id != old.operation_id
+        assert new.upload_generation == 2
+        assert new.status == "queued"
+
+    async def test_process_request_locks_user_before_operation_decision(
+        self, session: AsyncSession
+    ) -> None:
+        user = _mock_user(uid=222)
+
+        with patch(
+            "app.logic.session.lock_user_for_processing_request",
+            new_callable=AsyncMock,
+            create=True,
+        ) as lock_user:
+            await _operation_for_process_request(session, user)
+
+        lock_user.assert_awaited_once_with(session, uid=222)

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -87,7 +87,10 @@ class TestProcessingSession:
             PhaseUpdate(phase="layouts", done=5, total=5),
         ]
 
-        with patch("app.logic.session.run_processing", _processing_events(*events)):
+        with (
+            patch("app.logic.session.run_processing", _processing_events(*events)),
+            patch("app.logic.session.schedule_album_route_enrichment"),
+        ):
             session = ProcessingSession(_MOCK_HTTP, _mock_user())
             await session._task
             assert session.is_done
@@ -128,9 +131,10 @@ class TestProcessingSession:
 class TestProcessStream:
     @pytest.fixture(autouse=True)
     def _clean_sessions(self) -> Iterator[None]:
-        _sessions.clear()
-        yield
-        _sessions.clear()
+        with patch("app.logic.session.schedule_album_route_enrichment"):
+            _sessions.clear()
+            yield
+            _sessions.clear()
 
     async def test_reconnect_to_running_session(self) -> None:
         gate = asyncio.Event()

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -1,10 +1,18 @@
 import asyncio
 from collections.abc import AsyncIterator, Callable, Iterator
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.core.http_clients import HttpClients
+from app.logic.processing_operations import (
+    append_processing_event,
+    complete_processing_operation,
+    create_processing_operation,
+    latest_processing_operation,
+    mark_processing_operation_running,
+)
 from app.logic.session import (
     ProcessingSession,
     _sessions,
@@ -18,6 +26,9 @@ from app.logic.trip_processing import (
 )
 from app.models.user import User
 from tests.factories import collect_async
+
+if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
 _MOCK_HTTP = MagicMock(spec=HttpClients)
 
@@ -239,3 +250,148 @@ class TestProcessStream:
         assert first == TripStart(trip_index=0)
         calls = [call.args for call in schedule.call_args_list]
         assert calls == _scheduled_album_calls(22)
+
+
+class TestPersistedProcessStream:
+    @pytest.fixture(autouse=True)
+    def _clean_sessions(self) -> Iterator[None]:
+        _sessions.clear()
+        yield
+        _sessions.clear()
+
+    async def test_completed_processing_replays_from_database_after_memory_eviction(
+        self, session: AsyncSession
+    ) -> None:
+        starts: list[str] = []
+
+        def fake_start_processing_workflow(operation: object, _user: User) -> object:
+            starts.append(operation.workflow_id)
+            return object()
+
+        async def finish_operation() -> None:
+            await asyncio.sleep(0.01)
+            operation = await latest_processing_operation(session, uid=123)
+            assert operation is not None
+            await mark_processing_operation_running(session, operation)
+            await append_processing_event(session, operation, TripStart(trip_index=0))
+            await append_processing_event(
+                session, operation, PhaseUpdate(phase="layouts", done=1, total=1)
+            )
+            await complete_processing_operation(session, operation, status="succeeded")
+            await session.commit()
+
+        user = _mock_user(uid=123)
+        with patch(
+            "app.logic.session.start_processing_workflow",
+            fake_start_processing_workflow,
+        ):
+            finisher = asyncio.create_task(finish_operation())
+            first = await collect_async(process_stream(_MOCK_HTTP, user, session))
+            await finisher
+            _sessions.clear()
+            second = await collect_async(process_stream(_MOCK_HTTP, user, session))
+
+        operation = await latest_processing_operation(session, uid=123)
+        assert operation is not None
+        assert operation.status == "succeeded"
+        assert starts == ["processing:" + operation.operation_id]
+        assert (
+            first
+            == second
+            == [
+                TripStart(trip_index=0),
+                PhaseUpdate(phase="layouts", done=1, total=1),
+            ]
+        )
+
+    async def test_running_operation_without_local_session_polls_database_events(
+        self, session: AsyncSession
+    ) -> None:
+        user = _mock_user(uid=321)
+        operation = await create_processing_operation(
+            session, uid=321, upload_generation=1
+        )
+        await mark_processing_operation_running(session, operation)
+        await append_processing_event(session, operation, TripStart(trip_index=0))
+        await session.commit()
+
+        async def fake_processing(
+            _http: HttpClients, _user: User
+        ) -> AsyncIterator[ProcessingEvent]:
+            if _user.uid == -1:
+                yield TripStart(trip_index=99)
+            msg = "running operation should not start duplicate processing"
+            raise AssertionError(msg)
+
+        async def finish_operation() -> None:
+            await asyncio.sleep(0.01)
+            await append_processing_event(
+                session,
+                operation,
+                PhaseUpdate(phase="layouts", done=1, total=1),
+            )
+            await complete_processing_operation(session, operation, status="succeeded")
+            await session.commit()
+
+        with patch("app.logic.session.run_processing", fake_processing):
+            finisher = asyncio.create_task(finish_operation())
+            events = await collect_async(process_stream(_MOCK_HTTP, user, session))
+            await finisher
+
+        assert events == [
+            TripStart(trip_index=0),
+            PhaseUpdate(phase="layouts", done=1, total=1),
+        ]
+
+    async def test_queued_operation_starts_dbos_and_polls_database_events(
+        self, session: AsyncSession
+    ) -> None:
+        user = _mock_user(uid=654)
+
+        async def fake_processing(
+            _http: HttpClients, _user: User
+        ) -> AsyncIterator[ProcessingEvent]:
+            if _user.uid == -1:
+                yield TripStart(trip_index=99)
+            msg = "queued operation should start DBOS, not local processing"
+            raise AssertionError(msg)
+
+        async def finish_operation() -> None:
+            await asyncio.sleep(0.01)
+            operation = await latest_processing_operation(session, uid=654)
+            assert operation is not None
+            await mark_processing_operation_running(session, operation)
+            await append_processing_event(session, operation, TripStart(trip_index=0))
+            await append_processing_event(
+                session,
+                operation,
+                PhaseUpdate(phase="layouts", done=1, total=1),
+            )
+            await complete_processing_operation(session, operation, status="succeeded")
+            await session.commit()
+
+        starts: list[str] = []
+
+        def fake_start_processing_workflow(operation: object, _user: User) -> object:
+            starts.append(operation.workflow_id)
+            return object()
+
+        with (
+            patch("app.logic.session.run_processing", fake_processing),
+            patch(
+                "app.logic.session.start_processing_workflow",
+                fake_start_processing_workflow,
+                create=True,
+            ),
+        ):
+            finisher = asyncio.create_task(finish_operation())
+            events = await collect_async(process_stream(_MOCK_HTTP, user, session))
+            await finisher
+
+        operation = await latest_processing_operation(session, uid=654)
+        assert operation is not None
+        assert starts == ["processing:" + operation.operation_id]
+        assert events == [
+            TripStart(trip_index=0),
+            PhaseUpdate(phase="layouts", done=1, total=1),
+        ]

--- a/backend/tests/test_trip_pipeline.py
+++ b/backend/tests/test_trip_pipeline.py
@@ -1,5 +1,7 @@
+from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sqlalchemy import event
@@ -8,9 +10,15 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.config import get_settings
 from app.core.http_clients import HttpClients
-from app.logic.trip_pipeline import _process_trip, _save_new, _save_reupload
-from app.logic.trip_processing import PhaseUpdate, SegmentsFound
+from app.logic.trip_pipeline import (
+    _process_trip,
+    _save_new,
+    _save_reupload,
+    run_processing,
+)
+from app.logic.trip_processing import ErrorData, PhaseUpdate, SegmentsFound
 from app.models.album import Album
 from app.models.album_media import AlbumMedia, StepPageMedia
 from app.models.polarsteps import Location
@@ -56,6 +64,36 @@ async def _create_schema(engine: AsyncEngine) -> None:
 
 def _user() -> User:
     return make_user(UID, google_sub="test-sub")
+
+
+async def test_run_processing_stale_guard_skips_db_save(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
+    user = _user()
+    trip_dir = user.trips_folder / AID
+    trip_dir.mkdir(parents=True)
+
+    async def cancelled() -> bool:
+        return False
+
+    async def fake_process_trip(*args: object) -> AsyncIterator[PhaseUpdate]:
+        yield PhaseUpdate(phase="layouts", done=1, total=1)
+
+    with (
+        patch(
+            "app.logic.trip_pipeline._load_existing",
+            new=AsyncMock(return_value=({}, {}, {})),
+        ),
+        patch("app.logic.trip_pipeline._process_trip", fake_process_trip),
+        patch("app.logic.trip_pipeline._save_new", new=AsyncMock()) as save_new,
+    ):
+        events = await collect_async(
+            run_processing(_MOCK_HTTP, user, should_continue=cancelled)
+        )
+
+    save_new.assert_not_awaited()
+    assert events[-1] == ErrorData()
 
 
 def _album(

--- a/backend/tests/test_trip_pipeline.py
+++ b/backend/tests/test_trip_pipeline.py
@@ -96,6 +96,27 @@ async def test_run_processing_stale_guard_skips_db_save(
     assert events[-1] == ErrorData()
 
 
+async def test_save_new_guard_skips_commit_inside_save_transaction(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(get_settings(), "DATA_FOLDER", tmp_path)
+    engine = _sqlite_engine()
+    await _create_schema(engine)
+    album = _album()
+
+    async def stale(_session: AsyncSession) -> bool:
+        return False
+
+    with patch("app.logic.trip_pipeline.get_engine", return_value=engine):
+        saved = await _save_new(UID, [album], save_guard=stale)
+
+    async with AsyncSession(engine) as session:
+        rows = (await session.exec(select(Album))).all()
+
+    assert saved is False
+    assert rows == []
+
+
 def _album(
     *,
     title: str = "Old Trip",

--- a/backend/tests/test_trip_pipeline.py
+++ b/backend/tests/test_trip_pipeline.py
@@ -253,7 +253,7 @@ async def _save_reuploaded_objects(
         )
 
 
-class TestSaveNew:
+class TestSaveNewDependencyOrder:
     async def test_saves_step_media_after_parent_step_and_album_media(
         self,
     ) -> None:

--- a/backend/tests/test_trip_pipeline.py
+++ b/backend/tests/test_trip_pipeline.py
@@ -20,7 +20,7 @@ from app.logic.trip_pipeline import (
 )
 from app.logic.trip_processing import ErrorData, PhaseUpdate, SegmentsFound
 from app.models.album import Album
-from app.models.album_media import AlbumMedia, StepPageMedia
+from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
 from app.models.polarsteps import Location
 from app.models.segment import Segment, SegmentKind
 from app.models.step import Step
@@ -203,6 +203,27 @@ def _cover_media() -> AlbumMedia:
     )
 
 
+def _page_media() -> StepPageMedia:
+    return StepPageMedia(
+        uid=UID,
+        aid=AID,
+        step_id=1,
+        page_index=0,
+        position_index=0,
+        media_name="cover.jpg",
+    )
+
+
+def _unused_media() -> StepUnusedMedia:
+    return StepUnusedMedia(
+        uid=UID,
+        aid=AID,
+        step_id=1,
+        position_index=0,
+        media_name="cover.jpg",
+    )
+
+
 async def _seed_album_state(engine: AsyncEngine, *objects: object) -> None:
     async with AsyncSession(engine) as session:
         session.add(_user())
@@ -230,6 +251,30 @@ async def _save_reuploaded_objects(
             existing_albums={AID: existing_album},
             trip_dirs=[trip_dir],
         )
+
+
+class TestSaveNew:
+    async def test_saves_step_media_after_parent_step_and_album_media(
+        self,
+    ) -> None:
+        engine = _sqlite_engine(foreign_keys=True)
+        await _create_schema(engine)
+        await _seed_album_state(engine)
+
+        saved = False
+        with patch("app.logic.trip_pipeline.get_engine", return_value=engine):
+            saved = await _save_new(
+                UID,
+                [_album(), _cover_media(), _step(), _page_media(), _unused_media()],
+            )
+
+        async with AsyncSession(engine) as session:
+            page_media = (await session.exec(select(StepPageMedia))).all()
+            unused_media = (await session.exec(select(StepUnusedMedia))).all()
+
+        assert saved is True
+        assert page_media == [_page_media()]
+        assert unused_media == [_unused_media()]
 
 
 class TestProcessTripSegmentEvents:

--- a/backend/tests/test_user_process_route.py
+++ b/backend/tests/test_user_process_route.py
@@ -1,0 +1,32 @@
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.api.v1.routes.users import process_user
+from app.core.http_clients import HttpClients
+from app.logic.trip_processing import ProcessingEvent, TripStart
+from app.models.user import User
+
+
+def _mock_user(uid: int = 1) -> User:
+    user = AsyncMock(spec=User)
+    user.id = uid
+    return user
+
+
+async def test_process_route_passes_db_session_to_stream() -> None:
+    user = _mock_user()
+    http = MagicMock(spec=HttpClients)
+    db_session = object()
+
+    async def fake_process_stream(
+        stream_http: HttpClients, stream_user: User, stream_session: object
+    ) -> AsyncIterator[ProcessingEvent]:
+        assert stream_http is http
+        assert stream_user is user
+        assert stream_session is db_session
+        yield TripStart(trip_index=0)
+
+    with patch("app.api.v1.routes.users.process_stream", fake_process_stream):
+        events = [event async for event in process_user(user, http, db_session)]
+
+    assert events == [TripStart(trip_index=0)]

--- a/backend/tests/test_workflow_recovery.py
+++ b/backend/tests/test_workflow_recovery.py
@@ -4,10 +4,12 @@ from urllib.request import Request
 
 from app.logic.workflows.recovery import (
     WORKFLOW_RECOVERY_PATH,
+    WorkflowAdminState,
     list_dead_workflow_executors,
     record_workflow_executor_heartbeat,
     recover_dead_workflow_executors,
     recover_workflows_via_admin,
+    workflow_admin_election_once,
     workflow_heartbeat_once,
 )
 from app.models.processing import WorkflowExecutorHeartbeat
@@ -157,3 +159,51 @@ async def test_recover_dead_workflow_executors_recovers_stale(
     assert stale.status == "dead"
     assert recovered == ["workflow-1"]
     assert calls == [("http://127.0.0.1:3001", ["stale-worker"])]
+
+
+async def test_workflow_admin_election_promotes_when_lock_is_available() -> None:
+    state = WorkflowAdminState()
+    events: list[str] = []
+
+    async def promote() -> None:
+        events.append("promote")
+
+    async def recover() -> None:
+        events.append("recover")
+
+    await workflow_admin_election_once(
+        state,
+        lock_acquired=True,
+        promote_to_admin=promote,
+        recover_once=recover,
+    )
+
+    assert state.has_admin_server is True
+    assert events == ["promote", "recover"]
+
+
+async def test_workflow_admin_election_retries_after_missing_lock() -> None:
+    state = WorkflowAdminState()
+    events: list[str] = []
+
+    async def promote() -> None:
+        events.append("promote")
+
+    async def recover() -> None:
+        events.append("recover")
+
+    await workflow_admin_election_once(
+        state,
+        lock_acquired=False,
+        promote_to_admin=promote,
+        recover_once=recover,
+    )
+    await workflow_admin_election_once(
+        state,
+        lock_acquired=True,
+        promote_to_admin=promote,
+        recover_once=recover,
+    )
+
+    assert state.has_admin_server is True
+    assert events == ["promote", "recover"]

--- a/backend/tests/test_workflow_recovery.py
+++ b/backend/tests/test_workflow_recovery.py
@@ -1,0 +1,159 @@
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Self
+from urllib.request import Request
+
+from app.logic.workflows.recovery import (
+    WORKFLOW_RECOVERY_PATH,
+    list_dead_workflow_executors,
+    record_workflow_executor_heartbeat,
+    recover_dead_workflow_executors,
+    recover_workflows_via_admin,
+    workflow_heartbeat_once,
+)
+from app.models.processing import WorkflowExecutorHeartbeat
+
+if TYPE_CHECKING:
+    import pytest
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+async def test_records_executor_heartbeat(session: AsyncSession) -> None:
+    await record_workflow_executor_heartbeat(
+        session,
+        executor_id="worker-1",
+        admin_base_url="http://127.0.0.1:3001",
+    )
+
+    row = await session.get(WorkflowExecutorHeartbeat, "worker-1")
+
+    assert row is not None
+    assert row.admin_base_url == "http://127.0.0.1:3001"
+    assert row.status == "active"
+
+
+async def test_records_non_admin_executor_heartbeat(session: AsyncSession) -> None:
+    await record_workflow_executor_heartbeat(
+        session,
+        executor_id="worker-2",
+        admin_base_url=None,
+    )
+
+    row = await session.get(WorkflowExecutorHeartbeat, "worker-2")
+
+    assert row is not None
+    assert row.admin_base_url == ""
+    assert row.status == "active"
+
+
+async def test_list_dead_executors_marks_stale_active_rows_dead(
+    session: AsyncSession,
+) -> None:
+    stale = WorkflowExecutorHeartbeat(
+        executor_id="stale-worker",
+        admin_base_url="http://127.0.0.1:3001",
+        status="active",
+        last_seen_at=datetime.now(UTC) - timedelta(seconds=120),
+    )
+    current = WorkflowExecutorHeartbeat(
+        executor_id="current-worker",
+        admin_base_url="http://127.0.0.1:3001",
+        status="active",
+        last_seen_at=datetime.now(UTC),
+    )
+    already_dead = WorkflowExecutorHeartbeat(
+        executor_id="dead-worker",
+        admin_base_url="http://127.0.0.1:3001",
+        status="dead",
+        last_seen_at=datetime.now(UTC) - timedelta(seconds=120),
+    )
+    session.add_all([stale, current, already_dead])
+    await session.flush()
+
+    dead = await list_dead_workflow_executors(
+        session, stale_after=timedelta(seconds=60)
+    )
+
+    assert dead == ["stale-worker"]
+    assert stale.status == "dead"
+    assert current.status == "active"
+    assert already_dead.status == "dead"
+
+
+def test_recover_workflows_via_admin_posts_executor_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Request, float]] = []
+
+    class FakeResponse:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b'["workflow-1"]'
+
+    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+        calls.append((request, timeout))
+        return FakeResponse()
+
+    monkeypatch.setattr("app.logic.workflows.recovery.urlopen", fake_urlopen)
+
+    assert recover_workflows_via_admin("http://127.0.0.1:3001", ["stale-worker"]) == [
+        "workflow-1"
+    ]
+
+    request, timeout = calls[0]
+    assert request.full_url == f"http://127.0.0.1:3001{WORKFLOW_RECOVERY_PATH}"
+    assert request.method == "POST"
+    assert request.data == b'["stale-worker"]'
+    assert request.headers["Content-type"] == "application/json"
+    assert timeout == 30
+
+
+class _RecoverySettings:
+    DBOS_EXECUTOR_ID = "current-worker"
+    DBOS_ADMIN_PORT = 3001
+    DBOS_HEARTBEAT_TTL_SECONDS = 60.0
+    DBOS_RECOVERY_INTERVAL_SECONDS = 10.0
+
+
+async def test_workflow_heartbeat_once_records_current_executor(
+    session: AsyncSession,
+) -> None:
+    await workflow_heartbeat_once(session, _RecoverySettings(), has_admin_server=False)
+
+    current = await session.get(WorkflowExecutorHeartbeat, "current-worker")
+    assert current is not None
+    assert current.admin_base_url == ""
+    assert current.status == "active"
+
+
+async def test_recover_dead_workflow_executors_recovers_stale(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stale = WorkflowExecutorHeartbeat(
+        executor_id="stale-worker",
+        admin_base_url="http://127.0.0.1:3001",
+        status="active",
+        last_seen_at=datetime.now(UTC) - timedelta(seconds=120),
+    )
+    session.add(stale)
+    await session.flush()
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_recover(admin_base_url: str, executor_ids: list[str]) -> list[str]:
+        calls.append((admin_base_url, executor_ids))
+        return ["workflow-1"]
+
+    monkeypatch.setattr(
+        "app.logic.workflows.recovery.recover_workflows_via_admin",
+        fake_recover,
+    )
+
+    recovered = await recover_dead_workflow_executors(session, _RecoverySettings())
+
+    assert stale.status == "dead"
+    assert recovered == ["workflow-1"]
+    assert calls == [("http://127.0.0.1:3001", ["stale-worker"])]

--- a/backend/tests/test_workflow_recovery.py
+++ b/backend/tests/test_workflow_recovery.py
@@ -161,6 +161,38 @@ async def test_recover_dead_workflow_executors_recovers_stale(
     assert calls == [("http://127.0.0.1:3001", ["stale-worker"])]
 
 
+async def test_recover_dead_workflow_executors_runs_admin_call_in_thread(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stale = WorkflowExecutorHeartbeat(
+        executor_id="stale-worker",
+        admin_base_url="http://127.0.0.1:3001",
+        status="active",
+        last_seen_at=datetime.now(UTC) - timedelta(seconds=120),
+    )
+    session.add(stale)
+    await session.flush()
+    calls: list[tuple[object, tuple[object, ...]]] = []
+
+    async def fake_to_thread(func: object, *args: object) -> list[str]:
+        calls.append((func, args))
+        return ["workflow-1"]
+
+    monkeypatch.setattr(
+        "app.logic.workflows.recovery.asyncio.to_thread", fake_to_thread
+    )
+
+    recovered = await recover_dead_workflow_executors(session, _RecoverySettings())
+
+    assert recovered == ["workflow-1"]
+    assert calls == [
+        (
+            recover_workflows_via_admin,
+            ("http://127.0.0.1:3001", ["stale-worker"]),
+        )
+    ]
+
+
 async def test_workflow_admin_election_promotes_when_lock_is_available() -> None:
     state = WorkflowAdminState()
     events: list[str] = []

--- a/compose.yml
+++ b/compose.yml
@@ -76,6 +76,12 @@ services:
       VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-}
       ENVIRONMENT: ${ENVIRONMENT:?Variable not set}
       APP_VERSION: ${APP_VERSION:-}
+      DBOS_SYSTEM_DATABASE_URI: ${DBOS_SYSTEM_DATABASE_URI:-}
+      DBOS_EXECUTOR_ID: ${DBOS_EXECUTOR_ID:-}
+      DBOS_ADMIN_PORT: ${DBOS_ADMIN_PORT:-3001}
+      DBOS_RUN_ADMIN_SERVER: ${DBOS_RUN_ADMIN_SERVER:-true}
+      DBOS_HEARTBEAT_TTL_SECONDS: ${DBOS_HEARTBEAT_TTL_SECONDS:-60}
+      DBOS_RECOVERY_INTERVAL_SECONDS: ${DBOS_RECOVERY_INTERVAL_SECONDS:-10}
       SENTRY_DSN: ${SENTRY_DSN:-}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]

--- a/mise.toml
+++ b/mise.toml
@@ -126,6 +126,14 @@ description = "Tail Docker Compose logs"
 run = "docker compose logs -f"
 raw = true
 
+[tasks."workflow:dbos-recovery-check"]
+description = "Run a DBOS Postgres recovery smoke check"
+dir = "backend"
+usage = '''
+arg "<database_url>" help="Postgres SQLAlchemy URL for the DBOS system database"
+'''
+run = 'uv run python ../scripts/dbos_recovery_check.py run "$usage_database_url"'
+
 # -- Database -----------------------------------------------------
 
 [tasks."db:migrate"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository task scripts."""

--- a/scripts/dbos_recovery_check.py
+++ b/scripts/dbos_recovery_check.py
@@ -1,0 +1,248 @@
+import argparse
+import asyncio
+import inspect
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+import psycopg
+from dbos import DBOS, SetWorkflowID
+from psycopg import sql
+
+APP_NAME = "wanderbound-dbos-check"
+APP_VERSION = "dbos-recovery-check-v1"
+DBOS_SYSTEM_SCHEMA = "dbos_recovery_check"
+MARKER_TABLE = "dbos_recovery_check_markers"
+RECOVERY_ADMIN_PORT = 3001
+WORKFLOW_RECOVERY_PATH = "/dbos-workflow-recovery"
+
+
+def psycopg_url(database_url: str) -> str:
+    return database_url.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
+def dbos_recovery_config(
+    database_url: str,
+    *,
+    executor_id: str,
+    run_admin_server: bool = False,
+    admin_port: int = RECOVERY_ADMIN_PORT,
+) -> dict[str, Any]:
+    return {
+        "name": APP_NAME,
+        "system_database_url": database_url,
+        "run_admin_server": run_admin_server,
+        "admin_port": admin_port,
+        "log_level": "ERROR",
+        "executor_id": executor_id,
+        "application_version": APP_VERSION,
+        "dbos_system_schema": DBOS_SYSTEM_SCHEMA,
+    }
+
+
+def recover_workflows_via_admin(
+    admin_base_url: str, executor_ids: list[str]
+) -> list[str]:
+    parsed_url = urlparse(admin_base_url)
+    if parsed_url.scheme not in {"http", "https"}:
+        raise ValueError("DBOS admin URL must use http or https")
+    request = Request(  # noqa: S310
+        f"{admin_base_url.rstrip('/')}{WORKFLOW_RECOVERY_PATH}",
+        data=json.dumps(executor_ids).encode(),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urlopen(request, timeout=30) as response:  # noqa: S310
+        return list(json.loads(response.read().decode()))
+
+
+def _ensure_marker_table(database_url: str) -> None:
+    with psycopg.connect(psycopg_url(database_url)) as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {MARKER_TABLE} (
+                    operation_id TEXT NOT NULL,
+                    attempt INTEGER NOT NULL,
+                    executor_id TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    PRIMARY KEY (operation_id, attempt)
+                )
+                """
+            ).format(MARKER_TABLE=sql.Identifier(MARKER_TABLE))
+        )
+
+
+def _record_attempt(database_url: str, operation_id: str, executor_id: str) -> int:
+    with psycopg.connect(psycopg_url(database_url)) as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                "SELECT COALESCE(MAX(attempt), 0) + 1 FROM {MARKER_TABLE} "
+                "WHERE operation_id = %s"
+            ).format(MARKER_TABLE=sql.Identifier(MARKER_TABLE)),
+            (operation_id,),
+        )
+        attempt = cur.fetchone()[0]
+        cur.execute(
+            sql.SQL(
+                "INSERT INTO {MARKER_TABLE} "
+                "(operation_id, attempt, executor_id) VALUES (%s, %s, %s)"
+            ).format(MARKER_TABLE=sql.Identifier(MARKER_TABLE)),
+            (operation_id, attempt, executor_id),
+        )
+    return int(attempt)
+
+
+def _attempt_count(database_url: str, operation_id: str) -> int:
+    with psycopg.connect(psycopg_url(database_url)) as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                "SELECT COUNT(*) FROM {MARKER_TABLE} WHERE operation_id = %s"
+            ).format(MARKER_TABLE=sql.Identifier(MARKER_TABLE)),
+            (operation_id,),
+        )
+        return int(cur.fetchone()[0])
+
+
+@DBOS.step(name="recovery-check.block-on-first-attempt")
+async def _block_on_first_attempt(payload: dict[str, Any]) -> dict[str, Any]:
+    attempt = await asyncio.to_thread(
+        _record_attempt,
+        payload["database_url"],
+        payload["operation_id"],
+        payload["executor_id"],
+    )
+    if attempt == 1:
+        await asyncio.Event().wait()
+    return {"attempt": attempt}
+
+
+@DBOS.workflow(name="recovery-check.workflow")
+async def recovery_check_workflow(payload: dict[str, Any]) -> dict[str, Any]:
+    result = await _block_on_first_attempt(payload)
+    return {
+        "operation_id": payload["operation_id"],
+        "attempt": result["attempt"],
+        "recovered": result["attempt"] > 1,
+    }
+
+
+async def _run_worker(database_url: str, operation_id: str, executor_id: str) -> None:
+    _ensure_marker_table(database_url)
+    DBOS(config=dbos_recovery_config(database_url, executor_id=executor_id))
+    DBOS.launch()
+    try:
+        payload = {
+            "database_url": database_url,
+            "operation_id": operation_id,
+            "executor_id": executor_id,
+        }
+        with SetWorkflowID(operation_id):
+            await recovery_check_workflow(payload)
+    finally:
+        DBOS.destroy(workflow_completion_timeout_sec=1)
+
+
+def _recover(
+    database_url: str, operation_id: str, failed_executor_id: str
+) -> dict[str, Any]:
+    DBOS(
+        config=dbos_recovery_config(
+            database_url,
+            executor_id="worker-b",
+            run_admin_server=True,
+            admin_port=RECOVERY_ADMIN_PORT,
+        )
+    )
+    DBOS.launch()
+    try:
+        workflow_ids = recover_workflows_via_admin(
+            f"http://127.0.0.1:{RECOVERY_ADMIN_PORT}", [failed_executor_id]
+        )
+        if not workflow_ids:
+            raise RuntimeError(
+                f"No pending workflows recovered for {failed_executor_id}"
+            )
+        if operation_id not in workflow_ids:
+            raise RuntimeError(f"Recovered workflows did not include {operation_id}")
+        handle = DBOS.retrieve_workflow(operation_id)
+        result = handle.get_result()
+        if inspect.isawaitable(result):
+            result = asyncio.run(result)
+        return result
+    finally:
+        DBOS.destroy(workflow_completion_timeout_sec=1)
+
+
+def _wait_for_first_attempt(database_url: str, operation_id: str) -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if _attempt_count(database_url, operation_id) >= 1:
+            return
+        time.sleep(0.25)
+    raise TimeoutError("worker-a did not enter the blocking step")
+
+
+def _run_parent(database_url: str) -> dict[str, Any]:
+    operation_id = f"dbos-recovery-check-{uuid4()}"
+    worker_a = f"worker-a-{operation_id}"
+    _ensure_marker_table(database_url)
+
+    worker = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "worker",
+            database_url,
+            operation_id,
+            worker_a,
+        ]
+    )
+    try:
+        _wait_for_first_attempt(database_url, operation_id)
+        worker.terminate()
+        try:
+            worker.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            worker.kill()
+            worker.wait(timeout=10)
+
+        result = _recover(database_url, operation_id, worker_a)
+        attempts = _attempt_count(database_url, operation_id)
+        return {"result": result, "attempts": attempts}
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait(timeout=10)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    parent = subparsers.add_parser("run")
+    parent.add_argument("database_url")
+
+    worker = subparsers.add_parser("worker")
+    worker.add_argument("database_url")
+    worker.add_argument("operation_id")
+    worker.add_argument("executor_id")
+
+    args = parser.parse_args()
+    if args.command == "worker":
+        asyncio.run(_run_worker(args.database_url, args.operation_id, args.executor_id))
+        return
+    if args.command == "run":
+        print(json.dumps(_run_parent(args.database_url), sort_keys=True))  # noqa: T201
+        return
+    parser.error("missing command")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -106,6 +106,7 @@ dependencies = [
     { name = "asgi-correlation-id" },
     { name = "av" },
     { name = "coloraide" },
+    { name = "dbos" },
     { name = "fastapi", extra = ["standard"] },
     { name = "hishel", extra = ["httpx"] },
     { name = "httpx" },
@@ -157,6 +158,7 @@ requires-dist = [
     { name = "asgi-correlation-id", specifier = "~=5.0" },
     { name = "av", specifier = "~=17.0" },
     { name = "coloraide", specifier = "~=8.7" },
+    { name = "dbos", specifier = ">=2.22.0" },
     { name = "fastapi", extras = ["standard"], specifier = "<1" },
     { name = "hishel", extras = ["httpx"], specifier = "~=1.0" },
     { name = "httpx", specifier = "<1" },
@@ -358,6 +360,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
     { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
     { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
+name = "dbos"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "typer-slim" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/52/5e4944e7a0605b4da3119876502cc39af7775555f16982c6a298411a7f63/dbos-2.22.0.tar.gz", hash = "sha256:5d43a9d0388d851df0f7bbd4ed752bc8b67be3d6fbe358c8be4d22f6c4887db6", size = 479210, upload-time = "2026-05-15T15:33:51.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/bc/0fc571524ba11c9800a1a116cb9b157223bbff39b070e7a2c3ed5b4edbe6/dbos-2.22.0-py3-none-any.whl", hash = "sha256:09edc621ec2857dae73cc1b01bc7379999fe9ee4ef8c6ff4ac69dd1a5263001f", size = 198070, upload-time = "2026-05-15T15:33:49.893Z" },
 ]
 
 [[package]]
@@ -1161,6 +1180,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1408,6 +1439,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -1561,6 +1601,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
+]
+
+[[package]]
+name = "typer-slim"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add DBOS-backed durable processing operations and persisted processing events
- Move chunked upload sessions to shared storage so multiple workers can handle the same upload
- Add DBOS heartbeat, recovery, and single admin coordinator wiring for self-hosted deployments
- Document DBOS operational settings and add a recovery smoke-check task