### PR TITLE
fix: make environment config single-source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,75 +1,101 @@
-# --- Required -----------------------------------------
+# Generate SECRET_KEY, POSTGRES_PASSWORD, GARAGE_RPC_SECRET, and
+# UPLOAD_S3_SECRET_ACCESS_KEY with: openssl rand -hex 32
+# Generate UPLOAD_S3_ACCESS_KEY_ID with:
+# printf 'GK%s\n' "$(openssl rand -hex 16)"
 
-SECRET_KEY=                                               # python -c "import secrets; print(secrets.token_urlsafe(32))"
+# --- Required for Docker Compose --------------------
+
+SECRET_KEY=
 POSTGRES_PASSWORD=
-UPLOAD_S3_ACCESS_KEY_ID=                                  # Local Garage: printf 'GK%s\n' "$(openssl rand -hex 16)"
-UPLOAD_S3_SECRET_ACCESS_KEY=                              # Local Garage: openssl rand -hex 32
-VITE_MAPBOX_TOKEN=                                        # Free tier at https://mapbox.com
+GARAGE_RPC_SECRET=
+UPLOAD_S3_ACCESS_KEY_ID=
+UPLOAD_S3_SECRET_ACCESS_KEY=
 
-# At least one auth provider (Google or Microsoft) must be configured.
+# --- Required in every environment ------------------
 
-VITE_GOOGLE_CLIENT_ID=                                    # Google Cloud Console -> APIs & Services -> Credentials -> OAuth 2.0 Client ID
-VITE_MICROSOFT_CLIENT_ID=                                 # Azure Portal -> App registrations -> Application (client) ID
-GOOGLE_CLIENT_SECRET=                                     # Google Cloud Console -> APIs & Services -> Credentials -> OAuth 2.0 Client Secret
+# Create at https://mapbox.com
+VITE_MAPBOX_TOKEN=
 
-# --- Optional - Key Rotation -------------------------
+# Required when building the frontend or using Compose. Backend-only local runs
+# use the application defaults.
+ENVIRONMENT=
+VITE_FRONTEND_URL=
 
-# SECRET_KEY_PREVIOUS=                                    # Old SECRET_KEY, kept during a rotation so existing encrypted tokens stay readable
+# --- Required in production -------------------------
+# Production requires at least one auth provider.
 
-# --- Optional - Contant Info -------------------------
+# Google Cloud Console -> APIs & Services -> Credentials -> OAuth 2.0 Client ID
+VITE_GOOGLE_CLIENT_ID=
+
+# Required when VITE_GOOGLE_CLIENT_ID is set.
+GOOGLE_CLIENT_SECRET=
+
+# Azure Portal -> App registrations -> Application (client) ID
+VITE_MICROSOFT_CLIENT_ID=
+
+# --- Compose and local development ------------------
+# These values target the bundled local Compose stack. Production endpoint
+# values belong in deployment infrastructure.
+
+TAG=latest
+DOMAIN=localhost
+
+# --- Database ---------------------------------------
+
+POSTGRES_DB=app
+POSTGRES_USER=postgres
+SQLALCHEMY_DATABASE_URI=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}
+
+# --- Direct uploads ---------------------------------
+
+UPLOAD_S3_BUCKET=wanderbound-uploads
+UPLOAD_S3_REGION=garage
+UPLOAD_S3_INTERNAL_ENDPOINT_URL=http://localhost:3900
+UPLOAD_S3_PUBLIC_ENDPOINT_URL=${UPLOAD_S3_INTERNAL_ENDPOINT_URL}
+UPLOAD_S3_BROWSER_ORIGIN=${UPLOAD_S3_PUBLIC_ENDPOINT_URL}
+UPLOAD_S3_ADDRESSING_STYLE=path
+
+# --- Optional application overrides ----------------
+# Uncomment only when overriding the defaults defined by the application.
+
+# Keep the old key during a rotation so existing encrypted tokens stay readable.
+# SECRET_KEY_PREVIOUS=
+
+# Comma-separated extra origins. VITE_FRONTEND_URL is always allowed.
+# BACKEND_CORS_ORIGINS=
+
+# Set a byte limit. Leave unset to detect 90% of the data filesystem capacity.
+# MAX_STORAGE_BYTES=
+
+# LOG_LEVEL=
+# UPLOAD_S3_PRESIGN_TTL_SECONDS=
+# UPLOAD_SESSION_TTL_SECONDS=
+
+# --- Optional contact information -------------------
 
 # VITE_CONTACT_EMAIL=
 # VITE_GITHUB_URL=
 # VITE_AUTHOR_NAME=
 # VITE_AUTHOR_URL=
 
-# --- Optional - Monitoring ---------------------------
+# --- Optional monitoring ----------------------------
 
-# SENTRY_DSN=                                             # Backend (Python/FastAPI)
-# VITE_SENTRY_DSN=                                        # Frontend (Vue/browser) - separate Sentry project
-# SENTRY_TRACES_SAMPLE_RATE=0.1
-# VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
-# SENTRY_AUTH_TOKEN=                                      # Org auth token for source map uploads
-# SENTRY_ORG=                                             # Sentry org slug (for source map uploads)
-# SENTRY_FRONTEND_PROJECT=                                # Sentry project slug (for source map uploads)
-# SENTRY_BACKEND_PROJECT=                                 # Sentry backend project slug for release metadata
+# Backend Python project DSN.
+# SENTRY_DSN=
+# SENTRY_TRACES_SAMPLE_RATE=
 
-# --- Defaults -----------------------------------------
-# For production: set DOMAIN, ENVIRONMENT=production, and VITE_FRONTEND_URL=https://<domain>.
+# Frontend browser project DSN.
+# VITE_SENTRY_DSN=
+# VITE_SENTRY_TRACES_SAMPLE_RATE=
 
