### PR TITLE
chore(compose): remove bundled backup services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,18 +55,7 @@ MAX_STORAGE_BYTES=10737418240       # 10 GB. 0 = auto-detect (90% of filesystem 
 
 # --- Defaults - Postgres -----------------------------
 # The backend reads SQLALCHEMY_DATABASE_URI directly; POSTGRES_USER/DB are for
-# the Docker Postgres image init and the db-backup container.
+# the Docker Postgres image init.
 
 POSTGRES_DB=app
 POSTGRES_USER=postgres
-
-# --- Defaults - Backups -------------------------------
-# DB backups: tiered retention (daily/weekly/monthly snapshots).
-# Data backups: flat retention (delete after N days).
-
-# BACKUP_DB_SCHEDULE=0 3 * * *       # cron expression for DB dump
-# BACKUP_KEEP_DAYS=7                 # daily snapshots to keep
-# BACKUP_KEEP_WEEKS=4                # weekly snapshots to keep
-# BACKUP_KEEP_MONTHS=6               # monthly snapshots to keep
-# BACKUP_DATA_SCHEDULE=0 4 * * *     # cron expression for data volume archive
-# BACKUP_RETENTION_DAYS=7            # days to keep data archives

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Open `http://localhost:5173`.
 For production, set `DOMAIN` and `ENVIRONMENT=production` in `.env` and run
 `docker compose -f compose.yml up -d`.
 
+The Compose stack runs the app, database, and frontend. Configure database and
+app data backups in your deployment infrastructure.
+
 > [!WARNING]
 > The backend uses in-memory state and must run as a single worker process.
 > Do not run multiple backend containers or uvicorn workers.

--- a/compose.yml
+++ b/compose.yml
@@ -90,55 +90,6 @@ services:
     volumes:
       - app-data:/app/backend/data
 
-  db-backup:
-    image: prodrigestivill/postgres-backup-local
-    restart: always
-    <<: *security
-    tmpfs:
-      - /tmp
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-          cpus: "0.5"
-          pids: 64
-    networks: [backend]
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      POSTGRES_HOST: db
-      POSTGRES_DB: ${POSTGRES_DB:?Variable not set}
-      POSTGRES_USER: ${POSTGRES_USER:?Variable not set}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Variable not set}
-      SCHEDULE: ${BACKUP_DB_SCHEDULE:-0 3 * * *}
-      BACKUP_KEEP_DAYS: ${BACKUP_KEEP_DAYS:-7}
-      BACKUP_KEEP_WEEKS: ${BACKUP_KEEP_WEEKS:-4}
-      BACKUP_KEEP_MONTHS: ${BACKUP_KEEP_MONTHS:-6}
-    volumes:
-      - backup-data:/backups
-
-  data-backup:
-    image: offen/docker-volume-backup:v2
-    restart: always
-    <<: *security
-    network_mode: none
-    tmpfs:
-      - /tmp
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-          cpus: "0.5"
-          pids: 64
-    environment:
-      BACKUP_CRON_EXPRESSION: ${BACKUP_DATA_SCHEDULE:-0 4 * * *}
-      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-7}
-      BACKUP_FILENAME: data-%Y-%m-%dT%H-%M-%S.tar.gz
-    volumes:
-      - app-data:/backup/app-data:ro
-      - backup-data:/archive
-
   frontend:
     image: 'frontend:${TAG:-latest}'
     restart: always
@@ -187,4 +138,3 @@ networks:
 volumes:
   db-data:
   app-data:
-  backup-data:


### PR DESCRIPTION
- Remove the compose-managed database and app-data backup services.
- Remove backup-specific environment examples from .env.example.
- Document that production backups are owned by deployment infrastructure.