### PR TITLE
fix: reconnect expired Google Photos grants

### DIFF
--- a/backend/app/api/v1/routes/external_media.py
+++ b/backend/app/api/v1/routes/external_media.py
@@ -114,7 +114,7 @@ async def _load_google_import_context(
             await validate_import_target(session, album=album, request=body)
         except ValueError as exc:
             validation_error = str(exc)
-    access_token = await _ensure_fresh_access_token(http, user)
+        access_token = await _ensure_fresh_access_token(http, user, session)
     return GoogleImportContext(
         body=body,
         album=album,
@@ -294,7 +294,7 @@ async def replace_google_media(  # noqa: PLR0913
 ) -> AlbumMedia:
     album = await _get_album_or_404(aid, user, session)
     _require_google_available(user)
-    access_token = await _ensure_fresh_access_token(http, user)
+    access_token = await _ensure_fresh_access_token(http, user, session)
     if await session.get(AlbumMedia, (user.id, aid, body.media_name)) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Media not found")
     target_album_dir = album_dir(user, aid)

--- a/backend/app/api/v1/routes/google_photos.py
+++ b/backend/app/api/v1/routes/google_photos.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import secrets
 from collections.abc import AsyncIterable
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -236,20 +237,31 @@ def _build_token_getter(
 
 
 async def _ensure_fresh_access_token(
-    http: HttpClientsDep, user: UserDep
+    http: HttpClientsDep, user: UserDep, session: SessionDep
 ) -> AccessToken:
     """One-shot fetch for single-request endpoints (no caching needed)."""
     refresh_token = _get_refresh_token(user)
     try:
         token = await http.gphotos_oauth.refresh_token(refresh_token)
     except RefreshTokenError as exc:
-        # Avoid logger.exception: httpx request bodies would leak the
-        # plaintext refresh token and client secret into Sentry.
-        logger.error(  # noqa: TRY400
-            "google_photos.token_refresh_failed",
-            user_id=user.id,
-            error_type=type(exc).__name__,
-        )
+        error_code = None
+        if exc.response is not None:
+            with suppress(ValueError, AttributeError):
+                error_code = exc.response.json().get("error")
+        if error_code == "invalid_grant":
+            user.google_photos_refresh_token = None
+            user.google_photos_connected_at = None
+            session.add(user)
+            await session.commit()
+            logger.warning("google_photos.authorization_invalidated", user_id=user.id)
+        else:
+            # Avoid logger.exception: httpx request bodies would leak the
+            # plaintext refresh token and client secret into Sentry.
+            logger.error(  # noqa: TRY400
+                "google_photos.token_refresh_failed",
+                user_id=user.id,
+                error_type=type(exc).__name__,
+            )
         raise HTTPException(
             status.HTTP_401_UNAUTHORIZED,
             "Google Photos authorization expired. Please reconnect.",
@@ -373,9 +385,10 @@ class PickerSessionResponse(BaseModel):
 async def create_session(
     user: UserDep,
     http: HttpClientsDep,
+    session: SessionDep,
     max_item_count: Annotated[int | None, Query(ge=0)] = None,
 ) -> PickerSessionResponse:
-    access_token = await _ensure_fresh_access_token(http, user)
+    access_token = await _ensure_fresh_access_token(http, user, session)
     picker = await create_picker_session(
         http.gphotos_picker,
         access_token,
@@ -393,18 +406,24 @@ class SessionStatusResponse(BaseModel):
 
 @router.get("/sessions/{session_id}")
 async def poll_session(
-    session_id: PickerSessionId, user: UserDep, http: HttpClientsDep
+    session_id: PickerSessionId,
+    user: UserDep,
+    http: HttpClientsDep,
+    session: SessionDep,
 ) -> SessionStatusResponse:
-    access_token = await _ensure_fresh_access_token(http, user)
+    access_token = await _ensure_fresh_access_token(http, user, session)
     data = await poll_picker_session(http.gphotos_picker, session_id, access_token)
     return SessionStatusResponse(ready=data.media_items_set)
 
 
 @router.delete("/sessions/{session_id}", status_code=204)
 async def close_session(
-    session_id: PickerSessionId, user: UserDep, http: HttpClientsDep
+    session_id: PickerSessionId,
+    user: UserDep,
+    http: HttpClientsDep,
+    session: SessionDep,
 ) -> None:
-    access_token = await _ensure_fresh_access_token(http, user)
+    access_token = await _ensure_fresh_access_token(http, user, session)
     await delete_picker_session(http.gphotos_picker, session_id, access_token)
 
 

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -7,11 +7,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
+from httpx import Request, Response
 from httpx_oauth.oauth2 import (
     GetAccessTokenError,
     OAuth2Token,
     RefreshTokenError,
 )
+from sqlmodel import select
 
 from app.api.v1.routes.google_photos import _validate_match_names, match_media
 from app.logic.media_upgrade.phash_matching import MatchResult
@@ -285,7 +287,7 @@ class TestOAuthCallback:
 
 
 class TestTokenRevocation:
-    async def test_expired_token_returns_401(
+    async def test_expired_token_disconnects_google_photos(
         self,
         client: AsyncClient,
         session: AsyncSession,
@@ -293,12 +295,21 @@ class TestTokenRevocation:
     ) -> None:
         http = await connected_google_photos_http(client, session)
         http.gphotos_oauth.refresh_token.side_effect = RefreshTokenError(
-            "invalid_grant"
+            "refresh failed",
+            Response(
+                400,
+                json={"error": "invalid_grant"},
+                request=Request("POST", "https://oauth2.googleapis.com/token"),
+            ),
         )
 
         resp = await google_photos_routes.create_session()
 
         assert resp.status_code == 401
+        user = (await session.exec(select(User))).one()
+        await session.refresh(user)
+        assert user.google_photos_refresh_token is None
+        assert user.google_photos_connected_at is None
 
 
 class TestTokenLostSelfHeal:

--- a/frontend/src/composables/useAddExternalMedia.ts
+++ b/frontend/src/composables/useAddExternalMedia.ts
@@ -214,11 +214,12 @@ export function useAddExternalMedia(albumId: () => string) {
         phase.value = "authorizing";
         await googlePhotos.authorize(activePopup, signal);
       }
-
       phase.value = "picking";
-      const session = await googlePhotos.createPickerSession({
-        maxItemCount: EXTERNAL_MEDIA_IMPORT_MAX_ITEMS,
-      });
+      const session = await googlePhotos.createPickerSession(
+        activePopup,
+        signal,
+        { maxItemCount: EXTERNAL_MEDIA_IMPORT_MAX_ITEMS },
+      );
       activeSessionId = session.sessionId;
       activePopup.location.href = `${session.pickerUri}/autoclose`;
       await pollUntilReady(session.sessionId, signal);

--- a/frontend/src/composables/useGooglePhotos.ts
+++ b/frontend/src/composables/useGooglePhotos.ts
@@ -17,6 +17,12 @@ interface CreatePickerSessionOptions {
   maxItemCount?: number;
 }
 
+class GooglePhotosAuthorizationExpired extends Error {
+  constructor() {
+    super(UPGRADE_ERRORS.connectionLost);
+  }
+}
+
 export function useGooglePhotos() {
   const { user } = useUserQuery();
   const cache = useQueryCache();
@@ -89,20 +95,38 @@ export function useGooglePhotos() {
     await cache.invalidateQueries({ key: queryKeys.user() });
   }
 
-  async function createPickerSession(
+  async function requestPickerSession(
     options: CreatePickerSessionOptions = {},
   ): Promise<{
     sessionId: string;
     pickerUri: string;
   }> {
-    const { data } = await createSession({
+    const { data, response } = await createSession({
       query:
         options.maxItemCount === undefined
           ? undefined
           : { max_item_count: options.maxItemCount },
     });
+    if (response?.status === 401) throw new GooglePhotosAuthorizationExpired();
     if (!data) throw new Error(UPGRADE_ERRORS.connectionLost);
     return { sessionId: data.session_id, pickerUri: data.picker_uri };
+  }
+
+  async function createPickerSession(
+    popup: Window,
+    signal: AbortSignal,
+    options: CreatePickerSessionOptions = {},
+  ): Promise<{
+    sessionId: string;
+    pickerUri: string;
+  }> {
+    try {
+      return await requestPickerSession(options);
+    } catch (error) {
+      if (!(error instanceof GooglePhotosAuthorizationExpired)) throw error;
+      await authorizeInPopup(popup, signal);
+      return requestPickerSession(options);
+    }
   }
 
   async function pollPickerSession(

--- a/frontend/src/composables/useMediaUpgrade.ts
+++ b/frontend/src/composables/useMediaUpgrade.ts
@@ -167,7 +167,10 @@ export function useMediaUpgrade() {
 
       // Step 3: Create first picker session
       phase.value = "picking";
-      const { sessionId, pickerUri } = await gp.createPickerSession();
+      const { sessionId, pickerUri } = await gp.createPickerSession(
+        activePopup,
+        signal,
+      );
       sessionIds.push(sessionId);
       if (signal.aborted) return;
       activePopup.location.href = pickerUri + "/autoclose";
@@ -200,7 +203,7 @@ export function useMediaUpgrade() {
         }
 
         // "Select More": new session, popup was opened by selectMore()
-        const next = await gp.createPickerSession();
+        const next = await gp.createPickerSession(activePopup, signal);
         sessionIds.push(next.sessionId);
         currentSessionId = next.sessionId;
         if (signal.aborted) return;

--- a/frontend/src/composables/useReplaceExternalMedia.ts
+++ b/frontend/src/composables/useReplaceExternalMedia.ts
@@ -226,9 +226,11 @@ export function useReplaceExternalMedia() {
         await googlePhotos.authorize(activePopup, signal);
       }
       phase.value = "picking";
-      const session = await googlePhotos.createPickerSession({
-        maxItemCount: GOOGLE_REPLACEMENT_MAX_ITEMS,
-      });
+      const session = await googlePhotos.createPickerSession(
+        activePopup,
+        signal,
+        { maxItemCount: GOOGLE_REPLACEMENT_MAX_ITEMS },
+      );
       activeSessionId = session.sessionId;
       activePopup.location.href = `${session.pickerUri}/autoclose`;
       await pollUntilReady(session.sessionId, signal);

--- a/frontend/tests/composables/useAddExternalMedia.test.ts
+++ b/frontend/tests/composables/useAddExternalMedia.test.ts
@@ -43,8 +43,10 @@ describe("useAddExternalMedia", () => {
 
     await addMedia.importGoogle({ context: "cover" });
 
-    expect(googlePhotosMock.createPickerSession).toHaveBeenCalledWith({
-      maxItemCount: EXTERNAL_MEDIA_IMPORT_MAX_ITEMS,
-    });
+    expect(googlePhotosMock.createPickerSession).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(AbortSignal),
+      { maxItemCount: EXTERNAL_MEDIA_IMPORT_MAX_ITEMS },
+    );
   });
 });

--- a/frontend/tests/composables/useGooglePhotos.test.ts
+++ b/frontend/tests/composables/useGooglePhotos.test.ts
@@ -1,0 +1,96 @@
+import { useGooglePhotos } from "@/composables/useGooglePhotos";
+import { UPGRADE_ERRORS } from "@/utils/upgradeErrors";
+import { withSetup } from "../helpers";
+
+const api = vi.hoisted(() => ({
+  closeSession: vi.fn(),
+  createSession: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+const currentUser = vi.hoisted(() => ({
+  value: {
+    google_sub: "google-user",
+    google_photos_connected_at: "2026-07-15T23:27:32Z",
+  },
+}));
+
+vi.mock("@/client", () => api);
+vi.mock("@/queries/useUserQuery", () => ({
+  useUserQuery: () => ({ user: currentUser }),
+}));
+
+class CompletingBroadcastChannel {
+  onmessage: (() => void) | null = null;
+
+  constructor() {
+    queueMicrotask(() => this.onmessage?.());
+  }
+
+  close() {}
+}
+
+describe("useGooglePhotos", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    api.createSession.mockReset();
+  });
+
+  it("reauthorizes once when picker session creation finds an expired grant", async () => {
+    vi.stubGlobal("BroadcastChannel", CompletingBroadcastChannel);
+    api.createSession
+      .mockResolvedValueOnce({
+        data: undefined,
+        error: { detail: "Google Photos authorization expired. Please reconnect." },
+        response: new Response(null, { status: 401 }),
+      })
+      .mockResolvedValueOnce({
+        data: {
+          session_id: "session-2",
+          picker_uri: "https://photos.google.com/picker/session-2",
+        },
+      });
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: { href: "about:blank" },
+    } as unknown as Window;
+    const googlePhotos = withSetup(() => useGooglePhotos());
+
+    const session = await googlePhotos.createPickerSession(
+      popup,
+      new AbortController().signal,
+    );
+
+    expect(popup.location.href).toContain("/api/v1/google-photos/authorize");
+    expect(api.createSession).toHaveBeenCalledTimes(2);
+    expect(session).toEqual({
+      sessionId: "session-2",
+      pickerUri: "https://photos.google.com/picker/session-2",
+    });
+  });
+
+  it("surfaces a connection error when the single retry is unauthorized", async () => {
+    vi.stubGlobal("BroadcastChannel", CompletingBroadcastChannel);
+    api.createSession.mockResolvedValue({
+      data: undefined,
+      error: { detail: "Google Photos authorization expired. Please reconnect." },
+      response: new Response(null, { status: 401 }),
+    });
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: { href: "about:blank" },
+    } as unknown as Window;
+    const googlePhotos = withSetup(() => useGooglePhotos());
+
+    await expect(
+      googlePhotos.createPickerSession(
+        popup,
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(UPGRADE_ERRORS.connectionLost);
+    expect(api.createSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/composables/useReplaceExternalMedia.test.ts
+++ b/frontend/tests/composables/useReplaceExternalMedia.test.ts
@@ -85,9 +85,11 @@ describe("useReplaceExternalMedia", () => {
     const result = mountReplaceExternalMedia();
 
     await expect(result.replaceFromGoogle()).resolves.toBe("photo.jpg");
-    expect(googlePhotosMock.createPickerSession).toHaveBeenCalledWith({
-      maxItemCount: GOOGLE_REPLACEMENT_MAX_ITEMS,
-    });
+    expect(googlePhotosMock.createPickerSession).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(AbortSignal),
+      { maxItemCount: GOOGLE_REPLACEMENT_MAX_ITEMS },
+    );
   });
 
   it("invalidates print bundle after replacements", () => {


### PR DESCRIPTION
## Summary

- clear a Google Photos connection when Google returns `invalid_grant`
- reauthorize in the already-open popup and retry Picker session creation once
- keep client and transport refresh failures as error-level observability events

## Root cause

The stored refresh token had expired or been revoked, but `google_photos_connected_at` remained set. The frontend therefore skipped authorization and the backend failed before it could return a Picker URL.

## Verification

- backend: 552 tests passed
- frontend: 167 tests passed
- E2E: 62 tests passed
- full lint, type checks, dead-code checks, and generated-asset checks passed

Sentry: https://ravehdev.sentry.io/issues/135967890/events/8a7a6e8d39964eacaad8fbdb4f7ee1fd/