-ENVIRONMENT=local                                          # local | production
-VITE_ENVIRONMENT=local                                     # Same value, exposed to Vite for direct frontend builds
-DOMAIN=localhost                                           # Used in Traefik labels and to construct the backend URL
-VITE_FRONTEND_URL=http://localhost:5173
-# BACKEND_CORS_ORIGINS=                                    # Comma-separated extra origins (VITE_FRONTEND_URL is always allowed)
-VITE_MAX_UPLOAD_GB=4
-MAX_STORAGE_BYTES=10737418240                              # 10 GB. 0 = auto-detect (90% of filesystem capacity).
-
-# --- Defaults - Direct uploads -----------------------
-
-GARAGE_RPC_SECRET=                                         # openssl rand -hex 32
-UPLOAD_S3_BUCKET=wanderbound-uploads
-UPLOAD_S3_REGION=garage
-UPLOAD_S3_INTERNAL_ENDPOINT_URL=http://object-storage:3900 # Backend-facing endpoint
-UPLOAD_S3_PUBLIC_ENDPOINT_URL=http://localhost:3900        # Endpoint used in signed browser URLs
-UPLOAD_S3_BROWSER_ORIGIN=http://localhost:3900             # Exact browser-facing origin, without a path
-UPLOAD_S3_ADDRESSING_STYLE=path
-UPLOAD_S3_PRESIGN_TTL_SECONDS=900
-UPLOAD_SESSION_TTL_SECONDS=86400
-
-# --- Defaults - Postgres -----------------------------
-
-POSTGRES_DB=app
-POSTGRES_USER=postgres
-
-# --- Defaults - DBOS Workflows -----------------------
-# DBOS stores durable workflow state in Postgres. By default it uses the app DB.
-# Each backend process gets a unique executor ID automatically. 
-# If you override DBOS_EXECUTOR_ID, use a different value per backend worker.
+# --- Optional DBOS workflow overrides ---------------
+# DBOS stores durable workflow state in Postgres and uses the app database by
+# default. Each backend process gets a unique executor ID automatically. If you
+# override DBOS_EXECUTOR_ID, use a different value per backend worker.
 
 # DBOS_SYSTEM_DATABASE_URI=
 # DBOS_EXECUTOR_ID=
-# DBOS_ADMIN_PORT=3001
-# DBOS_RUN_ADMIN_SERVER=true
-# DBOS_HEARTBEAT_TTL_SECONDS=60
-# DBOS_RECOVERY_INTERVAL_SECONDS=10
+# DBOS_ADMIN_PORT=
+# DBOS_RUN_ADMIN_SERVER=
+# DBOS_HEARTBEAT_TTL_SECONDS=
+# DBOS_RECOVERY_INTERVAL_SECONDS=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,9 @@ jobs:
       needs.changes.outputs.frontend == 'true' ||
       needs.changes.outputs.ci == 'true'
     env:
-      VITE_ENVIRONMENT: local
+      ENVIRONMENT: local
       VITE_FRONTEND_URL: http://localhost
+      VITE_MAPBOX_TOKEN: ci-public-token
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
@@ -233,10 +234,13 @@ jobs:
       SECRET_KEY: ci
       DOMAIN: localhost
       ENVIRONMENT: local
+      VITE_FRONTEND_URL: http://localhost:5173
+      VITE_MAPBOX_TOKEN: ci-public-token
     steps:
       - uses: actions/checkout@v7
         with:
           lfs: true
+      - run: cp .env.example .env
       - uses: jdx/mise-action@v4
         with:
           version: 2026.4.8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,8 +100,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VITE_MAX_UPLOAD_GB=${{ vars.VITE_MAX_UPLOAD_GB }}
