### PR TITLE
feat(editor): center active nav step while scrolling

### DIFF
--- a/frontend/e2e/large-album-performance.test.ts
+++ b/frontend/e2e/large-album-performance.test.ts
@@ -159,6 +159,25 @@ async function scrollNavStepIntoView(page: Page, step: number) {
   await expect(target).toBeVisible({ timeout: 1_000 });
 }
 
+async function activeNavStepCenterOffset(page: Page, step: number) {
+  return page.evaluate((targetStep) => {
+    const navList = document.querySelector<HTMLElement>(
+      ".group-entries-virtual",
+    );
+    const target = document.querySelector<HTMLElement>(
+      `[data-nav-step="${targetStep}"]`,
+    );
+    if (!navList || !target) return Number.POSITIVE_INFINITY;
+    const navRect = navList.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    return Math.round(
+      targetRect.top +
+        targetRect.height / 2 -
+        (navRect.top + navRect.height / 2),
+    );
+  }, step);
+}
+
 test.describe("Large album editor performance", () => {
   test("opens a 240-step album while keeping rendered media bounded", async ({
     page,
@@ -199,5 +218,39 @@ test.describe("Large album editor performance", () => {
         .poll(() => page.locator("[data-media]").count())
         .toBeLessThan(120);
     }
+  });
+
+  test("keeps the active step near the middle of the nav while scrolling", async ({
+    page,
+  }) => {
+    await mockLargeAlbum(page);
+    await page.goto("/editor");
+    await expect(page.getByText("Large Album").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByRole("navigation").getByText("Netherlands").click();
+
+    await scrollNavStepIntoView(page, 180);
+    await page.locator(`[data-nav-step="180"]`).click();
+    await expect(page.getByText("Large Step 180").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.mouse.move(640, 360);
+    await page.mouse.wheel(0, 900);
+
+    await expect
+      .poll(() => page.locator("[data-nav-step].visible").textContent())
+      .toContain("Large Step");
+    const activeStep = await page
+      .locator("[data-nav-step].visible")
+      .getAttribute("data-nav-step");
+    expect(activeStep).not.toBeNull();
+
+    await expect
+      .poll(() => activeNavStepCenterOffset(page, Number(activeStep)))
+      .toBeGreaterThan(-90);
+    await expect
+      .poll(() => activeNavStepCenterOffset(page, Number(activeStep)))
+      .toBeLessThan(90);
   });
 });

--- a/frontend/src/components/editor/AlbumNav.vue
+++ b/frontend/src/components/editor/AlbumNav.vue
@@ -276,7 +276,7 @@ function scrollNavItemIntoView(selector: string) {
   void nextTick(() => {
     const el = listRef.value?.querySelector(selector);
     (el as HTMLElement | null)?.scrollIntoView({
-      block: "nearest",
+      block: "center",
       behavior: scrollBehavior(),
     });
   });

--- a/frontend/src/components/editor/nav/NavCountryGroup.vue
+++ b/frontend/src/components/editor/nav/NavCountryGroup.vue
@@ -6,7 +6,7 @@ import { SHORT_DATE } from "@/utils/date";
 import { sectionKeyMatchesRange } from "../../album/albumSections";
 import { useUserQuery } from "@/queries/useUserQuery";
 import { useI18n } from "vue-i18n";
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import NavStepItem from "./NavStepItem.vue";
 import NavMapItem from "./NavMapItem.vue";
 import {
@@ -43,11 +43,13 @@ const allHidden = computed(() =>
   props.group.stepIds.every((id) => props.hiddenSet.has(id)),
 );
 
-const NAV_ENTRY_ROW_SIZE = 44;
+const NAV_ENTRY_ROW_SIZE = 54;
 const NAV_ENTRY_SLICE_SIZE = 24;
-const virtualScrollRef = ref<{ scrollTo: (index: number) => void } | null>(
-  null,
-);
+type VirtualScrollExpose = {
+  scrollTo: (index: number) => void;
+  $el?: HTMLElement;
+};
+const virtualScrollRef = ref<VirtualScrollExpose | null>(null);
 
 function entryKey(entry: GroupEntry) {
   return entry.type === "step" ? `step-${entry.item.id}` : entry.key;
@@ -56,7 +58,19 @@ function entryKey(entry: GroupEntry) {
 function scrollActiveIntoVirtualView() {
   if (!props.open || props.activeStepId == null) return;
   const index = props.group.entryIndexByStepId.get(props.activeStepId);
-  if (index != null) virtualScrollRef.value?.scrollTo(index);
+  if (index == null) return;
+  virtualScrollRef.value?.scrollTo(index);
+  void nextTick(() => {
+    requestAnimationFrame(() => {
+      const scrollEl = virtualScrollRef.value?.$el;
+      if (!scrollEl) return;
+      scrollEl.scrollTop = Math.max(
+        0,
+        index * NAV_ENTRY_ROW_SIZE -
+          (scrollEl.clientHeight - NAV_ENTRY_ROW_SIZE) / 2,
+      );
+    });
+  });
 }
 
 watch(


### PR DESCRIPTION
Center active nav entries in the left navigation when the album scroll spy changes the active step or section.