### PR TITLE
feat: publish installation-neutral release images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,10 @@ GOOGLE_CLIENT_SECRET=                                     # Google Cloud Console
 # VITE_SENTRY_DSN=                                        # Frontend (Vue/browser) - separate Sentry project
 # SENTRY_TRACES_SAMPLE_RATE=0.1
 # VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
+# SENTRY_URL=                                             # Set only for a non-default or self-hosted Sentry server
 # SENTRY_AUTH_TOKEN=                                      # Org auth token for source map uploads
 # SENTRY_ORG=                                             # Sentry org slug (for source map uploads)
 # SENTRY_FRONTEND_PROJECT=                                # Sentry project slug (for source map uploads)
-# SENTRY_BACKEND_PROJECT=                                 # Sentry backend project slug for release metadata
 
 # --- Defaults -----------------------------------------
 # For production: set DOMAIN, ENVIRONMENT=production, and VITE_FRONTEND_URL=https://<domain>.
@@ -40,6 +40,7 @@ GOOGLE_CLIENT_SECRET=                                     # Google Cloud Console
 ENVIRONMENT=local                                          # local | production
 VITE_ENVIRONMENT=local                                     # Same value, exposed to Vite for direct frontend builds
 DOMAIN=localhost                                           # Used in Traefik labels and to construct the backend URL
+TAG=latest                                                 # Shared backend, frontend, and source-map image tag
 VITE_FRONTEND_URL=http://localhost:5173
 # BACKEND_CORS_ORIGINS=                                    # Comma-separated extra origins (VITE_FRONTEND_URL is always allowed)
 VITE_MAX_UPLOAD_GB=4
@@ -64,7 +65,7 @@ POSTGRES_USER=postgres
 
 # --- Defaults - DBOS Workflows -----------------------
 # DBOS stores durable workflow state in Postgres. By default it uses the app DB.
-# Each backend process gets a unique executor ID automatically. 
+# Each backend process gets a unique executor ID automatically.
 # If you override DBOS_EXECUTOR_ID, use a different value per backend worker.
 
 # DBOS_SYSTEM_DATABASE_URI=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
             docker:
               - 'compose.yml'
               - 'compose.override.yml'
+              - 'docker-bake.hcl'
               - 'garage.toml'
               - '.dockerignore'
               - 'backend/Dockerfile'
@@ -69,6 +70,7 @@ jobs:
               - 'scripts/init_upload_bucket.sh'
               - 'scripts/generate_direct_upload_fixture.py'
               - 'scripts/run_direct_upload_integration.sh'
+              - 'scripts/check_public_images.py'
               - 'PRIVACY.md'
               - 'TERMS.md'
             ci:
@@ -252,6 +254,7 @@ jobs:
         with:
           source: .
           files: compose.yml
+          targets: backend,frontend
           load: true
           set: |
             backend.cache-from=type=gha,scope=backend,repository=${{ github.repository }},ghtoken=${{ github.token }}
@@ -262,12 +265,30 @@ jobs:
         with:
           source: .
           files: compose.yml
+          targets: backend,frontend
           load: true
           set: |
             backend.cache-from=type=gha,scope=backend,repository=${{ github.repository }},ghtoken=${{ github.token }}
             backend.cache-to=type=gha,mode=min,scope=backend,repository=${{ github.repository }},ghtoken=${{ github.token }}
             frontend.cache-from=type=gha,scope=frontend,repository=${{ github.repository }},ghtoken=${{ github.token }}
             frontend.cache-to=type=gha,mode=max,scope=frontend,repository=${{ github.repository }},ghtoken=${{ github.token }}
+      - name: Build paired frontend artifacts
+        uses: docker/bake-action@v7
+        with:
+          source: .
+          files: docker-bake.hcl
+          targets: frontend-release
+          load: true
+          vars: |
+            APP_VERSION=ci
+            GIT_REVISION=${{ github.sha }}
+          set: |
+            frontend.cache-from=type=gha,scope=frontend-public,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            sourcemaps.cache-from=type=gha,scope=frontend-sourcemaps,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            frontend.cache-to=type=gha,mode=max,scope=frontend-public,repository=${{ github.repository }},ghtoken=${{ github.token }}
+            sourcemaps.cache-to=type=gha,mode=max,scope=frontend-sourcemaps,repository=${{ github.repository }},ghtoken=${{ github.token }}
+      - name: Verify paired frontend artifacts
+        run: mise run --skip-tools check:public-images
       - run: docker compose up -d --no-build
       - name: Wait for backend health
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,6 @@
 name: Publish
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
@@ -20,19 +16,28 @@ permissions:
   contents: read
 
 jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate stable SemVer tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH without leading zeroes"
+            exit 1
+          fi
+
   build-backend:
-    if: >-
-      github.event_name == 'push' ||
-      github.event.workflow_run.conclusion == 'success'
+    needs: validate-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           lfs: true
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - id: app-version
-        run: echo "value=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+        run: echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -43,13 +48,9 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-backend
+          flavor: latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=${{ steps.app-version.outputs.value }}
-            type=sha
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' }}
+            type=semver,pattern={{raw}}
       - uses: docker/build-push-action@v7
         with:
           context: .
@@ -63,117 +64,73 @@ jobs:
           cache-to: type=gha,mode=max,scope=backend
 
   build-frontend:
-    if: >-
-      github.event_name == 'push' ||
-      github.event.workflow_run.conclusion == 'success'
+    needs: validate-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           lfs: true
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - id: app-version
-        run: echo "value=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+        run: echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
+      - id: meta-frontend
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-frontend
+          bake-target: frontend
+          flavor: latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=${{ steps.app-version.outputs.value }}
-            type=sha
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' }}
-      - uses: docker/build-push-action@v7
+            type=semver,pattern={{raw}}
+      - id: meta-sourcemaps
+        uses: docker/metadata-action@v6
         with:
