### PR TITLE
fix(print): count continuation photos once

### DIFF
--- a/frontend/src/components/AlbumViewer.vue
+++ b/frontend/src/components/AlbumViewer.vue
@@ -167,7 +167,9 @@ const sections = computed(() =>
   ),
 );
 
-const sectionPageCounts = computed(() => sections.value.map(sectionPageCount));
+const sectionPageCounts = computed(() =>
+  sections.value.map((section) => sectionPageCount(section, mediaByName.value)),
+);
 
 type EditorItem =
   | { type: "header"; key: string }

--- a/frontend/src/components/album/albumSections.ts
+++ b/frontend/src/components/album/albumSections.ts
@@ -1,11 +1,13 @@
 import type {
   AlbumMeta,
+  AlbumMedia,
   DateRange,
   SegmentOutline,
   StepRead as Step,
 } from "@/client";
 import { layoutDescription } from "@/composables/useTextLayout";
 import { inDateRange, isoDate } from "@/utils/date";
+import { isPortrait } from "@/utils/media";
 
 /** Keys for fixed album pages that precede the data-driven sections. Validated against the API schema. */
 export const HEADER_KEYS = [
@@ -112,13 +114,40 @@ export function activeSectionId(
   return sec.type === "step" ? sec.step.id : sectionKey(sec);
 }
 
-export function sectionPageCount(section: Section): number {
-  if (section.type === "map" || section.type === "hike") return 1;
-  const step = section.step;
+export function stepPageCount(
+  step: Step,
+  mediaByName: ReadonlyMap<string, AlbumMedia> = new Map(),
+): number {
   const layout = layoutDescription(step.description || "");
   const photoPages = filterCoverFromPages(step.pages, step.cover);
   const continuationPages = Math.max(0, layout.pages.length - 1);
-  return 1 + continuationPages + photoPages.length;
+  const continuationPhotos = new Set<string>();
+  if (continuationPages > 0) {
+    for (const { page } of photoPages) {
+      for (const name of page) {
+        const media = mediaByName.get(name);
+        if (media && isPortrait(media)) continuationPhotos.add(name);
+        if (continuationPhotos.size >= continuationPages) break;
+      }
+      if (continuationPhotos.size >= continuationPages) break;
+    }
+  }
+  const remainingPhotoPages =
+    continuationPhotos.size > 0
+      ? photoPages.filter(({ page }) =>
+          page.some((name) => !continuationPhotos.has(name)),
+        )
+      : photoPages;
+  return 1 + continuationPages + remainingPhotoPages.length;
+}
+
+export function sectionPageCount(
+  section: Section,
+  mediaByName?: ReadonlyMap<string, AlbumMedia>,
+): number {
+  if (section.type === "map" || section.type === "hike") return 1;
+  const step = section.step;
+  return stepPageCount(step, mediaByName);
 }
 
 /** Group map ranges by the ID of their first overlapping step. */

--- a/frontend/tests/logic/albumSections.test.ts
+++ b/frontend/tests/logic/albumSections.test.ts
@@ -4,6 +4,7 @@ import {
   buildSections,
   activeSectionId,
   sectionKey,
+  stepPageCount,
   type Section,
 } from "@/components/album/albumSections";
 import type { DateRange } from "@/client";
@@ -46,6 +47,22 @@ describe("filterCoverFromPages", () => {
     ],
   ])("filters cover entries from %j", (pages, expected) => {
     expect(filterCoverFromPages(pages, "cover")).toEqual(expected);
+  });
+});
+
+describe("stepPageCount", () => {
+  it("does not double count portrait photos used on continuation description pages", () => {
+    const step = makeStep({
+      description: "x".repeat(120),
+      cover: null,
+      pages: [["portrait.jpg"], ["landscape.jpg"]],
+    });
+    const mediaByName = new Map([
+      ["portrait.jpg", { name: "portrait.jpg", width: 800, height: 1200 }],
+      ["landscape.jpg", { name: "landscape.jpg", width: 1200, height: 800 }],
+    ]);
+
+    expect(stepPageCount(step, mediaByName)).toBe(3);
   });
 });
 


### PR DESCRIPTION
- pass media metadata into album section page counting in print mode
- avoid double-counting portrait photos that are already placed on continuation description pages
- add a regression test for continuation-page photo counting