### PR TITLE
fix(editor): defer off-screen chapter map loads

### DIFF
--- a/frontend/e2e/large-album-performance.test.ts
+++ b/frontend/e2e/large-album-performance.test.ts
@@ -11,13 +11,13 @@ function photoName(stepIndex: number, photoIndex: number) {
   return `large-step-${stepIndex}-photo-${photoIndex}.jpg`;
 }
 
-function makeLargeMedia() {
+function makeLargeMedia(photosPerStep = PHOTOS_PER_STEP) {
   const media = [
     { name: "cover.jpg", width: 1920, height: 1080 },
     { name: "back.jpg", width: 1920, height: 1080 },
   ];
   for (let step = 1; step <= STEP_COUNT; step++) {
-    for (let photo = 1; photo <= PHOTOS_PER_STEP; photo++) {
+    for (let photo = 1; photo <= photosPerStep; photo++) {
       media.push({
         name: photoName(step, photo),
         width: photo % 2 === 0 ? 1080 : 1920,
@@ -28,10 +28,10 @@ function makeLargeMedia() {
   return media;
 }
 
-function makeLargeSteps() {
+function makeLargeSteps(photosPerStep = PHOTOS_PER_STEP) {
   return Array.from({ length: STEP_COUNT }, (_, index) => {
     const stepNumber = index + 1;
-    const photos = Array.from({ length: PHOTOS_PER_STEP }, (_, photoIndex) =>
+    const photos = Array.from({ length: photosPerStep }, (_, photoIndex) =>
       photoName(stepNumber, photoIndex + 1),
     );
     const timestamp = 1_704_067_200 + index * 86_400;
@@ -54,16 +54,35 @@ function makeLargeSteps() {
         night: null,
       },
       cover: photos[0],
-      pages: [photos],
+      pages: Array.from({ length: Math.ceil(photos.length / 4) }, (_, pageIndex) =>
+        photos.slice(pageIndex * 4, pageIndex * 4 + 4),
+      ),
       unused: [],
       datetime: new Date(timestamp * 1000).toISOString(),
     };
   });
 }
 
-async function mockLargeAlbum(page: Page) {
-  const steps = makeLargeSteps();
-  const media = makeLargeMedia();
+function makeLargeSegmentOutlines(steps: ReturnType<typeof makeLargeSteps>) {
+  return steps.slice(0, -1).map((step, index) => {
+    const nextStep = steps[index + 1];
+    return {
+      start_time: step.timestamp,
+      end_time: nextStep.timestamp,
+      kind: "driving",
+      timezone_id: "Europe/Amsterdam",
+      start_coord: [step.location.lat, step.location.lon],
+      end_coord: [nextStep.location.lat, nextStep.location.lon],
+    };
+  });
+}
+
+async function mockLargeAlbum(page: Page, chaptered = false) {
+  const photosPerStep = chaptered ? 16 : PHOTOS_PER_STEP;
+  const steps = makeLargeSteps(photosPerStep);
+  const media = makeLargeMedia(photosPerStep);
+  const segmentOutlines = chaptered ? makeLargeSegmentOutlines(steps) : [];
+  const segmentPointRequests: string[] = [];
   await page.addInitScript(() =>
     localStorage.setItem("last-album-id", "large-album"),
   );
@@ -117,26 +136,54 @@ async function mockLargeAlbum(page: Page) {
         hidden_headers: [],
         maps_ranges: [],
         safe_margin_mm: 0,
-        chapters: [
-          {
-            id: "chapter-1",
-            title: "Large Album",
-            subtitle: "Performance fixture",
-            step_ids: steps.map((step) => step.id),
-            front_cover_photo: "cover.jpg",
-            back_cover_photo: "back.jpg",
-          },
-        ],
+        chapters: chaptered
+          ? [
+              {
+                id: "chapter-1",
+                title: "Large Album",
+                subtitle: "Performance fixture",
+                step_ids: steps.slice(0, 120).map((step) => step.id),
+                front_cover_photo: "cover.jpg",
+                back_cover_photo: "back.jpg",
+              },
+              {
+                id: "chapter-2",
+                title: "Chapter 2",
+                subtitle: "",
+                step_ids: steps.slice(120, 180).map((step) => step.id),
+                front_cover_photo: "",
+                back_cover_photo: "",
+              },
+              {
+                id: "chapter-3",
+                title: "Chapter 3",
+                subtitle: "",
+                step_ids: steps.slice(180).map((step) => step.id),
+                front_cover_photo: "",
+                back_cover_photo: "",
+              },
+            ]
+          : [
+              {
+                id: "chapter-1",
+                title: "Large Album",
+                subtitle: "Performance fixture",
+                step_ids: steps.map((step) => step.id),
+                front_cover_photo: "cover.jpg",
+                back_cover_photo: "back.jpg",
+              },
+            ],
         colors: { nl: "#e77c31", be: "#3d7a5f", de: "#496b94" },
       },
     }),
   );
   await page.route(`${API}/albums/*/segments`, (route) =>
-    route.fulfill({ json: [] }),
+    route.fulfill({ json: segmentOutlines }),
   );
-  await page.route(`${API}/albums/*/segments/points*`, (route) =>
-    route.fulfill({ json: [] }),
-  );
+  await page.route(`${API}/albums/*/segments/points*`, (route) => {
+    segmentPointRequests.push(route.request().url());
+    return route.fulfill({ json: [] });
+  });
   await page.route(`${API}/albums/*/steps`, (route) =>
     route.fulfill({ json: steps }),
   );
@@ -146,6 +193,7 @@ async function mockLargeAlbum(page: Page) {
   await page.route("**/media/**", (route) =>
     route.fulfill({ contentType: "image/jpeg", body: mediaBody }),
   );
+  return segmentPointRequests;
 }
 
 async function scrollNavStepIntoView(page: Page, step: number) {
@@ -225,38 +273,6 @@ test.describe("Large album editor performance", () => {
     }
   });
 
-  test("jumps to a distant chapter cover without mounting the whole album", async ({
-    page,
-  }) => {
-    await mockLargeAlbum(page);
-    await page.goto("/editor");
-    await expect(page.getByText("Large Album").first()).toBeVisible({
-      timeout: 15_000,
-    });
-
-    const nav = page.getByRole("navigation");
-    await nav.getByRole("button", { name: "Chapter actions" }).first().click();
-    await page.getByText("Split chapter").click();
-    await expect(nav.getByText("Chapter 2")).toBeVisible();
-    await nav.getByRole("button", { name: "Chapter actions" }).last().click();
-    await page.getByText("Split chapter").click();
-    await expect(nav.getByText("Chapter 3")).toBeVisible();
-
-    const chapterCover = nav.locator(
-      '[data-nav-section="chapter-chapter-3-cover-front"]',
-    );
-    const beforeScrollY = await page.evaluate(() => window.scrollY);
-    await chapterCover.click();
-
-    await expect
-      .poll(() => page.evaluate(() => window.scrollY))
-      .toBeGreaterThan(beforeScrollY + 10_000);
-    await expect(chapterCover).toHaveClass(/visible/);
-    await expect
-      .poll(() => page.locator("[data-media]").count())
-      .toBeLessThan(120);
-  });
-
   test("keeps the active step near the middle of the nav while scrolling", async ({
     page,
   }) => {
@@ -287,5 +303,41 @@ test.describe("Large album editor performance", () => {
     await expect
       .poll(() => activeNavStepCenterOffset(page, Number(activeStep)))
       .toBeLessThan(90);
+  });
+
+  test("defers a distant chapter map until its page is opened", async ({
+    page,
+  }) => {
+    const segmentPointRequests = await mockLargeAlbum(page, true);
+    await page.goto("/editor");
+    await expect(page.getByText("Large Album").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const nav = page.getByRole("navigation");
+    await expect(nav.getByText("Chapter 3")).toBeVisible();
+    await nav.getByText("Chapter 3").click();
+
+    const chapterCover = nav.locator(
+      '[data-nav-section="chapter-chapter-3-cover-front"]',
+    );
+    const beforeScrollY = await page.evaluate(() => window.scrollY);
+    segmentPointRequests.length = 0;
+    await chapterCover.click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.scrollY))
+      .toBeGreaterThan(beforeScrollY + 10_000);
+    await expect(chapterCover).toHaveClass(/visible/);
+    await page.waitForTimeout(2_000);
+    expect(segmentPointRequests).toHaveLength(0);
+
+    await nav
+      .locator('[data-nav-section="chapter-chapter-3-full-map"]')
+      .click();
+    await expect.poll(() => segmentPointRequests.length).toBeGreaterThan(0);
+    await expect
+      .poll(() => page.locator("[data-media]").count())
+      .toBeLessThan(120);
   });
 });

--- a/frontend/src/components/album/map/MapPage.vue
+++ b/frontend/src/components/album/map/MapPage.vue
@@ -9,7 +9,7 @@ import { useSegmentPointsQuery } from "@/queries/useSegmentPointsQuery";
 import { safeMarginMm, safeMarginPx } from "@/composables/useSafeMargin";
 import { useI18n } from "vue-i18n";
 import type { Map } from "mapbox-gl";
-import { useTemplateRef, computed, watch } from "vue";
+import { useTemplateRef, computed, ref, watch } from "vue";
 
 const { t } = useI18n();
 
@@ -32,9 +32,13 @@ const toTime = computed(() =>
     : 0,
 );
 
-const { data: segments } = useSegmentPointsQuery(fromTime, toTime);
-
 const printMode = usePrintMode();
+const loadSegments = ref(printMode);
+const { data: segments } = useSegmentPointsQuery(
+  fromTime,
+  toTime,
+  loadSegments,
+);
 const container = useTemplateRef("map");
 const { map, fitBounds } = useMapbox({
   container,
@@ -42,6 +46,9 @@ const { map, fitBounds } = useMapbox({
   onReady: draw,
   preserveDrawingBuffer: printMode,
   deferInit: !printMode,
+  onNearViewport: () => {
+    loadSegments.value = true;
+  },
 });
 
 function draw(m: Map) {

--- a/frontend/src/composables/useMapbox.ts
+++ b/frontend/src/composables/useMapbox.ts
@@ -28,6 +28,9 @@ mapboxgl.setRTLTextPlugin(
   true, // lazy: only load when RTL text is encountered
 );
 
+const MAP_INIT_ROOT_MARGIN_PX = 200;
+const MAP_VISIBILITY_SETTLE_MS = 100;
+
 interface UseMapboxOptions {
   container: Ref<HTMLElement | null>;
   style?: string;
@@ -35,6 +38,7 @@ interface UseMapboxOptions {
   onReady?: (map: mapboxgl.Map) => void;
   preserveDrawingBuffer?: boolean;
   deferInit?: boolean;
+  onNearViewport?: () => void;
   /** BCP 47 locale for map labels (e.g. "he-IL", "en-US"). Accepts ref/getter. */
   locale?: MaybeRefOrGetter<string>;
 }
@@ -48,6 +52,7 @@ export function useMapbox(options: UseMapboxOptions) {
   let pendingIdle: (() => void) | null = null;
   let initIdleHandle: number | null = null;
   let initTimeout: ReturnType<typeof setTimeout> | null = null;
+  let visibilityTimeout: ReturnType<typeof setTimeout> | null = null;
   let initIntersectionObserver: IntersectionObserver | null = null;
 
   function init() {
@@ -204,6 +209,7 @@ export function useMapbox(options: UseMapboxOptions) {
     }
 
     const scheduleIdleInit = () => {
+      options.onNearViewport?.();
       if ("requestIdleCallback" in window) {
         initIdleHandle = window.requestIdleCallback(() => {
           initIdleHandle = null;
@@ -225,12 +231,27 @@ export function useMapbox(options: UseMapboxOptions) {
 
     initIntersectionObserver = new IntersectionObserver(
       (entries) => {
-        if (!entries.some((entry) => entry.isIntersecting)) return;
-        initIntersectionObserver?.disconnect();
-        initIntersectionObserver = null;
-        scheduleIdleInit();
+        if (
+          !entries.some((entry) => entry.isIntersecting) ||
+          visibilityTimeout !== null
+        )
+          return;
+        // Header correction can briefly move an overscanned map through the viewport.
+        // Recheck after layout settles before loading its full GPS payload.
+        visibilityTimeout = setTimeout(() => {
+          visibilityTimeout = null;
+          const rect = el.getBoundingClientRect();
+          if (
+            rect.bottom < -MAP_INIT_ROOT_MARGIN_PX ||
+            rect.top > window.innerHeight + MAP_INIT_ROOT_MARGIN_PX
+          )
+            return;
+          initIntersectionObserver?.disconnect();
+          initIntersectionObserver = null;
+          scheduleIdleInit();
+        }, MAP_VISIBILITY_SETTLE_MS);
       },
-      { rootMargin: "200px" },
+      { rootMargin: `${MAP_INIT_ROOT_MARGIN_PX}px` },
     );
     initIntersectionObserver.observe(el);
   }
@@ -238,6 +259,10 @@ export function useMapbox(options: UseMapboxOptions) {
   function cancelScheduledInit() {
     initIntersectionObserver?.disconnect();
     initIntersectionObserver = null;
+    if (visibilityTimeout !== null) {
+      clearTimeout(visibilityTimeout);
+      visibilityTimeout = null;
+    }
     if (initIdleHandle !== null) {
       window.cancelIdleCallback(initIdleHandle);
       initIdleHandle = null;

--- a/frontend/src/queries/useSegmentPointsQuery.ts
+++ b/frontend/src/queries/useSegmentPointsQuery.ts
@@ -1,5 +1,12 @@
 import { useQuery } from "@pinia/colada";
-import { markRaw, onScopeDispose, watch, type Ref } from "vue";
+import {
+  markRaw,
+  onScopeDispose,
+  toValue,
+  watch,
+  type MaybeRefOrGetter,
+  type Ref,
+} from "vue";
 import { readSegmentPoints, type Segment } from "@/client";
 import { queryKeys, STALE_TIME } from "./keys";
 import { useAlbum } from "@/composables/useAlbum";
@@ -18,6 +25,7 @@ function hasUnmatchedRoute(segments: Segment[] | undefined): boolean {
 export function useSegmentPointsQuery(
   fromTime: Ref<number>,
   toTime: Ref<number>,
+  enabled: MaybeRefOrGetter<boolean> = true,
 ) {
   const { albumId } = useAlbum();
 
@@ -32,6 +40,7 @@ export function useSegmentPointsQuery(
       return markRaw(data);
     },
     staleTime: STALE_TIME,
+    enabled,
   });
 
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -55,6 +64,7 @@ export function useSegmentPointsQuery(
     }
     if (
       disposed ||
+      !toValue(enabled) ||
       !hasUnmatchedRoute(query.data.value) ||
       attempts >= ROUTE_REFETCH_LIMIT
     )
@@ -71,7 +81,7 @@ export function useSegmentPointsQuery(
   }
 
   watch(
-    query.data,
+    [query.data, () => toValue(enabled)],
     () => {
       if (!hasUnmatchedRoute(query.data.value)) attempts = 0;
       schedule();

--- a/frontend/tests/queries/useSegmentPointsQuery.test.ts
+++ b/frontend/tests/queries/useSegmentPointsQuery.test.ts
@@ -22,12 +22,13 @@ type SegmentHandlerResult = Segment[] | Promise<Response>;
 function mountQuery(
   fromTime: Ref<number> = ref(0),
   toTime: Ref<number> = ref(100),
+  enabled: Ref<boolean> = ref(true),
 ) {
   const { result: query, unmount } = withParentSetup(
     () => {
       provideTestAlbum({ albumId: "aid-1" });
     },
-    () => useSegmentPointsQuery(fromTime, toTime),
+    () => useSegmentPointsQuery(fromTime, toTime, enabled),
   );
 
   return { query, unmount };
@@ -60,6 +61,19 @@ describe("useSegmentPointsQuery", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("waits until it is enabled before loading segment points", async () => {
+    const enabled = ref(false);
+    const calls = mockSegmentPoints(() => []);
+
+    mountQuery(ref(0), ref(100), enabled);
+    await flushPromises();
+    expect(calls()).toBe(0);
+
+    enabled.value = true;
+    await flushPromises();
+    expect(calls()).toBe(1);
   });
 
   it("refetches about every minute while driving routes are missing", async () => {


### PR DESCRIPTION
- Delay chapter map GPS queries until Mapbox is stably near the viewport.
- Reject transient IntersectionObserver hits caused by chapter header scroll correction.
- Preserve immediate print map loading and real editor maps.
- Add Pinia query and 240-step, 3-chapter Firefox regressions.
