### PR TITLE
fix: isolate Alembic database settings

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -8,7 +8,7 @@ from sqlmodel import SQLModel
 
 import alembic_postgresql_enum  # noqa: F401 - auto-handle enum types in migrations
 import app.models  # noqa: F401 - register all table models
-from app.core.config import get_settings
+from app.core.config import DatabaseSettings
 from app.core.db import PydanticJSON
 
 config = context.config
@@ -31,7 +31,8 @@ def render_item(type_: str, obj: Any, autogen_context: AutogenContext) -> str | 
 
 
 def get_url() -> str:
-    return str(get_settings().SQLALCHEMY_DATABASE_URI)
+    settings = DatabaseSettings()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+    return str(settings.SQLALCHEMY_DATABASE_URI)
 
 
 def run_migrations_offline() -> None:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,7 +38,7 @@ def ensure_psycopg_scheme(v: Any) -> Any:
     return v
 
 
-class Settings(BaseSettings):
+class DatabaseSettings(BaseSettings):
     model_config = SettingsConfigDict(
         # Use top level .env file (one level above ./backend/)
         env_file="../.env",
@@ -47,6 +47,12 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
+    SQLALCHEMY_DATABASE_URI: Annotated[
+        PostgresDsn, BeforeValidator(ensure_psycopg_scheme)
+    ]
+
+
+class Settings(DatabaseSettings):
     API_V1_STR: str = "/api/v1"
     SECRET_KEY: str
     SECRET_KEY_PREVIOUS: str | None = None
@@ -92,10 +98,6 @@ class Settings(BaseSettings):
         return [str(origin).rstrip("/") for origin in self.BACKEND_CORS_ORIGINS] + [
             str(self.VITE_FRONTEND_URL).rstrip("/")
         ]
-
-    SQLALCHEMY_DATABASE_URI: Annotated[
-        PostgresDsn, BeforeValidator(ensure_psycopg_scheme)
-    ]
 
     VITE_MAPBOX_TOKEN: str | None = None
 

--- a/backend/tests/test_alembic_environment.py
+++ b/backend/tests/test_alembic_environment.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_migrations_require_only_database_configuration(tmp_path: Path) -> None:
+    backend = Path(__file__).resolve().parents[1]
+    alembic_config = tmp_path / "alembic.ini"
+    alembic_config.write_text(
+        (backend / "alembic.ini")
+        .read_text()
+        .replace(
+            "script_location = app/alembic",
+            f"script_location = {backend}/app/alembic",
+        )
+    )
+
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "alembic",
+            "-c",
+            str(alembic_config),
+            "upgrade",
+            "f097a964b67c",
+            "--sql",
+        ],
+        cwd=tmp_path,
+        env={
+            "PYTHONPATH": str(backend),
+            "SQLALCHEMY_DATABASE_URI": (
+                "postgresql://wanderbound:secret@database/wanderbound"
+            ),
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
- separate database configuration from the full application settings model
- make Alembic instantiate only the database settings required for migrations
- add an isolated Alembic regression test that runs with only `SQLALCHEMY_DATABASE_URI`