-          context: .
-          file: frontend/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VITE_MAX_UPLOAD_GB=${{ vars.VITE_MAX_UPLOAD_GB }}
-            VITE_ENVIRONMENT=production
-            VITE_MAPBOX_TOKEN=${{ vars.VITE_MAPBOX_TOKEN }}
-            VITE_GOOGLE_CLIENT_ID=${{ vars.VITE_GOOGLE_CLIENT_ID }}
-            VITE_CONTACT_EMAIL=${{ vars.VITE_CONTACT_EMAIL }}
-            VITE_GITHUB_URL=${{ vars.VITE_GITHUB_URL }}
-            VITE_AUTHOR_NAME=${{ vars.VITE_AUTHOR_NAME }}
-            VITE_AUTHOR_URL=${{ vars.VITE_AUTHOR_URL }}
-            VITE_SENTRY_DSN=${{ vars.VITE_SENTRY_DSN }}
-            VITE_SENTRY_TRACES_SAMPLE_RATE=${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}
-            VITE_FRONTEND_URL=${{ vars.VITE_FRONTEND_URL }}
-            VITE_MICROSOFT_CLIENT_ID=${{ vars.VITE_MICROSOFT_CLIENT_ID }}
-            SENTRY_ORG=${{ vars.SENTRY_ORG }}
-            SENTRY_FRONTEND_PROJECT=${{ vars.SENTRY_FRONTEND_PROJECT }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-sourcemaps
+          bake-target: sourcemaps
+          flavor: latest=false
+          tags: |
+            type=semver,pattern={{raw}}
+      - uses: jdx/mise-action@v4
+        with:
+          version: 2026.4.8
+          install_args: python uv
+      - name: Build paired frontend artifacts for verification
+        uses: docker/bake-action@v7
+        with:
+          source: .
+          files: |
+            ./docker-bake.hcl
+            cwd://${{ steps.meta-frontend.outputs.bake-file }}
+            cwd://${{ steps.meta-sourcemaps.outputs.bake-file }}
+          targets: frontend-release
+          load: true
+          vars: |
             APP_VERSION=${{ steps.app-version.outputs.value }}
-          secrets: |
-            "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,mode=max,scope=frontend
-
-  create-sentry-release:
-    if: >-
-      github.event_name == 'push' ||
-      github.event.workflow_run.conclusion == 'success'
-    needs: [build-backend, build-frontend]
-    runs-on: ubuntu-latest
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-      - id: app-version
-        run: echo "value=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
-      - id: sentry-projects
+            GIT_REVISION=${{ github.sha }}
+          set: |
+            frontend.cache-from=type=gha,scope=frontend-public
+            frontend.cache-to=type=gha,mode=max,scope=frontend-public
+            sourcemaps.cache-from=type=gha,scope=frontend-sourcemaps
+            sourcemaps.cache-to=type=gha,mode=max,scope=frontend-sourcemaps
+      - name: Verify paired frontend artifacts
+        env:
+          FRONTEND_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-frontend:${{ steps.meta-frontend.outputs.version }}
+          SOURCEMAPS_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-sourcemaps:${{ steps.meta-sourcemaps.outputs.version }}
+        run: mise run --skip-tools check:public-images
+      - name: Push verified frontend artifacts
+        env:
+          FRONTEND_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-frontend:${{ steps.meta-frontend.outputs.version }}
+          SOURCEMAPS_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/wanderbound-sourcemaps:${{ steps.meta-sourcemaps.outputs.version }}
         run: |
-          projects=()
-          if [ -n "$SENTRY_FRONTEND_PROJECT" ]; then
-            projects+=("$SENTRY_FRONTEND_PROJECT")
-          fi
-          if [ -n "$SENTRY_BACKEND_PROJECT" ]; then
-            projects+=("$SENTRY_BACKEND_PROJECT")
-          fi
-          echo "value=${projects[*]}" >> "$GITHUB_OUTPUT"
-        env:
-          SENTRY_FRONTEND_PROJECT: ${{ vars.SENTRY_FRONTEND_PROJECT }}
-          SENTRY_BACKEND_PROJECT: ${{ vars.SENTRY_BACKEND_PROJECT }}
-      - name: Skip Sentry release
-        if: >-
-          env.SENTRY_AUTH_TOKEN == '' ||
-          env.SENTRY_ORG == '' ||
-          steps.sentry-projects.outputs.value == ''
-        run: echo "Skipping Sentry release because Sentry is not fully configured."
-      - uses: getsentry/action-release@v3
-        if: >-
-          env.SENTRY_AUTH_TOKEN != '' &&
-          env.SENTRY_ORG != '' &&
-          steps.sentry-projects.outputs.value != ''
-        env:
-          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ env.SENTRY_ORG }}
-        with:
-          environment: production
-          release: ${{ steps.app-version.outputs.value }}
-          projects: ${{ steps.sentry-projects.outputs.value }}
-          set_commits: auto
-          ignore_missing: true
-          ignore_empty: true
-          disable_telemetry: true
+          docker push "$FRONTEND_IMAGE"
+          docker push "$SOURCEMAPS_IMAGE"
 
   create-github-release:
-    if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-backend, build-frontend]
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ For production, set `DOMAIN` and `ENVIRONMENT=production` in `.env` and run
 The Compose stack runs the app, database, and frontend. Configure database and
 app data backups in your deployment infrastructure.
 
+The frontend reads its `VITE_*` settings when the container starts. Published
+frontend images do not contain one installation's values. Replace the frontend
+container after changing those settings.
+
+Published images use immutable `vMAJOR.MINOR.PATCH` release tags. Commits to
+`main` do not publish images, and no mutable `latest`, major, or minor aliases
+are published.
+
+Frontend source maps are published in a separate image with the same release
+tags. To upload a release's maps to your own Sentry project, set
+`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_FRONTEND_PROJECT`. Set
+`TAG` to the exact deployed frontend release tag. Set `SENTRY_URL` only for a
+non-default or self-hosted Sentry server, then run:
+
+```bash
+docker compose --profile sentry run --rm sentry-sourcemaps
+```
+
+This optional command reads the release from the source-map image. It does not
+change the application images or their startup configuration.
+
 The backend stores upload and processing progress in shared storage and Postgres,
 so multiple backend workers can serve the same user flow. All backend workers
 must use the same `DATA_FOLDER` volume and database.

--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -40,6 +40,12 @@ SENTRY_INFO_LOG_EVENTS = {
 }
 
 
+def sentry_release(version: str | None) -> str | None:
+    if not version:
+        return None
+    return f"wanderbound@{version.removeprefix('v')}"
+
+
 def setup_sentry(settings: Settings) -> None:
     if not _sentry_enabled(settings):
         return
@@ -52,7 +58,7 @@ def setup_sentry(settings: Settings) -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         environment=settings.ENVIRONMENT,
-        release=settings.APP_VERSION,
+        release=sentry_release(settings.APP_VERSION),
         traces_sampler=_traces_sampler(settings),
         trace_propagation_targets=[],
         trace_ignore_status_codes={404},

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -1,0 +1,8 @@
+from app.core.sentry import sentry_release
+
+
+def test_sentry_release_uses_package_semver() -> None:
+    assert sentry_release("v1.7.0") == "wanderbound@1.7.0"
+    assert sentry_release("1.7.0") == "wanderbound@1.7.0"
+    assert sentry_release("v1.7.0-5-g5bd3780e") == "wanderbound@1.7.0-5-g5bd3780e"
+    assert sentry_release(None) is None

