### PR TITLE
ci: skip GitHub releases for patch tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
             exit 1
           fi
           echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          echo "patch=${GITHUB_REF_NAME##*.}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -56,10 +57,12 @@ jobs:
         run: docker push "$APP_IMAGE:${{ steps.version.outputs.value }}"
 
       - uses: taiki-e/install-action@v2
+        if: steps.version.outputs.patch == '0'
         with:
           tool: git-cliff
 
       - name: Create GitHub release
+        if: steps.version.outputs.patch == '0'
         run: |
           git cliff --current --strip header > /tmp/release-notes.md
           gh release create "$GITHUB_REF_NAME" --verify-tag \


### PR DESCRIPTION
## Summary

- continue building and publishing the exact container image for every stable semver tag
- expose the validated tag's patch component to later workflow steps
- install `git-cliff` and create a GitHub Release only when the patch component is `0`

This means tags such as `v1.8.1` publish an image without a GitHub Release, while `v1.9.0` and `v2.0.0` do both.

## Verification

- `mise run lint`
- hook suite during signed commit and push
- executable tag matrix covering patch, minor, major, and invalid tags
