### PR TITLE
fix: handle expired Google Photos session response

### DIFF
--- a/frontend/src/composables/useGooglePhotos.ts
+++ b/frontend/src/composables/useGooglePhotos.ts
@@ -102,6 +102,7 @@ export function useGooglePhotos() {
     pickerUri: string;
   }> {
     const { data, response } = await createSession({
+      throwOnError: false,
       query:
         options.maxItemCount === undefined
           ? undefined

--- a/frontend/tests/composables/useGooglePhotos.test.ts
+++ b/frontend/tests/composables/useGooglePhotos.test.ts
@@ -37,20 +37,30 @@ describe("useGooglePhotos", () => {
     api.createSession.mockReset();
   });
 
-  it("reauthorizes once when picker session creation finds an expired grant", async () => {
+  it("handles the expired-grant response without the generated client throwing", async () => {
     vi.stubGlobal("BroadcastChannel", CompletingBroadcastChannel);
-    api.createSession
-      .mockResolvedValueOnce({
-        data: undefined,
-        error: { detail: "Google Photos authorization expired. Please reconnect." },
-        response: new Response(null, { status: 401 }),
-      })
-      .mockResolvedValueOnce({
-        data: {
-          session_id: "session-2",
-          picker_uri: "https://photos.google.com/picker/session-2",
-        },
-      });
+    api.createSession.mockImplementation(
+      (options?: { throwOnError?: boolean }) => {
+        if (api.createSession.mock.calls.length === 1) {
+          if (options?.throwOnError !== false) {
+            return Promise.reject(new Error("Request failed with status 401"));
+          }
+          return Promise.resolve({
+            data: undefined,
+            error: {
+              detail: "Google Photos authorization expired. Please reconnect.",
+            },
+            response: new Response(null, { status: 401 }),
+          });
+        }
+        return Promise.resolve({
+          data: {
+            session_id: "session-2",
+            picker_uri: "https://photos.google.com/picker/session-2",
+          },
+        });
+      },
+    );
     const popup = {
       closed: false,
       close: vi.fn(),
@@ -65,6 +75,10 @@ describe("useGooglePhotos", () => {
 
     expect(popup.location.href).toContain("/api/v1/google-photos/authorize");
     expect(api.createSession).toHaveBeenCalledTimes(2);
+    expect(api.createSession).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ throwOnError: false }),
+    );
     expect(session).toEqual({
       sessionId: "session-2",
       pickerUri: "https://photos.google.com/picker/session-2",


### PR DESCRIPTION
## What changed
- opt out of generated-client throwing for Google Photos session creation
- preserve the existing 401 detection and one-time OAuth retry
- make the regression test emulate the generated SDK's real throw-by-default behavior

## Root cause
The generated `createSession` SDK method defaults `throwOnError` to `true`. The previous test returned a resolved 401 object, but production rejected before the response-status check could run, so OAuth reauthorization never started.

## Verification
- frontend: 167 tests passed
- backend: 552 tests passed
- E2E: 62 tests passed
- lint, type checks, dead-code checks, and generated checks passed