### PR TITLE
fix(frontend): handle Google login SDK load failures

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "vue-draggable-plus": "^0.6.1",
         "vue-i18n": "^11.3.0",
         "vue-router": "^5.0.0",
-        "vue3-google-login": "^2.0.37",
+        "vue3-google-login": "^2.1.4",
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "0.99.0",
@@ -1276,7 +1276,7 @@
 
     "vue-tsc": ["vue-tsc@3.2.6", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.2.6" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q=="],
 
-    "vue3-google-login": ["vue3-google-login@2.0.37", "", { "peerDependencies": { "vue": "^3.0.3" } }, "sha512-1seGaevhcMPi/dKO36KktpqYMkJdzt4s5U7XjLvHPd50e8sCBcC8/Pv3Mz+QrK12rSOmiduTtxCuPcH2ULYozw=="],
+    "vue3-google-login": ["vue3-google-login@2.1.4", "", { "peerDependencies": { "vue": "^3.0.3" } }, "sha512-bWYd/vGMgOH001O0w2XI2K4MBr4+SCc2rWJJvqgo/nIuh88hItTCwVBINt5deKeDUILW2LbjXD0RDG2h8h7TDw=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "vue-draggable-plus": "^0.6.1",
     "vue-i18n": "^11.3.0",
     "vue-router": "^5.0.0",
-    "vue3-google-login": "^2.0.37"
+    "vue3-google-login": "^2.1.4"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "0.99.0",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,10 +3,9 @@ import { PiniaColada } from "@pinia/colada";
 import { Lang, Loading, LoadingBar, Meta, Notify, Quasar } from "quasar";
 import { createApp } from "vue";
 
-import vue3GoogleLogin from "vue3-google-login";
-
 import i18n from "@/i18n";
 import { applyLocale } from "@/composables/useLocale";
+import { setupGoogleLogin } from "@/plugins/googleLogin";
 
 // Self-hosted fonts with font-display: block.
 // Guarantees fonts are loaded before rendering (critical for PDF generation).
@@ -42,10 +41,7 @@ app.use(PiniaColada);
 app.use(router);
 useChunkErrorRecovery(router);
 app.use(i18n);
-const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-if (googleClientId) {
-  app.use(vue3GoogleLogin, { clientId: googleClientId });
-}
+setupGoogleLogin(app, import.meta.env.VITE_GOOGLE_CLIENT_ID);
 app.use(Quasar, {
   config: {
     loading: {},

--- a/frontend/src/plugins/googleLogin.ts
+++ b/frontend/src/plugins/googleLogin.ts
@@ -1,0 +1,13 @@
+import type { App } from "vue";
+import vue3GoogleLogin from "vue3-google-login";
+
+type GoogleLoginLoadErrorHandler = (error: unknown) => void;
+
+export function setupGoogleLogin(
+  app: App,
+  clientId: string | undefined,
+  handleLoadError: GoogleLoginLoadErrorHandler = () => undefined,
+): void {
+  if (!clientId) return;
+  app.use(vue3GoogleLogin, { clientId, error: handleLoadError });
+}

--- a/frontend/tests/plugins/googleLogin.test.ts
+++ b/frontend/tests/plugins/googleLogin.test.ts
@@ -1,0 +1,32 @@
+import { createApp } from "vue";
+
+vi.unmock("vue3-google-login");
+
+import { setupGoogleLogin } from "@/plugins/googleLogin";
+
+it("handles failures while loading the Google Identity Services library", async () => {
+  const handleLoadError = vi.fn();
+  const app = createApp({});
+  let googleScript: HTMLScriptElement | undefined;
+  const appendChild = vi.spyOn(document.head, "appendChild");
+  appendChild.mockImplementation(function <T extends Node>(node: T): T {
+    if (node instanceof HTMLScriptElement) {
+      googleScript = node;
+      queueMicrotask(() => node.dispatchEvent(new Event("error")));
+    }
+    return node;
+  });
+
+  setupGoogleLogin(app, "client-id", handleLoadError);
+
+  expect(googleScript?.src).toBe(
+    "https://accounts.google.com/gsi/client",
+  );
+
+  await vi.waitFor(() => {
+    expect(handleLoadError).toHaveBeenCalledWith(
+      "Failed to load the Google 3P Authorization JavaScript Library.",
+    );
+  });
+  appendChild.mockRestore();
+});


### PR DESCRIPTION
- update `vue3-google-login` to `2.1.4`, whose published bundle handles SDK loader failures
- install the plugin through a focused setup helper with its supported error callback
- add a real-package regression test that dispatches the Google script error event