### PR TITLE
fix: prevent media upgrade OOM

### DIFF
--- a/backend/app/logic/media_upgrade/pipeline.py
+++ b/backend/app/logic/media_upgrade/pipeline.py
@@ -61,8 +61,8 @@ from .processing import (
 logger = structlog.get_logger(__name__)
 
 _UPGRADE_TMP_DIR = ".upgrade-tmp"
-_UPGRADE_BASELINE_MB = 512
-_PER_UPGRADE_MB = 768
+_UPGRADE_BASELINE_MB = 1024
+_PER_UPGRADE_MB = 1024
 
 
 @functools.cache

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
-import anyio
 import imagehash
 import numpy as np
 import pytest
@@ -476,13 +475,13 @@ class TestRunMatching:
 
 
 class TestRunUpgrade:
-    async def test_limits_complete_upgrade_file_lifecycles(
+    async def test_serializes_upgrade_file_lifecycles_with_two_gib_limit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        limiter = anyio.CapacityLimiter(1)
         monkeypatch.setattr(
-            "app.logic.media_upgrade.pipeline._upgrade_limiter", lambda: limiter
+            "app.logic.media_upgrade.pipeline.detect_memory_mb", lambda: 2048
         )
+        _clear_caches()
         first_started = asyncio.Event()
         release_first = asyncio.Event()
         second_started = asyncio.Event()


### PR DESCRIPTION
- reserve 1 GiB for the application and resident browser when sizing media-upgrade concurrency
- budget 1 GiB per complete download and replacement lifecycle
- serialize upgrade lifecycles on the production 2 GiB container
- add a regression test covering the production-sized memory limit