-            VITE_ENVIRONMENT=production
+            ENVIRONMENT=production
             VITE_MAPBOX_TOKEN=${{ vars.VITE_MAPBOX_TOKEN }}
             VITE_GOOGLE_CLIENT_ID=${{ vars.VITE_GOOGLE_CLIENT_ID }}
             VITE_CONTACT_EMAIL=${{ vars.VITE_CONTACT_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ docker compose up -d
 
 Open `http://localhost:5173`.
 
-For production, set `DOMAIN` and `ENVIRONMENT=production` in `.env` and run
-`docker compose -f compose.yml up -d`.
+The bundled object storage binds only to loopback and is intended for local
+Compose use. Production deployments provide their exact S3 endpoints through
+deployment infrastructure.
 
 The Compose stack runs the app, database, and frontend. Configure database and
 app data backups in your deployment infrastructure.
@@ -77,11 +78,15 @@ must use the same `DATA_FOLDER` volume and database.
 commands. Install it, then:
 
 ```bash
-mise run setup               # Install deps, generate assets, run migrations
-docker compose up db -d      # Start Postgres
-mise run dev:backend         # FastAPI dev server
-mise run dev:frontend        # Vite dev server
+cp .env.example .env
+# Fill in the required values
+
+mise run setup # Install deps, generate assets, start the DB, run migrations
+mise run dev   # Start the full Compose development stack
 ```
+
+For host-run backend and frontend servers, use `mise run dev:db`,
+`mise run dev:storage`, `mise run dev:backend`, and `mise run dev:frontend`.
 
 Run `mise tasks` to see all available commands. Extra arguments pass
 through - e.g., `mise run test:backend -- -k test_auth`.

--- a/backend/app/api/v1/routes/uploads.py
+++ b/backend/app/api/v1/routes/uploads.py
@@ -21,7 +21,7 @@ from app.logic.workflows.uploads import (
     start_upload_workflow,
     upload_workflow_id,
 )
-from app.models.processing import UPLOAD_PART_SIZE_BYTES, UploadSession
+from app.models.processing import UploadSession
 from app.models.upload import UploadResult
 from app.models.user import User
 from app.services.upload_store import CompletionPart, ProviderPart, UploadStoreError
@@ -51,6 +51,11 @@ class CreateUploadResponse(BaseModel):
 
     upload_id: str = Field(serialization_alias="uploadId")
     key: str
+
+
+class UploadConfigResponse(BaseModel):
+    max_file_size_bytes: int
+    part_size_bytes: int
 
 
 class SignPartResponse(BaseModel):
@@ -116,12 +121,13 @@ def _require_key(row: UploadSession, key: str) -> None:
 
 
 def _part_size(row: UploadSession, part_number: int) -> int:
-    count = (row.size_bytes + UPLOAD_PART_SIZE_BYTES - 1) // UPLOAD_PART_SIZE_BYTES
+    part_size = get_settings().UPLOAD_PART_SIZE_BYTES
+    count = (row.size_bytes + part_size - 1) // part_size
     if not 1 <= part_number <= count:
         raise _error("upload_invalid_part", status.HTTP_422_UNPROCESSABLE_CONTENT)
     return min(
-        UPLOAD_PART_SIZE_BYTES,
-        row.size_bytes - (part_number - 1) * UPLOAD_PART_SIZE_BYTES,
+        part_size,
+        row.size_bytes - (part_number - 1) * part_size,
     )
 
 
@@ -132,6 +138,15 @@ def _ensure_uploading(row: UploadSession) -> None:
         raise _error("upload_not_active", status.HTTP_409_CONFLICT)
 
 
+@router.get("/config")
+async def upload_config() -> UploadConfigResponse:
+    settings = get_settings()
+    return UploadConfigResponse(
+        max_file_size_bytes=settings.MAX_UPLOAD_SIZE_BYTES,
+        part_size_bytes=settings.UPLOAD_PART_SIZE_BYTES,
+    )
+
+
 @router.post("/s3/multipart", status_code=status.HTTP_201_CREATED)
 async def create_upload(
     payload: CreateUploadRequest,
@@ -139,8 +154,8 @@ async def create_upload(
     session: SessionDep,
     store: UploadStoreDep,
 ) -> CreateUploadResponse:
-    maximum = get_settings().VITE_MAX_UPLOAD_GB * 1024**3
-    if not 0 < payload.metadata.size_bytes <= maximum:
+    settings = get_settings()
+    if not 0 < payload.metadata.size_bytes <= settings.MAX_UPLOAD_SIZE_BYTES:
         raise _error("upload_invalid_size", status.HTTP_400_BAD_REQUEST)
     existing, identity = await _resolve_auth(request, session)
     row = UploadSession.new(
@@ -149,7 +164,7 @@ async def create_upload(
         filename=payload.filename,
         content_type=payload.type,
         size_bytes=payload.metadata.size_bytes,
-        ttl_seconds=get_settings().UPLOAD_SESSION_TTL_SECONDS,
+        ttl_seconds=settings.UPLOAD_SESSION_TTL_SECONDS,
     )
     try:
         row.provider_upload_id = await asyncio.to_thread(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -76,7 +76,8 @@ class Settings(DatabaseSettings):
     VITE_GOOGLE_CLIENT_ID: str = ""
     VITE_MICROSOFT_CLIENT_ID: str = ""
     GOOGLE_CLIENT_SECRET: str = ""
-    VITE_MAX_UPLOAD_GB: int = Field(default=4, ge=1, le=4)
+    MAX_UPLOAD_SIZE_BYTES: int = 4 * 1024**3
+    UPLOAD_PART_SIZE_BYTES: int = 64 * 1024**2
 
     UPLOAD_S3_BUCKET: str
     UPLOAD_S3_REGION: str
@@ -99,7 +100,7 @@ class Settings(DatabaseSettings):
             str(self.VITE_FRONTEND_URL).rstrip("/")
         ]
 
-    VITE_MAPBOX_TOKEN: str | None = None
+    VITE_MAPBOX_TOKEN: str
 
     DATA_FOLDER: Path = Field(default=Path("./data").resolve())
     MAX_STORAGE_BYTES: int = 0
@@ -123,8 +124,6 @@ class Settings(DatabaseSettings):
         if self.ENVIRONMENT != "production":
             return self
         missing: list[str] = []
-        if not self.VITE_MAPBOX_TOKEN:
-            missing.append("VITE_MAPBOX_TOKEN")
         if "localhost" in str(self.VITE_FRONTEND_URL):
             missing.append("VITE_FRONTEND_URL")
         if not self.VITE_GOOGLE_CLIENT_ID and not self.VITE_MICROSOFT_CLIENT_ID:

--- a/backend/app/models/processing.py
+++ b/backend/app/models/processing.py
@@ -21,7 +21,6 @@ UploadStatus = Literal[
     "failed",
     "aborted",
 ]
-UPLOAD_PART_SIZE_BYTES = 67_108_864
 
 
 def _now() -> datetime:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -406,6 +406,27 @@
         }
       }
     },
+    "/api/v1/users/uploads/config": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Upload Config",
+        "operationId": "upload_config",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/users/uploads/s3/multipart": {
       "post": {
         "tags": [
@@ -4257,6 +4278,24 @@
         },
         "type": "object",
         "title": "UploadCompleteEvent"
+      },
+      "UploadConfigResponse": {
+        "properties": {
+          "max_file_size_bytes": {
+            "type": "integer",
+            "title": "Max File Size Bytes"
+          },
+          "part_size_bytes": {
+            "type": "integer",
+            "title": "Part Size Bytes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "max_file_size_bytes",
+          "part_size_bytes"
+        ],
+        "title": "UploadConfigResponse"
       },
       "UploadErrorEvent": {
         "properties": {

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,11 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault(
+    "SQLALCHEMY_DATABASE_URI",
+    "postgresql+psycopg://test:test@localhost/test",
+)
 os.environ.setdefault("UPLOAD_S3_BUCKET", "test-uploads")
 os.environ.setdefault("UPLOAD_S3_REGION", "test")
 os.environ.setdefault("UPLOAD_S3_INTERNAL_ENDPOINT_URL", "http://localhost:3900")
@@ -20,6 +25,7 @@ os.environ.setdefault("UPLOAD_S3_PUBLIC_ENDPOINT_URL", "http://localhost:3900")
 os.environ.setdefault("UPLOAD_S3_ADDRESSING_STYLE", "path")
 os.environ.setdefault("UPLOAD_S3_ACCESS_KEY_ID", "test")
 os.environ.setdefault("UPLOAD_S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("VITE_MAPBOX_TOKEN", "test")
 
 from app.api.v1.deps import _get_http_clients, _get_session
 from app.core.config import get_settings

--- a/backend/tests/test_config_defaults.py
+++ b/backend/tests/test_config_defaults.py
@@ -1,0 +1,15 @@
+from app.core.config import Settings
+
+
+def test_application_defaults_belong_to_settings() -> None:
+    defaulted_fields = (
+        "ENVIRONMENT",
+        "VITE_FRONTEND_URL",
+        "MAX_UPLOAD_SIZE_BYTES",
+        "UPLOAD_PART_SIZE_BYTES",
+    )
+
+    assert all(
+        not Settings.model_fields[field_name].is_required()
+        for field_name in defaulted_fields
+    )

--- a/backend/tests/test_direct_upload_routes.py
+++ b/backend/tests/test_direct_upload_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,6 +14,7 @@ from app.models.user import UserPublic
 from tests.factories import make_user, sign_in
 
 if TYPE_CHECKING:
+    import pytest
     from httpx import AsyncClient
     from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -36,6 +38,43 @@ async def test_multipart_routes_require_an_upload_owner(client: AsyncClient) -> 
     response = await client.post("/api/v1/users/uploads/s3/multipart", json=_payload())
 
     assert response.status_code == 401
+
+
+async def test_upload_config_matches_enforced_limits(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    configured_maximum = 12_345
+    configured_part_size = 4_321
+    monkeypatch.setattr(
+        "app.api.v1.routes.uploads.get_settings",
+        lambda: SimpleNamespace(
+            MAX_UPLOAD_SIZE_BYTES=configured_maximum,
+            UPLOAD_PART_SIZE_BYTES=configured_part_size,
+            UPLOAD_SESSION_TTL_SECONDS=60,
+        ),
+    )
+    store = MagicMock()
+    store.create.return_value = "provider-id"
+    app.dependency_overrides[_get_upload_store] = lambda: store
+    await sign_in(client)
+
+    config = await client.get("/api/v1/users/uploads/config")
+    maximum = config.json()["max_file_size_bytes"]
+
+    accepted = await client.post(
+        "/api/v1/users/uploads/s3/multipart",
+        json={**_payload(), "metadata": {"size_bytes": maximum}},
+    )
+    rejected = await client.post(
+        "/api/v1/users/uploads/s3/multipart",
+        json={**_payload(), "metadata": {"size_bytes": maximum + 1}},
+    )
+
+    assert config.status_code == 200
+    assert maximum == configured_maximum
+    assert config.json()["part_size_bytes"] == configured_part_size
+    assert accepted.status_code == 201
+    assert rejected.status_code == 400
 
 
 async def test_uppy_multipart_contract(

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -5,6 +5,10 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
 
+  object-storage:
+    ports:
+      - "127.0.0.1:3900:3900"
+
   backend:
     restart: "no"
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,7 @@ services:
           pids: 256
     networks: [backend]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:?Variable not set} -d ${POSTGRES_DB:?Variable not set}"]
       interval: 10s
       retries: 5
       start_period: 30s
@@ -51,13 +51,11 @@ services:
           pids: 256
     networks: [backend]
     command: [/garage, server, --single-node, --default-bucket]
-    ports:
-      - "127.0.0.1:3900:3900"
     environment:
-      GARAGE_RPC_SECRET: ${GARAGE_RPC_SECRET:-}
+      GARAGE_RPC_SECRET: ${GARAGE_RPC_SECRET:?Variable not set}
       GARAGE_DEFAULT_ACCESS_KEY: ${UPLOAD_S3_ACCESS_KEY_ID:?Variable not set}
       GARAGE_DEFAULT_SECRET_KEY: ${UPLOAD_S3_SECRET_ACCESS_KEY:?Variable not set}
-      GARAGE_DEFAULT_BUCKET: ${UPLOAD_S3_BUCKET:-wanderbound-uploads}
+      GARAGE_DEFAULT_BUCKET: ${UPLOAD_S3_BUCKET:?Variable not set}
     healthcheck:
       test: [CMD, /garage, status]
       interval: 5s
@@ -80,19 +78,19 @@ services:
         condition: service_healthy
     environment:
       AWS_ENDPOINT_URL: http://object-storage:3900
-      AWS_DEFAULT_REGION: ${UPLOAD_S3_REGION:-garage}
+      AWS_DEFAULT_REGION: ${UPLOAD_S3_REGION:?Variable not set}
       AWS_ACCESS_KEY_ID: ${UPLOAD_S3_ACCESS_KEY_ID:?Variable not set}
       AWS_SECRET_ACCESS_KEY: ${UPLOAD_S3_SECRET_ACCESS_KEY:?Variable not set}
       AWS_EC2_METADATA_DISABLED: "true"
-      UPLOAD_S3_BUCKET: ${UPLOAD_S3_BUCKET:-wanderbound-uploads}
-      UPLOAD_CORS_ORIGIN: ${VITE_FRONTEND_URL:-http://localhost:5173}
+      UPLOAD_S3_BUCKET: ${UPLOAD_S3_BUCKET:?Variable not set}
+      UPLOAD_CORS_ORIGIN: ${VITE_FRONTEND_URL:?Variable not set}
     tmpfs:
       - /tmp
     volumes:
       - ./scripts/init_upload_bucket.sh:/scripts/init_upload_bucket.sh:ro
 
   backend:
-    image: 'backend:${TAG:-latest}'
+    image: 'backend:${TAG:?Variable not set}'
     restart: always
     <<: *security
     init: true
@@ -118,36 +116,36 @@ services:
         condition: service_healthy
         restart: true
     environment:
-      SQLALCHEMY_DATABASE_URI: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      SECRET_KEY: ${SECRET_KEY:?Variable not set}
-      SECRET_KEY_PREVIOUS: ${SECRET_KEY_PREVIOUS:-}
-      VITE_FRONTEND_URL: ${VITE_FRONTEND_URL:-}
-      FRONTEND_URL: ${FRONTEND_URL:-http://frontend:8080}
-      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      VITE_MICROSOFT_CLIENT_ID: ${VITE_MICROSOFT_CLIENT_ID:-}
-      MAX_STORAGE_BYTES: ${MAX_STORAGE_BYTES:-}
-      BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS:-}
-      VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-}
-      ENVIRONMENT: ${ENVIRONMENT:?Variable not set}
-      APP_VERSION: ${APP_VERSION:-}
-      DBOS_SYSTEM_DATABASE_URI: ${DBOS_SYSTEM_DATABASE_URI:-}
-      DBOS_EXECUTOR_ID: ${DBOS_EXECUTOR_ID:-}
-      DBOS_ADMIN_PORT: ${DBOS_ADMIN_PORT:-3001}
-      DBOS_RUN_ADMIN_SERVER: ${DBOS_RUN_ADMIN_SERVER:-true}
-      DBOS_HEARTBEAT_TTL_SECONDS: ${DBOS_HEARTBEAT_TTL_SECONDS:-60}
-      DBOS_RECOVERY_INTERVAL_SECONDS: ${DBOS_RECOVERY_INTERVAL_SECONDS:-10}
-      SENTRY_DSN: ${SENTRY_DSN:-}
-      UPLOAD_S3_BUCKET: ${UPLOAD_S3_BUCKET:?Variable not set}
-      UPLOAD_S3_REGION: ${UPLOAD_S3_REGION:?Variable not set}
-      UPLOAD_S3_INTERNAL_ENDPOINT_URL: ${UPLOAD_S3_INTERNAL_ENDPOINT_URL:?Variable not set}
-      UPLOAD_S3_PUBLIC_ENDPOINT_URL: ${UPLOAD_S3_PUBLIC_ENDPOINT_URL:?Variable not set}
-      UPLOAD_S3_ADDRESSING_STYLE: ${UPLOAD_S3_ADDRESSING_STYLE:?Variable not set}
-      UPLOAD_S3_ACCESS_KEY_ID: ${UPLOAD_S3_ACCESS_KEY_ID:?Variable not set}
-      UPLOAD_S3_SECRET_ACCESS_KEY: ${UPLOAD_S3_SECRET_ACCESS_KEY:?Variable not set}
-      UPLOAD_S3_PRESIGN_TTL_SECONDS: ${UPLOAD_S3_PRESIGN_TTL_SECONDS:-900}
-      UPLOAD_SESSION_TTL_SECONDS: ${UPLOAD_SESSION_TTL_SECONDS:-86400}
-      VITE_MAX_UPLOAD_GB: ${VITE_MAX_UPLOAD_GB:-4}
+      - SQLALCHEMY_DATABASE_URI=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - SECRET_KEY=${SECRET_KEY:?Variable not set}
+      - SECRET_KEY_PREVIOUS
+      - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:?Variable not set}
+      - FRONTEND_URL=http://frontend:8080
+      - VITE_GOOGLE_CLIENT_ID
+      - GOOGLE_CLIENT_SECRET
+      - VITE_MICROSOFT_CLIENT_ID
+      - MAX_STORAGE_BYTES
+      - BACKEND_CORS_ORIGINS
+      - VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:?Variable not set}
+      - ENVIRONMENT=${ENVIRONMENT:?Variable not set}
+      - LOG_LEVEL
+      - DBOS_SYSTEM_DATABASE_URI
+      - DBOS_EXECUTOR_ID
+      - DBOS_ADMIN_PORT
+      - DBOS_RUN_ADMIN_SERVER
+      - DBOS_HEARTBEAT_TTL_SECONDS
+      - DBOS_RECOVERY_INTERVAL_SECONDS
+      - SENTRY_DSN
+      - SENTRY_TRACES_SAMPLE_RATE
+      - UPLOAD_S3_BUCKET=${UPLOAD_S3_BUCKET:?Variable not set}
+      - UPLOAD_S3_REGION=${UPLOAD_S3_REGION:?Variable not set}
+      - UPLOAD_S3_INTERNAL_ENDPOINT_URL=http://object-storage:3900
+      - UPLOAD_S3_PUBLIC_ENDPOINT_URL=${UPLOAD_S3_PUBLIC_ENDPOINT_URL:?Variable not set}
+      - UPLOAD_S3_ADDRESSING_STYLE=${UPLOAD_S3_ADDRESSING_STYLE:?Variable not set}
+      - UPLOAD_S3_ACCESS_KEY_ID=${UPLOAD_S3_ACCESS_KEY_ID:?Variable not set}
+      - UPLOAD_S3_SECRET_ACCESS_KEY=${UPLOAD_S3_SECRET_ACCESS_KEY:?Variable not set}
+      - UPLOAD_S3_PRESIGN_TTL_SECONDS
+      - UPLOAD_SESSION_TTL_SECONDS
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 10s
@@ -162,11 +160,11 @@ services:
       - app-data:/app/backend/data
 
   frontend:
-    image: 'frontend:${TAG:-latest}'
+    image: 'frontend:${TAG:?Variable not set}'
     restart: always
     <<: *security
     environment:
-      UPLOAD_S3_BROWSER_ORIGIN: ${UPLOAD_S3_BROWSER_ORIGIN:-http://localhost:3900}
+      UPLOAD_S3_BROWSER_ORIGIN: ${UPLOAD_S3_BROWSER_ORIGIN:?Variable not set}
     tmpfs:
       - /etc/nginx/conf.d:uid=101,gid=101
       - /var/cache/nginx:uid=101,gid=101
@@ -181,7 +179,8 @@ services:
     networks: [frontend]
     labels:
       - traefik.enable=true
-      - traefik.http.routers.wanderbound-fe.rule=Host(`${DOMAIN}`)
+      - traefik.docker.network=traefik
+      - traefik.http.routers.wanderbound-fe.rule=Host(`${DOMAIN:?Variable not set}`)
       - traefik.http.routers.wanderbound-fe.entrypoints=websecure
       - traefik.http.routers.wanderbound-fe.tls.certresolver=letsencrypt
       - traefik.http.services.wanderbound-fe.loadbalancer.server.port=8080
@@ -189,17 +188,17 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
       args:
-        - VITE_MAX_UPLOAD_GB=${VITE_MAX_UPLOAD_GB:-4}
-        - VITE_ENVIRONMENT=${ENVIRONMENT:?Variable not set}
-        - VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
-        - VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID:-}
-        - VITE_CONTACT_EMAIL=${VITE_CONTACT_EMAIL:-}
-        - VITE_GITHUB_URL=${VITE_GITHUB_URL:-}
-        - VITE_AUTHOR_NAME=${VITE_AUTHOR_NAME:-}
-        - VITE_AUTHOR_URL=${VITE_AUTHOR_URL:-}
-        - VITE_SENTRY_DSN=${VITE_SENTRY_DSN:-}
-        - VITE_SENTRY_TRACES_SAMPLE_RATE=${VITE_SENTRY_TRACES_SAMPLE_RATE:-0.1}
-        - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:-http://localhost}
+        - ENVIRONMENT=${ENVIRONMENT:?Variable not set}
+        - VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:?Variable not set}
+        - VITE_GOOGLE_CLIENT_ID
+        - VITE_MICROSOFT_CLIENT_ID
+        - VITE_CONTACT_EMAIL
+        - VITE_GITHUB_URL
+        - VITE_AUTHOR_NAME
+        - VITE_AUTHOR_URL
+        - VITE_SENTRY_DSN
+        - VITE_SENTRY_TRACES_SAMPLE_RATE
+        - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:?Variable not set}
 
 networks:
   backend:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,8 +19,7 @@ COPY ./frontend /app/frontend
 COPY ./PRIVACY.md ./TERMS.md /app/
 COPY ./backend/openapi.json /app/backend/openapi.json
 
-ARG VITE_MAX_UPLOAD_GB
-ARG VITE_ENVIRONMENT
+ARG ENVIRONMENT
 ARG VITE_MAPBOX_TOKEN
 ARG VITE_GOOGLE_CLIENT_ID
 ARG VITE_CONTACT_EMAIL
@@ -29,7 +28,7 @@ ARG VITE_AUTHOR_NAME
 ARG VITE_AUTHOR_URL
 ARG VITE_SENTRY_DSN
 ARG VITE_SENTRY_TRACES_SAMPLE_RATE
-ARG VITE_FRONTEND_URL=http://localhost
+ARG VITE_FRONTEND_URL
 ARG VITE_MICROSOFT_CLIENT_ID
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
@@ -54,11 +53,9 @@ COPY --from=build-stage /app/frontend/dist/ /usr/share/nginx/html
 COPY ./frontend/nginx/nginx.conf /etc/nginx/templates/default.conf.template
 COPY ./frontend/nginx/proxy-params.conf /etc/nginx/proxy-params.conf
 
-ENV NGINX_ENVSUBST_FILTER="BACKEND_HOST|BACKEND_PORT|MAX_UPLOAD_SIZE|UPLOAD_S3_BROWSER_ORIGIN"
+ENV NGINX_ENVSUBST_FILTER="BACKEND_HOST|BACKEND_PORT|UPLOAD_S3_BROWSER_ORIGIN"
 ENV BACKEND_HOST=backend
 ENV BACKEND_PORT=8000
-ENV MAX_UPLOAD_SIZE=4
-ENV UPLOAD_S3_BROWSER_ORIGIN=http://localhost:3900
 
 RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /run /etc/nginx/conf.d
 

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import { expect, test as base, type Page } from "@playwright/test";
+import type { UploadConfigResponse } from "@/client";
 import {
   mockUser,
   mockAuthStateAnonymous,
@@ -70,6 +71,17 @@ async function mockCommonApi(page: Page) {
   );
   await page.route("**/media/**", (route) =>
     route.fulfill({ contentType: "image/jpeg", body: mediaBody }),
+  );
+}
+
+async function mockUploadConfig(page: Page) {
+  await page.route(`${API}/users/uploads/config`, (route) =>
+    route.fulfill({
+      json: {
+        max_file_size_bytes: Number.MAX_SAFE_INTEGER,
+        part_size_bytes: Number.MAX_SAFE_INTEGER,
+      } satisfies UploadConfigResponse,
+    }),
   );
 }
 
@@ -234,6 +246,7 @@ export const test = base.extend<{
 }>({
   page: async ({ page }, use) => {
     const assertAllMocked = await installStrictMockGuard(page);
+    await mockUploadConfig(page);
     await use(page);
     assertAllMocked();
   },

--- a/frontend/integration/compose.yml
+++ b/frontend/integration/compose.yml
@@ -1,4 +1,8 @@
 services:
+  object-storage:
+    ports:
+      - "127.0.0.1:${DIRECT_UPLOAD_STORAGE_PORT:?Variable not set}:3900"
+
   backend:
     command: >-
       sh -c "alembic upgrade head &&
@@ -7,7 +11,7 @@ services:
 
   frontend:
     ports:
-      - "127.0.0.1:5173:8080"
+      - "127.0.0.1:${DIRECT_UPLOAD_FRONTEND_PORT:?Variable not set}:8080"
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/integration/direct-upload.spec.ts
+++ b/frontend/integration/direct-upload.spec.ts
@@ -3,14 +3,14 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
-const frontendOrigin = "http://localhost:5173";
-const garageOrigin = "http://localhost:3900";
+const frontendOrigin = process.env.DIRECT_UPLOAD_BASE_URL;
+const garageOrigin = process.env.UPLOAD_S3_BROWSER_ORIGIN;
 const fixturePath = process.env.DIRECT_UPLOAD_FIXTURE;
 const projectName = process.env.COMPOSE_PROJECT_NAME;
 const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 const execFileAsync = promisify(execFile);
 
-if (!fixturePath || !projectName) {
+if (!frontendOrigin || !garageOrigin || !fixturePath || !projectName) {
   throw new Error("direct upload integration environment is incomplete");
 }
 

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -17,7 +17,6 @@ upstream backend {
 server {
   listen 8080;
   root /usr/share/nginx/html;
-  client_max_body_size ${MAX_UPLOAD_SIZE}g;
   client_body_timeout 300s;
   limit_req_status 429;
 

--- a/frontend/playwright.upload-integration.config.ts
+++ b/frontend/playwright.upload-integration.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
+const baseURL = process.env.DIRECT_UPLOAD_BASE_URL;
+if (!baseURL) throw new Error("DIRECT_UPLOAD_BASE_URL must be set");
+
 export default defineConfig({
   timeout: 120_000,
   expect: { timeout: 15_000 },
@@ -10,7 +13,7 @@ export default defineConfig({
   outputDir: "./integration/test-results",
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "line",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },

--- a/frontend/src/components/register/ZipUploader.vue
+++ b/frontend/src/components/register/ZipUploader.vue
@@ -10,8 +10,12 @@ const emit = defineEmits<{
   uploaded: [data: UploadResult];
 }>();
 
-const maxUploadGb = Number(import.meta.env.VITE_MAX_UPLOAD_GB) || 4;
-const maxFileSize = maxUploadGb * 1024 * 1024 * 1024;
+const props = defineProps<{
+  maxFileSize: number;
+  partSize: number;
+}>();
+
+const maxUploadGb = props.maxFileSize / 1024 ** 3;
 const $q = useQuasar();
 const { t } = useI18n();
 const dragging = ref(false);
@@ -27,7 +31,8 @@ const {
   cancel,
   reset,
 } = useDirectZipUpload({
-  maxFileSize,
+  maxFileSize: props.maxFileSize,
+  partSize: props.partSize,
   onUploaded: (result) => emit("uploaded", result),
 });
 
@@ -70,7 +75,7 @@ function handleFile(selected: File) {
     $q.notify({ type: "negative", message: t("register.badZip") });
     return;
   }
-  if (selected.size > maxFileSize) {
+  if (selected.size > props.maxFileSize) {
     $q.notify({
       type: "negative",
       message: t("register.fileTooLarge", { max: maxUploadGb }),

--- a/frontend/src/composables/useDirectZipUpload.ts
+++ b/frontend/src/composables/useDirectZipUpload.ts
@@ -9,7 +9,6 @@ import AwsS3 from "@uppy/aws-s3";
 import Uppy, { type UppyFile } from "@uppy/core";
 import { onScopeDispose, ref } from "vue";
 
-const PART_SIZE = 64 * 1024 * 1024;
 const COMPLETION_ATTEMPTS = 3;
 const STREAM_CONNECTIONS = 3;
 
@@ -111,6 +110,7 @@ export async function followUploadIngestion(
 
 export function useDirectZipUpload(options: {
   maxFileSize: number;
+  partSize: number;
   onUploaded: (result: UploadResult) => void;
 }) {
   const file = ref<File | null>(null);
@@ -133,7 +133,7 @@ export function useDirectZipUpload(options: {
     limit: 8,
     shouldUseMultipart: true,
     allowedMetaFields: ["size_bytes"],
-    getChunkSize: () => PART_SIZE,
+    getChunkSize: () => options.partSize,
   });
 
   function clearState() {

--- a/frontend/src/pages/UploadView.vue
+++ b/frontend/src/pages/UploadView.vue
@@ -7,6 +7,7 @@ import type { UploadResult } from "@/client";
 import { useTripProcessingStream } from "@/composables/useTripProcessingStream";
 import { useUserQuery } from "@/queries/useUserQuery";
 import { useAuthStateQuery } from "@/queries/useAuthStateQuery";
+import { useUploadConfigQuery } from "@/queries/useUploadConfigQuery";
 import { queryKeys } from "@/queries/keys";
 import { useI18n } from "vue-i18n";
 import { useMeta } from "quasar";
@@ -27,6 +28,7 @@ const router = useRouter();
 const cache = useQueryCache();
 
 const { data: authStateData } = useAuthStateQuery();
+const { data: uploadConfig } = useUploadConfigQuery();
 const { user } = useUserQuery();
 const stream = useTripProcessingStream();
 const handoff = (history.state ?? {}) as {
@@ -136,10 +138,15 @@ function onDone() {
           <q-separator class="q-my-md" />
         </template>
 
-        <ZipUploader
-          v-if="mapboxSupported"
-          @uploaded="onUploaded"
-        />
+        <template v-if="mapboxSupported">
+          <ZipUploader
+            v-if="uploadConfig"
+            :max-file-size="uploadConfig.max_file_size_bytes"
+            :part-size="uploadConfig.part_size_bytes"
+            @uploaded="onUploaded"
+          />
+          <q-skeleton v-else type="rect" height="10rem" />
+        </template>
         <UnsupportedBanner v-else :reason="mapboxReason" />
       </q-card>
 

--- a/frontend/src/queries/keys.ts
+++ b/frontend/src/queries/keys.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
     [...queryKeys.printBundles(aid), chapter ?? NONE] as const,
   user: () => ["user"] as const,
   authState: () => ["auth-state"] as const,
+  uploadConfig: () => ["upload-config"] as const,
 };
 
 function isPrintBundlesKey(key: EntryKey): boolean {

--- a/frontend/src/queries/useUploadConfigQuery.ts
+++ b/frontend/src/queries/useUploadConfigQuery.ts
@@ -1,0 +1,11 @@
+import { uploadConfig } from "@/client";
+import { useQuery } from "@pinia/colada";
+import { queryKeys } from "./keys";
+
+export function useUploadConfigQuery() {
+  return useQuery({
+    key: queryKeys.uploadConfig(),
+    query: async () => (await uploadConfig()).data,
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -10,7 +10,6 @@ declare const APP_VERSION: string | undefined;
 
 interface ImportMetaEnv {
   readonly VITE_ENVIRONMENT: "local" | "production";
-  readonly VITE_MAX_UPLOAD_GB: string;
   readonly VITE_MAPBOX_TOKEN: string;
   readonly VITE_GOOGLE_CLIENT_ID: string;
   readonly VITE_MICROSOFT_CLIENT_ID: string;

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import type { UploadConfigResponse } from "@/client";
 import {
   mockUser,
   mockAlbum,
@@ -18,6 +19,12 @@ export {
 } from "../fixtures/mocks";
 
 export const handlers = [
+  http.get(`${BASE}/users/uploads/config`, () =>
+    HttpResponse.json({
+      max_file_size_bytes: Number.MAX_SAFE_INTEGER,
+      part_size_bytes: Number.MAX_SAFE_INTEGER,
+    } satisfies UploadConfigResponse),
+  ),
   http.get(`${BASE}/users`, () => HttpResponse.json(mockUser)),
   http.patch(`${BASE}/users`, () => HttpResponse.json(mockUser)),
   http.get(`${BASE}/albums/:aid`, () => HttpResponse.json(mockAlbum)),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,15 +10,19 @@ const sentryApplicationKey = "wanderbound";
 const envDir = path.resolve(__dirname, "..");
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, envDir);
-  const environment = env.VITE_ENVIRONMENT;
+  const env = loadEnv(mode, envDir, "");
+  const environment = env.ENVIRONMENT;
   if (environment !== "local" && environment !== "production") {
-    throw new Error("VITE_ENVIRONMENT must be set to local or production");
+    throw new Error("ENVIRONMENT must be set to local or production");
+  }
+  if (!env.VITE_MAPBOX_TOKEN) {
+    throw new Error("VITE_MAPBOX_TOKEN must be set");
   }
 
   return {
     define: {
       APP_VERSION: JSON.stringify(version),
+      "import.meta.env.VITE_ENVIRONMENT": JSON.stringify(environment),
     },
     envDir,
     server: {

--- a/mise.toml
+++ b/mise.toml
@@ -22,10 +22,26 @@ run = [
     "prek install --prepare-hooks",
     "prek install --hook-type commit-msg",
     "mise run generate",
+    "mise run dev:db",
     "mise run db:migrate",
 ]
 
 # -- Dev servers --------------------------------------------------
+
+[tasks."dev:db"]
+description = "Start the development database"
+run = "docker compose up db --detach"
+
+[tasks."dev:storage"]
+description = "Start and initialize development object storage"
+run = "docker compose up object-storage object-storage-init --detach"
+
+[tasks.dev]
+description = "Start the complete development stack"
+run = [
+    "docker network inspect traefik >/dev/null 2>&1 || docker network create traefik",
+    "docker compose up --detach",
+]
 
 [tasks."dev:backend"]
 description = "Start backend dev server"

--- a/scripts/generate_direct_upload_fixture.py
+++ b/scripts/generate_direct_upload_fixture.py
@@ -3,9 +3,10 @@ from pathlib import Path
 from sys import argv
 from zipfile import ZIP_STORED, ZipFile
 
+from app.core.config import get_settings
 
-PART_SIZE = 64 * 1024 * 1024
-PAYLOAD_SIZE = 2 * PART_SIZE + 1024 * 1024
+
+PAYLOAD_SIZE = 2 * get_settings().UPLOAD_PART_SIZE_BYTES + 1024 * 1024
 WRITE_SIZE = 1024 * 1024
 
 

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -15,6 +15,7 @@ os.environ.setdefault("UPLOAD_S3_PUBLIC_ENDPOINT_URL", "http://localhost:3900")
 os.environ.setdefault("UPLOAD_S3_ADDRESSING_STYLE", "path")
 os.environ.setdefault("UPLOAD_S3_ACCESS_KEY_ID", "codegen")
 os.environ.setdefault("UPLOAD_S3_SECRET_ACCESS_KEY", "codegen")
+os.environ.setdefault("VITE_MAPBOX_TOKEN", "codegen")
 
 from app.main import app  # noqa: E402
 

--- a/scripts/run_direct_upload_integration.sh
+++ b/scripts/run_direct_upload_integration.sh
@@ -7,9 +7,17 @@ env_file="$work_dir/integration.env"
 fixture="$work_dir/direct-upload.zip"
 project_name="wanderbound-direct-upload-$(basename "$work_dir" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
 
+free_port() {
+  python -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+storage_port=$(free_port)
+frontend_port=$(free_port)
+
 compose=(
   docker compose
   --project-name "$project_name"
+  --env-file "$root/.env.example"
   --env-file "$env_file"
   -f "$root/compose.yml"
   -f "$root/frontend/integration/compose.yml"
@@ -34,16 +42,17 @@ printf '%s\n' \
   "POSTGRES_USER=postgres" \
   "POSTGRES_DB=app" \
   "ENVIRONMENT=local" \
-  "VITE_ENVIRONMENT=local" \
+  "VITE_MAPBOX_TOKEN=integration-public-token" \
   "DOMAIN=localhost" \
-  "VITE_FRONTEND_URL=http://localhost:5173" \
-  "VITE_MAX_UPLOAD_GB=1" \
+  "VITE_FRONTEND_URL=http://localhost:$frontend_port" \
+  "DIRECT_UPLOAD_STORAGE_PORT=$storage_port" \
+  "DIRECT_UPLOAD_FRONTEND_PORT=$frontend_port" \
   "MAX_STORAGE_BYTES=1073741824" \
   "UPLOAD_S3_BUCKET=wanderbound-integration-uploads" \
   "UPLOAD_S3_REGION=garage" \
   "UPLOAD_S3_INTERNAL_ENDPOINT_URL=http://object-storage:3900" \
-  "UPLOAD_S3_PUBLIC_ENDPOINT_URL=http://localhost:3900" \
-  "UPLOAD_S3_BROWSER_ORIGIN=http://localhost:3900" \
+  "UPLOAD_S3_PUBLIC_ENDPOINT_URL=http://localhost:$storage_port" \
+  "UPLOAD_S3_BROWSER_ORIGIN=http://localhost:$storage_port" \
   "UPLOAD_S3_ADDRESSING_STYLE=path" \
   "UPLOAD_S3_ACCESS_KEY_ID=GK00000000000000000000000000000000" \
   "UPLOAD_S3_SECRET_ACCESS_KEY=0000000000000000000000000000000000000000000000000000000000000000" \
@@ -51,14 +60,16 @@ printf '%s\n' \
   >"$env_file"
 
 set -a
+source "$root/.env.example"
 source "$env_file"
 set +a
 uv run --directory "$root/backend" python ../scripts/generate_openapi.py
-python "$root/scripts/generate_direct_upload_fixture.py" "$fixture"
+uv run --directory "$root/backend" python ../scripts/generate_direct_upload_fixture.py "$fixture"
 "${compose[@]}" down --volumes --remove-orphans
 "${compose[@]}" up --detach --build --wait
 
 cd "$root/frontend"
+DIRECT_UPLOAD_BASE_URL="http://localhost:$frontend_port" \
 DIRECT_UPLOAD_FIXTURE="$fixture" bun x playwright test \
   --config playwright.upload-integration.config.ts \
   "$@"


### PR DESCRIPTION
- keep application defaults in Pydantic `Settings` and require only shared or deployment-specific values from the environment
- remove Compose fallback defaults, duplicate Vite configuration, and the invented public Garage host and route
- serve upload and multipart limits from `Settings` through one runtime configuration endpoint
- keep Garage private in the base stack, with loopback publishing only in the development override
- add `mise run dev:db`, `mise run dev:storage`, and `mise run dev`
- make the direct-upload integration stack allocate isolated ports and consume its configured origins