--- a/compose.yml
+++ b/compose.yml
@@ -166,6 +166,18 @@ services:
     restart: always
     <<: *security
     environment:
+      VITE_ENVIRONMENT: ${ENVIRONMENT:?Variable not set}
+      VITE_MAX_UPLOAD_GB: ${VITE_MAX_UPLOAD_GB:-4}
+      VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-}
+      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
+      VITE_MICROSOFT_CLIENT_ID: ${VITE_MICROSOFT_CLIENT_ID:-}
+      VITE_CONTACT_EMAIL: ${VITE_CONTACT_EMAIL:-}
+      VITE_GITHUB_URL: ${VITE_GITHUB_URL:-}
+      VITE_AUTHOR_NAME: ${VITE_AUTHOR_NAME:-}
+      VITE_AUTHOR_URL: ${VITE_AUTHOR_URL:-}
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+      VITE_SENTRY_TRACES_SAMPLE_RATE: ${VITE_SENTRY_TRACES_SAMPLE_RATE:-0.1}
+      VITE_FRONTEND_URL: ${VITE_FRONTEND_URL:-http://localhost}
       UPLOAD_S3_BROWSER_ORIGIN: ${UPLOAD_S3_BROWSER_ORIGIN:-http://localhost:3900}
     tmpfs:
       - /etc/nginx/conf.d:uid=101,gid=101
@@ -188,18 +200,27 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
-      args:
-        - VITE_MAX_UPLOAD_GB=${VITE_MAX_UPLOAD_GB:-4}
-        - VITE_ENVIRONMENT=${ENVIRONMENT:?Variable not set}
-        - VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
-        - VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID:-}
-        - VITE_CONTACT_EMAIL=${VITE_CONTACT_EMAIL:-}
-        - VITE_GITHUB_URL=${VITE_GITHUB_URL:-}
-        - VITE_AUTHOR_NAME=${VITE_AUTHOR_NAME:-}
-        - VITE_AUTHOR_URL=${VITE_AUTHOR_URL:-}
-        - VITE_SENTRY_DSN=${VITE_SENTRY_DSN:-}
-        - VITE_SENTRY_TRACES_SAMPLE_RATE=${VITE_SENTRY_TRACES_SAMPLE_RATE:-0.1}
-        - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:-http://localhost}
+      target: frontend
+
+  sentry-sourcemaps:
+    profiles: [sentry]
+    image: ghcr.io/itay-raveh/wanderbound-sourcemaps:${TAG:-latest}
+    user: "101:101"
+    read_only: true
+    environment:
+      SENTRY_URL: ${SENTRY_URL:-https://sentry.io/}
+      SENTRY_ORG: ${SENTRY_ORG:-}
+      SENTRY_PROJECT: ${SENTRY_FRONTEND_PROJECT:-}
+      SENTRY_AUTH_TOKEN: ${SENTRY_AUTH_TOKEN:-}
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - 'exec sentry-cli sourcemaps upload --release "wanderbound@$${APP_VERSION#v}" --validate --wait /artifacts'
+    tmpfs:
+      - /tmp
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      target: sourcemaps
 
 networks:
   backend:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,35 @@
+variable "APP_VERSION" {
+  default = "development"
+}
+
+variable "GIT_REVISION" {
+  default = "local"
+}
+
+target "_frontend-build" {
+  context    = "."
+  dockerfile = "frontend/Dockerfile"
+  args = {
+    APP_VERSION = APP_VERSION
+  }
+  labels = {
+    "org.opencontainers.image.revision" = GIT_REVISION
+    "org.opencontainers.image.version"  = APP_VERSION
+  }
+}
+
+target "frontend" {
+  inherits = ["_frontend-build"]
+  target   = "frontend"
+  tags     = ["wanderbound-frontend:local"]
+}
+
+target "sourcemaps" {
+  inherits = ["_frontend-build"]
+  target   = "sourcemaps"
+  tags     = ["wanderbound-sourcemaps:local"]
+}
+
+group "frontend-release" {
+  targets = ["frontend", "sourcemaps"]
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,3 @@
-# check=skip=SecretsUsedInArgOrEnv (all ARGs are public frontend config, not secrets)
 FROM oven/bun:1-debian AS build-stage
 
 WORKDIR /app
@@ -19,40 +18,32 @@ COPY ./frontend /app/frontend
 COPY ./PRIVACY.md ./TERMS.md /app/
 COPY ./backend/openapi.json /app/backend/openapi.json
 
-ARG VITE_MAX_UPLOAD_GB
-ARG VITE_ENVIRONMENT
-ARG VITE_MAPBOX_TOKEN
-ARG VITE_GOOGLE_CLIENT_ID
-ARG VITE_CONTACT_EMAIL
-ARG VITE_GITHUB_URL
-ARG VITE_AUTHOR_NAME
-ARG VITE_AUTHOR_URL
-ARG VITE_SENTRY_DSN
-ARG VITE_SENTRY_TRACES_SAMPLE_RATE
-ARG VITE_FRONTEND_URL=http://localhost
-ARG VITE_MICROSOFT_CLIENT_ID
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 
-ARG SENTRY_ORG
-ARG SENTRY_FRONTEND_PROJECT
-ENV SENTRY_ORG=${SENTRY_ORG}
-ENV SENTRY_FRONTEND_PROJECT=${SENTRY_FRONTEND_PROJECT}
+RUN --network=none bun run build \
+    && cp -a dist /app/frontend-runtime \
+    && find /app/frontend-runtime -type f -name '*.map' -delete
 
-RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
-    bun run build
+FROM nginx:1 AS frontend
 
-
-FROM nginx:1
+ARG APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/itay-raveh/wanderbound"
 LABEL org.opencontainers.image.description="Wanderbound frontend"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
-COPY --from=build-stage /app/frontend/dist/ /usr/share/nginx/html
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build-stage /app/frontend-runtime/ /usr/share/nginx/html
+COPY --from=build-stage /app/frontend/dist/index.html /opt/wanderbound/index.html
 
 COPY ./frontend/nginx/nginx.conf /etc/nginx/templates/default.conf.template
 COPY ./frontend/nginx/proxy-params.conf /etc/nginx/proxy-params.conf
+COPY --chmod=755 ./frontend/nginx/40-wanderbound-config.sh /docker-entrypoint.d/40-wanderbound-config.sh
 
 ENV NGINX_ENVSUBST_FILTER="BACKEND_HOST|BACKEND_PORT|MAX_UPLOAD_SIZE|UPLOAD_S3_BROWSER_ORIGIN"
 ENV BACKEND_HOST=backend
@@ -60,8 +51,32 @@ ENV BACKEND_PORT=8000
 ENV MAX_UPLOAD_SIZE=4
 ENV UPLOAD_S3_BROWSER_ORIGIN=http://localhost:3900
 
-RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /run /etc/nginx/conf.d
+RUN chown -R nginx:nginx \
+    /var/cache/nginx \
+    /var/log/nginx \
+    /run \
+    /etc/nginx/conf.d
 
 USER nginx
 
 EXPOSE 8080
+
+
+FROM getsentry/sentry-cli:2.58.5@sha256:cb8c539da5a608b6afc185ccdf4985d6f625432c0135c731364c1c39aaa62dcf AS sourcemaps
+
+LABEL org.opencontainers.image.source="https://github.com/itay-raveh/wanderbound"
+LABEL org.opencontainers.image.description="Wanderbound frontend source maps"
+LABEL org.opencontainers.image.licenses="AGPL-3.0"
+
+USER root
+
+ARG APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
+ENV HOME=/tmp
+
+COPY --from=build-stage --chown=101:101 /app/frontend/dist/assets/ /artifacts/assets
+
+RUN find /artifacts -type f ! -name '*.js' ! -name '*.map' -delete \
+    && chmod -R a-w /artifacts
+
+USER 101:101

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,12 @@ import pluginVue from "eslint-plugin-vue";
 
 export default defineConfigWithVueTs(
   {
-    ignores: ["dist/**", "src/client/**", "openapi-ts.config.ts"],
+    ignores: [
+      "dist/**",
+      "public/config.js",
+      "src/client/**",
+      "openapi-ts.config.ts",
+    ],
   },
   pluginVue.configs["flat/essential"],
   vueTsConfigs.recommendedTypeChecked,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,16 +11,22 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Wanderbound" />
     <meta property="og:description" content="Turn your Polarsteps trips into photo albums" />
-    <meta property="og:image" content="%VITE_FRONTEND_URL%/og-image.png" />
-    <meta property="og:url" content="%VITE_FRONTEND_URL%/" />
+    <meta
+      property="og:image"
+      content="__WANDERBOUND_FRONTEND_URL__/og-image.png"
+    />
+    <meta property="og:url" content="__WANDERBOUND_FRONTEND_URL__/" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Wanderbound" />
     <meta name="twitter:description" content="Turn your Polarsteps trips into photo albums" />
-    <meta name="twitter:image" content="%VITE_FRONTEND_URL%/og-image.png" />
+    <meta
+      name="twitter:image"
+      content="__WANDERBOUND_FRONTEND_URL__/og-image.png"
+    />
 
-    <link rel="canonical" href="%VITE_FRONTEND_URL%/" />
+    <link rel="canonical" href="__WANDERBOUND_FRONTEND_URL__/" />
 
     <link rel="preload" href="/fonts/assistant-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="dns-prefetch" href="https://api.mapbox.com">
@@ -41,6 +47,7 @@
       })();
     </script>
     <div id="app"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/frontend/nginx/40-wanderbound-config.sh
+++ b/frontend/nginx/40-wanderbound-config.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+web_root=${1:-/var/run/wanderbound}
+nginx_config=${2:-/etc/nginx/conf.d/default.conf}
+built_index=${3:-/opt/wanderbound/index.html}
+
+fail() {
+  printf 'Invalid or missing %s\n' "$1" >&2
+  exit 1
+}
+
+export VITE_MAX_UPLOAD_GB=${VITE_MAX_UPLOAD_GB:-4}
+export VITE_SENTRY_TRACES_SAMPLE_RATE=${VITE_SENTRY_TRACES_SAMPLE_RATE:-0.1}
+export VITE_FRONTEND_URL=${VITE_FRONTEND_URL:-http://localhost}
+
+case ${VITE_ENVIRONMENT:-} in
+  local | production) ;;
+  *) fail VITE_ENVIRONMENT ;;
+esac
+
+sentry_origin=
+if [ -n "${VITE_SENTRY_DSN:-}" ]; then
+  sentry_origin=$(jq -enr --arg value "$VITE_SENTRY_DSN" '
+    $value
+    | capture("^(?<scheme>https?)://[^/?#@]+@(?<authority>(?:\\[[0-9A-Fa-f:.]+\\]|[A-Za-z0-9.-]+)(?::[0-9]+)?)/[^?#[:space:]]+(?:\\?[^#[:space:]]*)?(?:#[^[:space:]]*)?$")
+    | "\(.scheme)://\(.authority)"
+  ') || fail VITE_SENTRY_DSN
+fi
+
+[ -f "$built_index" ] || fail built_index
+[ -f "$nginx_config" ] || fail nginx_config
+grep -q '__WANDERBOUND_SENTRY_ORIGIN__' "$nginx_config" || fail nginx_config
+mkdir -p "$web_root"
+
+config_tmp=$(mktemp "$web_root/.config.js.XXXXXX")
+index_tmp=$(mktemp "$web_root/.index.html.XXXXXX")
+nginx_tmp=$(mktemp "$nginx_config.XXXXXX")
+trap 'rm -f "$config_tmp" "$index_tmp" "$nginx_tmp"' EXIT HUP INT TERM
+
+{
+  printf 'globalThis.WANDERBOUND_CONFIG = '
+  jq -cjn '$ENV | with_entries(select(.key | startswith("VITE_")))'
+  printf ';\n'
+} > "$config_tmp"
+
+escaped_frontend_url=$(jq -nr --arg value "$VITE_FRONTEND_URL" '$value | @html')
+jq -Rrs --arg value "$escaped_frontend_url" '
+  gsub("__WANDERBOUND_FRONTEND_URL__"; $value)
+' "$built_index" > "$index_tmp"
+
+sed "s|__WANDERBOUND_SENTRY_ORIGIN__|$sentry_origin|g" \
+  "$nginx_config" > "$nginx_tmp"
+
+mv "$config_tmp" "$web_root/config.js"
+mv "$index_tmp" "$web_root/index.html"
+mv "$nginx_tmp" "$nginx_config"
+trap - EXIT HUP INT TERM

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -43,7 +43,7 @@ server {
   set $csp_style    "style-src 'self' 'unsafe-inline' https://accounts.google.com";
   set $csp_img      "img-src 'self' data: blob: https://api.mapbox.com https://*.tiles.mapbox.com https://lh3.googleusercontent.com";
   set $csp_font     "font-src 'self'";
-  set $csp_connect  "connect-src 'self' ${UPLOAD_S3_BROWSER_ORIGIN} https://api.mapbox.com https://events.mapbox.com https://accounts.google.com/gsi/ https://login.microsoftonline.com https://o4511082013589504.ingest.de.sentry.io https://cloudflareinsights.com";
+  set $csp_connect  "connect-src 'self' ${UPLOAD_S3_BROWSER_ORIGIN} https://api.mapbox.com https://events.mapbox.com https://accounts.google.com/gsi/ https://login.microsoftonline.com __WANDERBOUND_SENTRY_ORIGIN__ https://cloudflareinsights.com";
   set $csp_frame    "frame-src https://accounts.google.com/gsi/";
   set $csp_worker   "worker-src 'self' blob:";
   set $csp_extra    "frame-ancestors 'none'; base-uri 'self'; form-action 'self'";
@@ -83,6 +83,16 @@ server {
   # Vite-hashed assets - immutable, cache forever
   location /assets/ {
     add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
+  location = /config.js {
+    alias /var/run/wanderbound/config.js;
+    add_header Cache-Control "no-store";
+  }
+
+  location = /index.html {
+    alias /var/run/wanderbound/index.html;
+    add_header Cache-Control "no-store";
   }
 
   location / {

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,0 +1,1 @@
+globalThis.WANDERBOUND_CONFIG = {};

--- a/frontend/src/components/SiteFooter.vue
+++ b/frontend/src/components/SiteFooter.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
 import { useI18n } from "vue-i18n";
 
+import { frontendConfig } from "@/config";
+
 const { t } = useI18n();
 
-const contactEmail = import.meta.env.VITE_CONTACT_EMAIL;
-const githubUrl = import.meta.env.VITE_GITHUB_URL;
-const authorName = import.meta.env.VITE_AUTHOR_NAME;
-const authorUrl = import.meta.env.VITE_AUTHOR_URL;
+const contactEmail = frontendConfig.VITE_CONTACT_EMAIL;
+const githubUrl = frontendConfig.VITE_GITHUB_URL;
+const authorName = frontendConfig.VITE_AUTHOR_NAME;
+const authorUrl = frontendConfig.VITE_AUTHOR_URL;
 const appVersion = APP_VERSION;
 const year = new Date().getFullYear();
 

--- a/frontend/src/components/register/LoginButtons.vue
+++ b/frontend/src/components/register/LoginButtons.vue
@@ -2,8 +2,10 @@
 import { useI18n } from "vue-i18n";
 import { type CallbackTypes } from "vue3-google-login";
 
+import { frontendConfig } from "@/config";
+
 const { t } = useI18n();
-const googleSignInEnabled = Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID);
+const googleSignInEnabled = Boolean(frontendConfig.VITE_GOOGLE_CLIENT_ID);
 
 const emit = defineEmits<{
   google: [response: CallbackTypes.CredentialPopupResponse];

--- a/frontend/src/components/register/ZipUploader.vue
+++ b/frontend/src/components/register/ZipUploader.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { UploadResult } from "@/client";
 import { useDirectZipUpload } from "@/composables/useDirectZipUpload";
+import { frontendConfig } from "@/config";
 import { symOutlinedLuggage } from "@quasar/extras/material-symbols-outlined";
 import { useQuasar } from "quasar";
 import { ref } from "vue";
@@ -10,7 +11,7 @@ const emit = defineEmits<{
   uploaded: [data: UploadResult];
 }>();
 
-const maxUploadGb = Number(import.meta.env.VITE_MAX_UPLOAD_GB) || 4;
+const maxUploadGb = Number(frontendConfig.VITE_MAX_UPLOAD_GB) || 4;
 const maxFileSize = maxUploadGb * 1024 * 1024 * 1024;
 const $q = useQuasar();
 const { t } = useI18n();

--- a/frontend/src/composables/useMapbox.ts
+++ b/frontend/src/composables/useMapbox.ts
@@ -1,6 +1,7 @@
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 
+import { frontendConfig } from "@/config";
 import { useResizeObserver } from "@vueuse/core";
 import {
   onBeforeUnmount,
@@ -12,7 +13,7 @@ import {
   type Ref,
 } from "vue";
 
-mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
+mapboxgl.accessToken = frontendConfig.VITE_MAPBOX_TOKEN ?? "";
 
 // Disable telemetry to avoid CORS errors from events.mapbox.com
 Object.defineProperty(

--- a/frontend/src/composables/useMicrosoftAuth.ts
+++ b/frontend/src/composables/useMicrosoftAuth.ts
@@ -1,6 +1,8 @@
 import type { PublicClientApplication } from "@azure/msal-browser";
 
-const clientId = import.meta.env.VITE_MICROSOFT_CLIENT_ID;
+import { frontendConfig } from "@/config";
+
+const clientId = frontendConfig.VITE_MICROSOFT_CLIENT_ID ?? "";
 
 let msalPromise: Promise<PublicClientApplication> | null = null;
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,11 @@
+type FrontendConfig = Readonly<Record<`VITE_${string}`, string | undefined>>;
+
+const runtimeConfig = (
+  globalThis as typeof globalThis & {
+    WANDERBOUND_CONFIG?: FrontendConfig;
+  }
+).WANDERBOUND_CONFIG ?? {};
+
+export const frontendConfig: FrontendConfig = import.meta.env.DEV
+  ? import.meta.env
+  : runtimeConfig;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -25,6 +25,7 @@ import router from "./router";
 
 import { useChunkErrorRecovery } from "@/composables/useChunkErrorRecovery";
 import { client } from "@/client/client.gen";
+import { frontendConfig } from "@/config";
 import { setupSentry } from "@/plugins/sentry";
 
 client.setConfig({
@@ -42,7 +43,7 @@ app.use(PiniaColada);
 app.use(router);
 useChunkErrorRecovery(router);
 app.use(i18n);
-const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const googleClientId = frontendConfig.VITE_GOOGLE_CLIENT_ID;
 if (googleClientId) {
   app.use(vue3GoogleLogin, { clientId: googleClientId });
 }

--- a/frontend/src/plugins/sentry.ts
+++ b/frontend/src/plugins/sentry.ts
@@ -3,6 +3,9 @@ import type { Pinia } from "pinia";
 import type { App } from "vue";
 import type { Router } from "vue-router";
 
+import { frontendConfig } from "@/config";
+import { sentryRelease } from "@/sentryRelease";
+
 const PRELOAD_ERROR_PATTERNS = [
   "Failed to fetch dynamically imported module",
   "error loading dynamically imported module",
@@ -31,9 +34,9 @@ export function setupSentry(app: App, router: Router, pinia: Pinia): void {
   const tracesSampleRate = sentryTracesSampleRate();
   Sentry.init({
     app,
-    dsn: import.meta.env.VITE_SENTRY_DSN,
-    environment: import.meta.env.VITE_ENVIRONMENT,
-    release: APP_VERSION,
+    dsn: frontendConfig.VITE_SENTRY_DSN,
+    environment: frontendConfig.VITE_ENVIRONMENT,
+    release: sentryRelease(APP_VERSION),
     integrations: [
       Sentry.feedbackIntegration({
         autoInject: true,
@@ -90,14 +93,14 @@ export function setupSentry(app: App, router: Router, pinia: Pinia): void {
 
 function sentryEnabled(): boolean {
   return (
-    import.meta.env.VITE_ENVIRONMENT === "production" &&
-    Boolean(import.meta.env.VITE_SENTRY_DSN)
+    frontendConfig.VITE_ENVIRONMENT === "production" &&
+    Boolean(frontendConfig.VITE_SENTRY_DSN)
   );
 }
 
 function sentryTracesSampleRate(): number {
   const value = Number(
-    import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ??
+    frontendConfig.VITE_SENTRY_TRACES_SAMPLE_RATE ??
       DEFAULT_SENTRY_TRACES_SAMPLE_RATE,
   );
   if (!Number.isFinite(value) || value < 0 || value > 1) {

--- a/frontend/src/sentryRelease.ts
+++ b/frontend/src/sentryRelease.ts
@@ -1,0 +1,6 @@
+const SENTRY_PACKAGE = "wanderbound";
+
+export function sentryRelease(version: string | undefined): string | undefined {
+  if (!version) return undefined;
+  return `${SENTRY_PACKAGE}@${version.replace(/^v/, "")}`;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -7,21 +7,3 @@ declare module "*.vue" {
 }
 
 declare const APP_VERSION: string | undefined;
-
-interface ImportMetaEnv {
-  readonly VITE_ENVIRONMENT: "local" | "production";
-  readonly VITE_MAX_UPLOAD_GB: string;
-  readonly VITE_MAPBOX_TOKEN: string;
-  readonly VITE_GOOGLE_CLIENT_ID: string;
-  readonly VITE_MICROSOFT_CLIENT_ID: string;
-  readonly VITE_CONTACT_EMAIL?: string;
-  readonly VITE_GITHUB_URL?: string;
-  readonly VITE_AUTHOR_NAME?: string;
-  readonly VITE_AUTHOR_URL?: string;
-  readonly VITE_SENTRY_DSN?: string;
-  readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}

--- a/frontend/tests/configInventory.test.ts
+++ b/frontend/tests/configInventory.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = path.resolve(process.cwd(), "..");
+
+describe("frontend configuration inventory", () => {
+  it("is exhaustive only in operator values and Compose", () => {
+    const example = readFileSync(
+      path.join(repositoryRoot, ".env.example"),
+      "utf8",
+    );
+    const names = new Set(
+      [...example.matchAll(/^#?\s*(VITE_[A-Z0-9_]+)=/gm)].map(
+        ([, name]) => name,
+      ),
+    );
+    const grep = spawnSync("git", ["grep", "-Il", "-e", "VITE_"], {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+    });
+    expect(grep.status).toBe(0);
+
+    const exhaustiveFiles = grep.stdout
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .filter((file) => {
+        const source = readFileSync(path.join(repositoryRoot, file), "utf8");
+        return [...names].every((name) => source.includes(name));
+      })
+      .sort();
+
+    expect(exhaustiveFiles).toEqual([".env.example", "compose.yml"]);
+  });
+});

--- a/frontend/tests/sentryConfig.test.ts
+++ b/frontend/tests/sentryConfig.test.ts
@@ -1,0 +1,64 @@
+import type { Pinia } from "pinia";
+import type { App } from "vue";
+import type { Router } from "vue-router";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sentry = {
+  browserTracingIntegration: vi.fn(() => ({})),
+  createSentryPiniaPlugin: vi.fn(() => ({})),
+  feedbackIntegration: vi.fn(() => ({})),
+  init: vi.fn(),
+  replayIntegration: vi.fn(() => ({})),
+  thirdPartyErrorFilterIntegration: vi.fn(() => ({})),
+};
+
+vi.mock("@sentry/vue", () => sentry);
+
+async function setupWith(config: Record<string, string>) {
+  vi.doMock("@/config", () => ({ frontendConfig: config }));
+  const { setupSentry } = await import("@/plugins/sentry");
+  const pinia = { use: vi.fn() } as unknown as Pinia;
+  setupSentry({} as App, {} as Router, pinia);
+  return pinia;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("Sentry startup configuration", () => {
+  it.each([
+    ["local", "https://public@example.test/1"],
+    ["production", ""],
+  ])(
+    "stays disabled for environment %s and DSN %s",
+    async (environment, dsn) => {
+      await setupWith({
+        VITE_ENVIRONMENT: environment,
+        VITE_SENTRY_DSN: dsn,
+        VITE_SENTRY_TRACES_SAMPLE_RATE: "0.5",
+      });
+
+      expect(sentry.init).not.toHaveBeenCalled();
+    },
+  );
+
+  it("uses the runtime target, image release, and current sampling fallback", async () => {
+    await setupWith({
+      VITE_ENVIRONMENT: "production",
+      VITE_SENTRY_DSN: "https://public@example.test/1",
+      VITE_SENTRY_TRACES_SAMPLE_RATE: "invalid",
+    });
+
+    expect(sentry.init).toHaveBeenCalledOnce();
+    const options = sentry.init.mock.calls[0]?.[0];
+    expect(options).toMatchObject({
+      dsn: "https://public@example.test/1",
+      environment: "production",
+      release: "wanderbound@0.0.0-test",
+    });
+    expect(options?.tracesSampler({})).toBe(0.1);
+  });
+});

--- a/frontend/tests/sentryRelease.test.ts
+++ b/frontend/tests/sentryRelease.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { sentryRelease } from "@/sentryRelease";
+
+describe("sentryRelease", () => {
+  it.each([
+    ["v1.7.0", "wanderbound@1.7.0"],
+    ["1.7.0", "wanderbound@1.7.0"],
+    ["v1.7.0-5-g5bd3780e", "wanderbound@1.7.0-5-g5bd3780e"],
+  ])("maps %s to %s", (version, expected) => {
+    expect(sentryRelease(version)).toBe(expected);
+  });
+
+  it("preserves an absent development version", () => {
+    expect(sentryRelease(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/tests/startupConfig.test.ts
+++ b/frontend/tests/startupConfig.test.ts
@@ -1,0 +1,168 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import vm from "node:vm";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const script = path.resolve(process.cwd(), "nginx/40-wanderbound-config.sh");
+const tempDirectories: string[] = [];
+
+const baseEnvironment = {
+  PATH: process.env.PATH ?? "/usr/bin:/bin",
+  VITE_ENVIRONMENT: "production",
+  VITE_FRONTEND_URL:
+    "https://wanderbound.example.test/?one=\"%3C&two='unicode-שלום",
+};
+
+interface Fixture {
+  runtimeRoot: string;
+  builtIndex: string;
+  nginxConfig: string;
+}
+
+function createFixture(): Fixture {
+  const root = mkdtempSync(path.join(tmpdir(), "wanderbound-config-"));
+  tempDirectories.push(root);
+  const runtimeRoot = path.join(root, "runtime");
+  const builtIndex = path.join(root, "built-index.html");
+  const nginxConfig = path.join(root, "default.conf");
+  mkdirSync(runtimeRoot);
+  writeFileSync(
+    builtIndex,
+    '<meta property="og:url" content="__WANDERBOUND_FRONTEND_URL__/">\n' +
+      '<link rel="canonical" href="__WANDERBOUND_FRONTEND_URL__/">\n',
+  );
+  writeFileSync(
+    nginxConfig,
+    "connect-src 'self' __WANDERBOUND_SENTRY_ORIGIN__;\n",
+  );
+  return { runtimeRoot, builtIndex, nginxConfig };
+}
+
+function runScript(
+  fixture: Fixture,
+  overrides: Record<string, string | undefined> = {},
+) {
+  const environment: Record<string, string> = { ...baseEnvironment };
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value === undefined) delete environment[name];
+    else environment[name] = value;
+  }
+  return spawnSync(
+    "/bin/sh",
+    [script, fixture.runtimeRoot, fixture.nginxConfig, fixture.builtIndex],
+    { encoding: "utf8", env: environment },
+  );
+}
+
+function readConfig(fixture: Fixture): Record<string, string> {
+  const context = vm.createContext({});
+  vm.runInContext(
+    readFileSync(path.join(fixture.runtimeRoot, "config.js"), "utf8"),
+    context,
+  );
+  return context.WANDERBOUND_CONFIG as Record<string, string>;
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("frontend container startup configuration", () => {
+  it("serializes every VITE_ value into one runtime object", () => {
+    const fixture = createFixture();
+    const value = 'quoted " slash \\ newline\n<script> שלום';
+
+    const result = runScript(fixture, {
+      VITE_TEST_VALUE: value,
+      DATABASE_PASSWORD: "must-not-be-public",
+    });
+
+    expect(result.status).toBe(0);
+    expect(readConfig(fixture)).toMatchObject({
+      VITE_ENVIRONMENT: "production",
+      VITE_TEST_VALUE: value,
+    });
+    expect(readConfig(fixture)).not.toHaveProperty("DATABASE_PASSWORD");
+  });
+
+  it("applies the existing public defaults", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture);
+
+    expect(result.status).toBe(0);
+    expect(readConfig(fixture)).toMatchObject({
+      VITE_MAX_UPLOAD_GB: "4",
+      VITE_SENTRY_TRACES_SAMPLE_RATE: "0.1",
+    });
+  });
+
+  it("replaces installation-specific HTML metadata", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture);
+
+    expect(result.status).toBe(0);
+    const index = readFileSync(
+      path.join(fixture.runtimeRoot, "index.html"),
+      "utf8",
+    );
+    expect(index).not.toContain("__WANDERBOUND_FRONTEND_URL__");
+    expect(index.match(/https:\/\/wanderbound\.example\.test/g)).toHaveLength(
+      2,
+    );
+    expect(index).toContain("&quot;%3C&amp;two=&apos;unicode-שלום");
+  });
+
+  it("adds only the Sentry DSN origin to the rendered CSP", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, {
+      VITE_SENTRY_DSN:
+        "https://public-key@errors.example.test:9443/42?ignored=yes#fragment",
+    });
+
+    expect(result.status).toBe(0);
+    const nginxConfig = readFileSync(fixture.nginxConfig, "utf8");
+    expect(nginxConfig).toContain("https://errors.example.test:9443");
+    expect(nginxConfig).not.toContain("public-key");
+    expect(nginxConfig).not.toContain("/42");
+  });
+
+  it("removes the Sentry CSP placeholder when the DSN is absent", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(fixture.nginxConfig, "utf8")).toBe(
+      "connect-src 'self' ;\n",
+    );
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["invalid", "staging"],
+  ])("rejects a %s environment", (_name, environment) => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, { VITE_ENVIRONMENT: environment });
+
+    expect(result.status).not.toBe(0);
+    expect(() =>
+      readFileSync(path.join(fixture.runtimeRoot, "config.js")),
+    ).toThrow();
+    expect(result.stderr).not.toContain(environment ?? "undefined");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,85 +3,80 @@ import vue from "@vitejs/plugin-vue";
 import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import path from "path";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
+
+import { sentryRelease } from "./src/sentryRelease";
 
 const version = process.env.APP_VERSION;
+const release = sentryRelease(version);
 const sentryApplicationKey = "wanderbound";
 const envDir = path.resolve(__dirname, "..");
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, envDir);
-  const environment = env.VITE_ENVIRONMENT;
-  if (environment !== "local" && environment !== "production") {
-    throw new Error("VITE_ENVIRONMENT must be set to local or production");
-  }
-
-  return {
-    define: {
-      APP_VERSION: JSON.stringify(version),
+export default defineConfig({
+  define: {
+    APP_VERSION: JSON.stringify(version),
+  },
+  envDir,
+  server: {
+    host: true,
+    allowedHosts: true,
+    proxy: {
+      "/api": "http://localhost:8000",
     },
-    envDir,
-    server: {
-      host: true,
-      allowedHosts: true,
-      proxy: {
-        "/api": "http://localhost:8000",
+  },
+  plugins: [
+    vue({
+      template: { transformAssetUrls },
+    }),
+    quasar({
+      sassVariables: path.resolve(__dirname, "src/quasar-variables.sass"),
+    }),
+    VueI18nPlugin({
+      include: [path.resolve(__dirname, "src/i18n/locales/**")],
+    }),
+    sentryVitePlugin({
+      applicationKey: sentryApplicationKey,
+      release: {
+        name: release,
+        setCommits: false,
+        create: false,
+        finalize: false,
+        deploy: false,
       },
-    },
-    plugins: [
-      vue({
-        template: { transformAssetUrls },
-      }),
-      quasar({
-        sassVariables: path.resolve(__dirname, "src/quasar-variables.sass"),
-      }),
-      VueI18nPlugin({
-        include: [path.resolve(__dirname, "src/i18n/locales/**")],
-      }),
-      sentryVitePlugin({
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_FRONTEND_PROJECT,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        applicationKey: sentryApplicationKey,
-        release: {
-          name: version,
-          setCommits: false,
-        },
-        telemetry: false,
-        sourcemaps: {
-          filesToDeleteAfterUpload: ["./dist/**/*.map"],
-        },
-      }),
-    ],
-    resolve: {
-      dedupe: ["@mapbox/mapbox-gl-supported"],
-      alias: {
-        "@": path.resolve(__dirname, "./src"),
-        "@fonts": path.resolve(__dirname, "fonts.json"),
+      telemetry: false,
+      sourcemaps: {
+        disable: "disable-upload",
       },
+    }),
+  ],
+  resolve: {
+    dedupe: ["@mapbox/mapbox-gl-supported"],
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "@fonts": path.resolve(__dirname, "fonts.json"),
     },
-    build: {
-      sourcemap: "hidden",
-      chunkSizeWarningLimit: 1800, // mapbox-gl is ~1.7MB and cannot be tree-shaken or split
-      rollupOptions: {
-        input: {
-          main: path.resolve(__dirname, "index.html"),
-          redirect: path.resolve(__dirname, "redirect.html"),
-        },
-        output: {
-          manualChunks: {
-            mapbox: ["mapbox-gl"],
-            sentry: ["@sentry/vue"],
-            turf: [
-              "@turf/along",
-              "@turf/distance",
-              "@turf/helpers",
-              "@turf/length",
-              "@turf/nearest-point-on-line",
-            ],
-          },
+  },
+  build: {
+    sourcemap: "hidden",
+    chunkSizeWarningLimit: 1800, // mapbox-gl is ~1.7MB and cannot be tree-shaken or split
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, "index.html"),
+        redirect: path.resolve(__dirname, "redirect.html"),
+      },
+      output: {
+        manualChunks: {
+          mapbox: ["mapbox-gl"],
+          sentry: ["@sentry/vue"],
+          turf: [
+            "@turf/along",
+            "@turf/distance",
+            "@turf/helpers",
+            "@turf/length",
+            "@turf/nearest-point-on-line",
+          ],
         },
       },
     },
-  };
+  },
 });

--- a/mise.toml
+++ b/mise.toml
@@ -284,6 +284,10 @@ run = [
     "mise run check:generated:openapi",
 ]
 
+[tasks."check:public-images"]
+description = "Verify installation-neutral frontend and source-map images"
+run = 'uv run scripts/check_public_images.py "${FRONTEND_IMAGE:-wanderbound-frontend:local}" "${SOURCEMAPS_IMAGE:-wanderbound-sourcemaps:local}"'
+
 [tasks.generate]
 description = "Regenerate all derived assets (except landing - needs live servers)"
 depends = [

--- a/scripts/check_public_images.py
+++ b/scripts/check_public_images.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+DEBUG_ID = re.compile(rb"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+
+
+def run(*command: str) -> bytes:
+    return subprocess.run(command, check=True, capture_output=True).stdout
+
+
+def shell(image: str, command: str) -> bytes:
+    return run("docker", "run", "--rm", "--entrypoint", "sh", image, "-c", command)
+
+
+def inspect(image: str) -> dict[str, object]:
+    return json.loads(run("docker", "image", "inspect", image))[0]
+
+
+def environment(image_data: dict[str, object]) -> dict[str, str]:
+    config = image_data["Config"]
+    assert isinstance(config, dict)
+    values = config.get("Env") or []
+    assert isinstance(values, list)
+    return dict(value.split("=", 1) for value in values)
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def debug_ids(image: str, root: str) -> set[bytes]:
+    javascript = shell(image, f"find {root} -type f -name '*.js' -exec cat {{}} +")
+    return set(DEBUG_ID.findall(javascript))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("frontend")
+    parser.add_argument("sourcemaps")
+    args = parser.parse_args()
+
+    frontend = inspect(args.frontend)
+    sourcemaps = inspect(args.sourcemaps)
+    frontend_env = environment(frontend)
+    sourcemaps_env = environment(sourcemaps)
+
+    maps = shell(
+        args.frontend,
+        "find /usr/share/nginx/html -type f -name '*.map' -print",
+    )
+    if maps:
+        fail("frontend image contains source maps")
+
+    artifact_files = (
+        shell(args.sourcemaps, "find /artifacts -type f -print | sort")
+        .decode()
+        .splitlines()
+    )
+    if not any(path.endswith(".js") for path in artifact_files):
+        fail("source-map image contains no JavaScript")
+    if not any(path.endswith(".map") for path in artifact_files):
+        fail("source-map image contains no source maps")
+
+    frontend_ids = debug_ids(args.frontend, "/usr/share/nginx/html/assets")
+    sourcemap_ids = debug_ids(args.sourcemaps, "/artifacts/assets")
+    if not frontend_ids:
+        fail("frontend JavaScript contains no debug IDs")
+    if frontend_ids != sourcemap_ids:
+        fail("frontend and source-map debug IDs differ")
+
+    if frontend_env.get("APP_VERSION") != sourcemaps_env.get("APP_VERSION"):
+        fail("frontend and source-map APP_VERSION values differ")
+    if not frontend_env.get("APP_VERSION"):
+        fail("paired images have no APP_VERSION")
+
+    for image, values in (
+        (args.frontend, frontend_env),
+        (args.sourcemaps, sourcemaps_env),
+    ):
+        installation_names = [
+            name for name in values if name.startswith(("VITE_", "SENTRY_"))
+        ]
+        if installation_names:
+            fail(f"{image} contains installation environment values")
+
+    print(
+        f"validated {len(frontend_ids)} debug IDs across "
+        f"{len(artifact_files)} source-map artifacts"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- move public frontend configuration from image build time to container startup
- build a version-matched public source-map image without installation Sentry credentials
- normalize frontend, backend, and source-map uploads to the same Sentry package release
- publish backend, frontend, and source-map images only for strict stable vMAJOR.MINOR.PATCH Git tags
- stop publishing mutable latest, SHA, major, and minor image aliases