### PR TITLE
fix(tooling): clean knip configuration

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,9 +1,10 @@
 {
+  "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["vite.config.ts"],
   "project": ["src/**/*.{ts,vue}", "!src/client/**"],
   "vite": {
     "config": []
   },
-  "ignoreDependencies": ["postcss-rtlcss", "@hey-api/client-fetch"],
+  "ignoreDependencies": ["postcss-rtlcss"],
   "ignoreBinaries": ["uv", "scripts/generate-og-image.ts"]
 }

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "workspaces": {
+    ".": {
+      "entry": [
+        "scripts/generate-og-image.ts",
+        "scripts/generate-landing.ts"
+      ],
+      "project": ["scripts/**/*.ts", "*.config.js"],
+      "ignoreDependencies": ["@commitlint/cli"]
+    },
+    "frontend": {
+      "entry": [
+        "vite.config.ts",
+        "postcss.config.js",
+        "public/oauth-connected.js",
+        "e2e/**/*.ts",
+        "smoke/**/*.ts",
+        "tests/**/*.ts"
+      ],
+      "project": [
+        "src/**/*.{ts,vue}",
+        "e2e/**/*.ts",
+        "smoke/**/*.ts",
+        "tests/**/*.ts",
+        "!src/client/**"
+      ],
+      "vite": {
+        "config": []
+      },
+      "ignoreUnresolved": ["/src/client/index.ts"],
+      "ignoreBinaries": ["uv", "scripts/generate-og-image.ts"]
+    }
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -93,7 +93,6 @@ run = "uv run vulture"
 
 [tasks."deadcode:frontend"]
 description = "Find dead JS/TS code (knip)"
-dir = "frontend"
 run = "bun x knip"
 
 # -- Formatting ---------------------------------------------------


### PR DESCRIPTION
- add a root Knip workspace config so root scripts and frontend code are checked from one entry point
- remove the stale frontend dependency ignore for @hey-api/client-fetch
- run the frontend dead-code task from the repo root so it uses the workspace config