### PR TITLE
feat: Google Photos matching recall for large selections

### DIFF
--- a/backend/app/logic/media_upgrade/phash_matching.py
+++ b/backend/app/logic/media_upgrade/phash_matching.py
@@ -1,8 +1,7 @@
 """Perceptual hashing and bipartite matching for media upgrade.
 
 Matches compressed Polarsteps media (photos and videos) to Google Photos
-originals using perceptual hashing (pHash) and the Hungarian algorithm
-for optimal bipartite assignment.
+originals using perceptual hashing (pHash) and optimal bipartite assignment.
 """
 
 from datetime import datetime
@@ -17,7 +16,8 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from PIL import Image
-from scipy.optimize import linear_sum_assignment
+from scipy.sparse import coo_array
+from scipy.sparse.csgraph import min_weight_full_bipartite_matching
 
 from app.logic.layout.media import MediaName, open_oriented
 from app.models.google_photos import GoogleMediaId, PickedMediaItem
@@ -123,7 +123,7 @@ def compute_phash_from_bytes(data: bytes) -> imagehash.ImageHash:
 
 
 # ---------------------------------------------------------------------------
-# Cost matrix and Hungarian matching
+# Cost matrix and optimal matching
 # ---------------------------------------------------------------------------
 
 _CROSS_TYPE_COST = MATCH_THRESHOLD + 1
@@ -142,17 +142,15 @@ def _pairwise_distance(a: MediaHash, b: MediaHash) -> int:
 def build_cost_matrix(
     local_media: list[HashedMedia],
     candidate_media: list[HashedMedia],
-) -> list[list[int]]:
+) -> np.ndarray:
     """Build a distance matrix. Cross-type pairs get infinite cost."""
-    matrix: list[list[int]] = []
-    for loc in local_media:
-        row: list[int] = []
-        for cand in candidate_media:
+    matrix = np.empty((len(local_media), len(candidate_media)), dtype=np.int16)
+    for row, loc in enumerate(local_media):
+        for column, cand in enumerate(candidate_media):
             if loc.is_video != cand.is_video:
-                row.append(_CROSS_TYPE_COST)
+                matrix[row, column] = _CROSS_TYPE_COST
             else:
-                row.append(_pairwise_distance(loc.hash, cand.hash))
-        matrix.append(row)
+                matrix[row, column] = _pairwise_distance(loc.hash, cand.hash)
     return matrix
 
 
@@ -165,20 +163,24 @@ def _thresholded_assignment(
 
     local_count, candidate_count = cost.shape
     unmatched_cost = local_count * threshold + 1
-    invalid_cost = unmatched_cost * (local_count + 1)
-    assignment = np.full(
-        (local_count, candidate_count + local_count),
-        invalid_cost,
-        dtype=np.int64,
+    valid_rows, valid_columns = np.nonzero(cost <= threshold)
+    dummy_rows = np.arange(local_count)
+    dummy_columns = candidate_count + dummy_rows
+    rows = np.concatenate((valid_rows, dummy_rows))
+    columns = np.concatenate((valid_columns, dummy_columns))
+    weights = np.concatenate(
+        (
+            cost[valid_rows, valid_columns].astype(np.int64) + 1,
+            np.full(local_count, unmatched_cost + 1, dtype=np.int64),
+        )
     )
-    valid = cost <= threshold
-    assignment[:, :candidate_count][valid] = cost[valid]
-    assignment[np.arange(local_count), candidate_count + np.arange(local_count)] = (
-        unmatched_cost
-    )
-    rows, columns = linear_sum_assignment(assignment)
-    real = columns < candidate_count
-    return rows[real], columns[real]
+    assignment = coo_array(
+        (weights, (rows, columns)),
+        shape=(local_count, candidate_count + local_count),
+    ).tocsr()
+    matched_rows, matched_columns = min_weight_full_bipartite_matching(assignment)
+    real = matched_columns < candidate_count
+    return matched_rows[real], matched_columns[real]
 
 
 def match_media_globally(
@@ -189,14 +191,14 @@ def match_media_globally(
     if not local_media or not candidate_media:
         return MatchingOutcome([], MatchingDiagnostics(0, 0))
 
-    cost = np.asarray(build_cost_matrix(local_media, candidate_media), dtype=np.int16)
+    cost = build_cost_matrix(local_media, candidate_media)
     same_type = np.equal.outer(
         [item.is_video for item in local_media],
         [item.is_video for item in candidate_media],
     )
-    valid = same_type & (cost <= threshold)
-    assignment_cost = np.where(valid, cost, threshold + 1)
-    rows, columns = _thresholded_assignment(assignment_cost, threshold)
+    cost[~same_type] = threshold + 1
+    valid = cost <= threshold
+    rows, columns = _thresholded_assignment(cost, threshold)
     matches = [
         MatchResult(
             local_name=local_media[row].key,
@@ -205,8 +207,11 @@ def match_media_globally(
         )
         for row, column in zip(rows, columns, strict=True)
     ]
-    same_type_cost = np.where(same_type, cost, np.iinfo(np.int16).max)
-    nearest = same_type_cost.min(axis=1)
+    nearest = cost.min(
+        axis=1,
+        where=same_type,
+        initial=np.iinfo(np.int16).max,
+    )
     return MatchingOutcome(
         matches,
         MatchingDiagnostics(

--- a/backend/app/logic/media_upgrade/phash_matching.py
+++ b/backend/app/logic/media_upgrade/phash_matching.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from PIL import Image
 from scipy.optimize import linear_sum_assignment
 
-from app.logic.layout.media import MediaName, is_video, open_oriented
+from app.logic.layout.media import MediaName, open_oriented
 from app.models.google_photos import GoogleMediaId, PickedMediaItem
 
 # Hamming distance threshold for accepting a pHash match.
@@ -30,9 +30,6 @@ from app.models.google_photos import GoogleMediaId, PickedMediaItem
 # 8-12 bits of hash variance. 12 sits at the upper end of "same image, different
 # compression" and below "different image" territory (~15+).
 MATCH_THRESHOLD = 12
-
-# Skip cross-step fallback if the matrix exceeds this size.
-_FALLBACK_MAX_DIMENSION = 100
 
 type MediaHash = imagehash.ImageHash | list[imagehash.ImageHash]
 
@@ -179,18 +176,9 @@ def _thresholded_assignment(
     assignment[np.arange(local_count), candidate_count + np.arange(local_count)] = (
         unmatched_cost
     )
-
     rows, columns = linear_sum_assignment(assignment)
     real = columns < candidate_count
     return rows[real], columns[real]
-
-
-def match_within_window(
-    local_media: list[HashedMedia],
-    candidate_media: list[HashedMedia],
-    threshold: int = MATCH_THRESHOLD,
-) -> list[MatchResult]:
-    return match_media_globally(local_media, candidate_media, threshold).matches
 
 
 def match_media_globally(
@@ -272,82 +260,18 @@ def deduplicate_items(
     return list({item.id: item for item in items}.values())
 
 
-def _hashed_locals(
-    media_names: list[MediaName],
-    local_hashes: dict[MediaName, MediaHash],
-    matched_locals: set[MediaName],
-) -> list[HashedMedia]:
-    return [
-        HashedMedia(key=n, hash=local_hashes[n], is_video=is_video(n))
-        for n in media_names
-        if n in local_hashes and n not in matched_locals
-    ]
-
-
-def _hashed_candidates(
-    items: list[PickedMediaItem],
-    candidate_hashes: dict[GoogleMediaId, imagehash.ImageHash],
-    matched_candidates: set[GoogleMediaId],
-) -> list[HashedMedia]:
-    return [
-        HashedMedia(
-            key=item.id,
-            hash=candidate_hashes[item.id],
-            is_video=item.type == "VIDEO",
-        )
-        for item in items
-        if item.id in candidate_hashes and item.id not in matched_candidates
-    ]
-
-
-def match_across_windows(
-    windows: list[StepWindow],
+def relevant_media_names(
+    media_by_step: dict[int, list[MediaName]],
+    step_ids: list[int],
     google_by_window: dict[int, list[PickedMediaItem]],
-    media_names: list[MediaName],
-    local_hashes: dict[MediaName, MediaHash],
-    candidate_hashes: dict[GoogleMediaId, imagehash.ImageHash],
-) -> tuple[list[MatchResult], set[MediaName], set[GoogleMediaId]]:
-    """Run Hungarian matching within each time window."""
-    all_matches: list[MatchResult] = []
-    matched_locals: set[MediaName] = set()
-    matched_candidates: set[GoogleMediaId] = set()
-
-    for window in windows:
-        hashed_locals = _hashed_locals(media_names, local_hashes, matched_locals)
-        hashed_cands = _hashed_candidates(
-            google_by_window[window.step_id], candidate_hashes, matched_candidates
+) -> list[MediaName]:
+    populated = {step_id for step_id, items in google_by_window.items() if items}
+    selected_steps = populated or set(step_ids)
+    return list(
+        dict.fromkeys(
+            name
+            for step_id in step_ids
+            if step_id in selected_steps
+            for name in media_by_step.get(step_id, [])
         )
-        if not hashed_locals or not hashed_cands:
-            continue
-
-        results = match_within_window(hashed_locals, hashed_cands)
-        for r in results:
-            all_matches.append(r)
-            matched_locals.add(r.local_name)
-            matched_candidates.add(r.google_id)
-
-    return all_matches, matched_locals, matched_candidates
-
-
-def cross_step_fallback(  # noqa: PLR0913
-    all_matches: list[MatchResult],
-    matched_locals: set[MediaName],
-    matched_candidates: set[GoogleMediaId],
-    media_names: list[MediaName],
-    local_hashes: dict[MediaName, MediaHash],
-    google_items: list[PickedMediaItem],
-    candidate_hashes: dict[GoogleMediaId, imagehash.ImageHash],
-) -> None:
-    """Try matching remaining unmatched media across all windows."""
-    hashed_locals = _hashed_locals(media_names, local_hashes, matched_locals)
-    hashed_cands = _hashed_candidates(
-        google_items, candidate_hashes, matched_candidates
     )
-
-    if (
-        hashed_locals
-        and hashed_cands
-        and len(hashed_locals) <= _FALLBACK_MAX_DIMENSION
-        and len(hashed_cands) <= _FALLBACK_MAX_DIMENSION
-    ):
-        all_matches.extend(match_within_window(hashed_locals, hashed_cands))

--- a/backend/app/logic/media_upgrade/phash_matching.py
+++ b/backend/app/logic/media_upgrade/phash_matching.py
@@ -56,6 +56,16 @@ class MatchResult(BaseModel):
     upgraded: bool = False
 
 
+class MatchingDiagnostics(NamedTuple):
+    valid_edges: int
+    nearest_13_to_15: int
+
+
+class MatchingOutcome(NamedTuple):
+    matches: list[MatchResult]
+    diagnostics: MatchingDiagnostics
+
+
 class StepWindow(BaseModel):
     step_id: int
     start: float  # unix timestamp
@@ -149,30 +159,73 @@ def build_cost_matrix(
     return matrix
 
 
+def _thresholded_assignment(
+    cost: np.ndarray,
+    threshold: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    if cost.size == 0:
+        return np.array([], dtype=int), np.array([], dtype=int)
+
+    local_count, candidate_count = cost.shape
+    unmatched_cost = local_count * threshold + 1
+    invalid_cost = unmatched_cost * (local_count + 1)
+    assignment = np.full(
+        (local_count, candidate_count + local_count),
+        invalid_cost,
+        dtype=np.int64,
+    )
+    valid = cost <= threshold
+    assignment[:, :candidate_count][valid] = cost[valid]
+    assignment[np.arange(local_count), candidate_count + np.arange(local_count)] = (
+        unmatched_cost
+    )
+
+    rows, columns = linear_sum_assignment(assignment)
+    real = columns < candidate_count
+    return rows[real], columns[real]
+
+
 def match_within_window(
     local_media: list[HashedMedia],
     candidate_media: list[HashedMedia],
     threshold: int = MATCH_THRESHOLD,
 ) -> list[MatchResult]:
-    """Run Hungarian algorithm on a cost matrix, reject pairs above threshold."""
+    return match_media_globally(local_media, candidate_media, threshold).matches
+
+
+def match_media_globally(
+    local_media: list[HashedMedia],
+    candidate_media: list[HashedMedia],
+    threshold: int = MATCH_THRESHOLD,
+) -> MatchingOutcome:
     if not local_media or not candidate_media:
-        return []
+        return MatchingOutcome([], MatchingDiagnostics(0, 0))
 
-    cost = np.array(build_cost_matrix(local_media, candidate_media))
-    row_idx, col_idx = linear_sum_assignment(cost)
-
-    results: list[MatchResult] = []
-    for r, c in zip(row_idx, col_idx, strict=True):
-        dist = int(cost[r, c])
-        if dist <= threshold:
-            results.append(
-                MatchResult(
-                    local_name=local_media[r].key,
-                    google_id=candidate_media[c].key,
-                    distance=dist,
-                )
-            )
-    return results
+    cost = np.asarray(build_cost_matrix(local_media, candidate_media), dtype=np.int16)
+    same_type = np.equal.outer(
+        [item.is_video for item in local_media],
+        [item.is_video for item in candidate_media],
+    )
+    valid = same_type & (cost <= threshold)
+    assignment_cost = np.where(valid, cost, threshold + 1)
+    rows, columns = _thresholded_assignment(assignment_cost, threshold)
+    matches = [
+        MatchResult(
+            local_name=local_media[row].key,
+            google_id=candidate_media[column].key,
+            distance=int(cost[row, column]),
+        )
+        for row, column in zip(rows, columns, strict=True)
+    ]
+    same_type_cost = np.where(same_type, cost, np.iinfo(np.int16).max)
+    nearest = same_type_cost.min(axis=1)
+    return MatchingOutcome(
+        matches,
+        MatchingDiagnostics(
+            valid_edges=int(valid.sum()),
+            nearest_13_to_15=int(((nearest >= 13) & (nearest <= 15)).sum()),
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/logic/media_upgrade/pipeline.py
+++ b/backend/app/logic/media_upgrade/pipeline.py
@@ -41,15 +41,16 @@ from app.services.google_photos import (
 )
 
 from .phash_matching import (
+    HashedMedia,
     MatchResult,
     MediaHash,
     bucket_by_window,
     build_step_windows,
     compute_phash_from_bytes,
     compute_phash_from_path,
-    cross_step_fallback,
     deduplicate_items,
-    match_across_windows,
+    match_media_globally,
+    relevant_media_names,
 )
 from .processing import (
     extract_video_frame_hashes,
@@ -191,18 +192,18 @@ async def run_matching(  # noqa: PLR0913
     ) as span:
         windows = build_step_windows(step_timestamps, step_ids)
         google_by_window = bucket_by_window(google_items, windows)
-        all_window_items = [
-            item for items in google_by_window.values() for item in items
-        ]
-        unique_items = deduplicate_items(all_window_items)
-
-        populated_steps = {sid for sid, items in google_by_window.items() if items}
-        media_names = [
-            name
-            for sid in step_ids
-            if sid in populated_steps
-            for name in media_by_step.get(sid, [])
-        ]
+        unique_items = deduplicate_items(
+            [
+                item
+                for item in google_items
+                if not (
+                    item.type == "VIDEO"
+                    and item.video_processing_status is not None
+                    and item.video_processing_status != "READY"
+                )
+            ]
+        )
+        media_names = relevant_media_names(media_by_step, step_ids, google_by_window)
         set_span_data(
             span,
             **{
@@ -255,27 +256,50 @@ async def run_matching(  # noqa: PLR0913
                 "candidate_hash.count": len(candidate_hashes),
             },
         ):
-            all_matches, matched_locals, matched_candidates = match_across_windows(
-                windows, google_by_window, media_names, local_hashes, candidate_hashes
-            )
-            cross_step_fallback(
-                all_matches,
-                matched_locals,
-                matched_candidates,
-                media_names,
-                local_hashes,
-                google_items,
-                candidate_hashes,
-            )
+            hashed_locals = [
+                HashedMedia(name, local_hashes[name], is_video(name))
+                for name in media_names
+                if name in local_hashes
+            ]
+            hashed_candidates = [
+                HashedMedia(
+                    item.id,
+                    candidate_hashes[item.id],
+                    item.type == "VIDEO",
+                )
+                for item in unique_items
+                if item.id in candidate_hashes
+            ]
+            outcome = match_media_globally(hashed_locals, hashed_candidates)
+            all_matches = outcome.matches
             if upgrade_candidates is not None:
                 for match in all_matches:
                     match.upgraded = match.local_name not in upgrade_candidates
 
+        diagnostics = {
+            "picked": len(google_items),
+            "matchable_picked": len(unique_items),
+            "relevant_local": len(media_names),
+            "local_hashed": len(local_hashes),
+            "candidate_hashed": len(candidate_hashes),
+            "valid_edges": outcome.diagnostics.valid_edges,
+            "matched": len(all_matches),
+            "unmatched_local": len(local_hashes) - len(all_matches),
+            "nearest_13_to_15": outcome.diagnostics.nearest_13_to_15,
+        }
+        logger.info("google_photos.matching.completed", **diagnostics)
         set_span_data(
             span,
             **{
                 "matched.count": len(all_matches),
                 "unmatched.count": len(google_items) - len(all_matches),
+                "matchable_picked.count": diagnostics["matchable_picked"],
+                "relevant_local.count": diagnostics["relevant_local"],
+                "local_hashed.count": diagnostics["local_hashed"],
+                "candidate_hashed.count": diagnostics["candidate_hashed"],
+                "valid_edges.count": diagnostics["valid_edges"],
+                "unmatched_local.count": diagnostics["unmatched_local"],
+                "nearest_13_to_15.count": diagnostics["nearest_13_to_15"],
             },
         )
 

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from PIL import Image
 from PIL.ExifTags import Base as ExifBase
+from structlog.testing import capture_logs
 
 from app.logic.media_upgrade import phash_matching
 
@@ -18,14 +19,11 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.logic.media_upgrade.phash_matching import (
-    _FALLBACK_MAX_DIMENSION,
     HashedMedia,
     MatchResult,
     bucket_by_window,
     build_step_windows,
     compute_phash_from_path,
-    cross_step_fallback,
-    match_within_window,
 )
 from app.logic.media_upgrade.pipeline import (
     MatchCompleted,
@@ -176,6 +174,30 @@ class TestMatchWithinWindow:
         assert outcome.diagnostics.valid_edges == 0
         assert outcome.diagnostics.nearest_13_to_15 == 1
 
+    def test_global_matching_is_independent_of_candidate_order(self) -> None:
+        local = [
+            _hm("a.jpg", _make_hash(0)),
+            _hm("b.jpg", _make_hash((1 << 64) - 1)),
+        ]
+        forward = [
+            _hm("google-a", _make_hash(0)),
+            _hm("google-b", _make_hash((1 << 64) - 1)),
+        ]
+
+        first = phash_matching.match_media_globally(local, forward).matches
+        second = phash_matching.match_media_globally(
+            local, list(reversed(forward))
+        ).matches
+
+        assert {(match.local_name, match.google_id) for match in first} == {
+            ("a.jpg", "google-a"),
+            ("b.jpg", "google-b"),
+        }
+        assert {(match.local_name, match.google_id) for match in second} == {
+            ("a.jpg", "google-a"),
+            ("b.jpg", "google-b"),
+        }
+
     def test_optimal_assignment_not_greedy(self) -> None:
         h_base = _make_hash(0)
 
@@ -194,11 +216,11 @@ class TestMatchWithinWindow:
         bits_gp2[2] = True
         h_gp2 = imagehash.ImageHash(bits_gp2)
 
-        results = match_within_window(
+        results = phash_matching.match_media_globally(
             [_hm("photo1.jpg", h_p1), _hm("photo2.jpg", h_p2)],
             [_hm("gp-1", h_base), _hm("gp-2", h_gp2)],
-        )
-        matched_locals = {r.local_name for r in results}
+        ).matches
+        matched_locals = {result.local_name for result in results}
         assert "photo1.jpg" in matched_locals
         assert "photo2.jpg" in matched_locals
 
@@ -215,37 +237,6 @@ class TestBucketByWindow:
         bucketed = bucket_by_window([item], windows)
         assert any(i.id == "g1" for i in bucketed[1])
         assert any(i.id == "g1" for i in bucketed[2])
-
-
-class TestCrossStepFallback:
-    @pytest.mark.parametrize(
-        ("dimension", "expected_matches"),
-        [
-            (_FALLBACK_MAX_DIMENSION, _FALLBACK_MAX_DIMENSION),
-            (_FALLBACK_MAX_DIMENSION + 1, 0),
-        ],
-    )
-    def test_dimension_limit(self, dimension: int, expected_matches: int) -> None:
-        h = _make_hash(0)
-        names = [f"photo{i}.jpg" for i in range(dimension)]
-        hashes = dict.fromkeys(names, h)
-        items = [
-            _make_item(f"gp-{i}", "2024-01-15T10:00:00Z") for i in range(dimension)
-        ]
-        candidate_hashes = {f"gp-{i}": h for i in range(dimension)}
-
-        all_matches: list[MatchResult] = []
-        cross_step_fallback(
-            all_matches,
-            matched_locals=set(),
-            matched_candidates=set(),
-            media_names=names,
-            local_hashes=hashes,
-            candidate_hashes=candidate_hashes,
-            google_items=items,
-        )
-
-        assert len(all_matches) == expected_matches
 
 
 class TestProcessPhoto:
@@ -394,6 +385,116 @@ class TestPersistUpgrade:
 
 
 class TestRunMatching:
+    async def test_logs_aggregate_matching_diagnostics_after_hash_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        h = _make_hash(0)
+
+        async def fake_local(
+            _album_dir: Path, name: str
+        ) -> tuple[str, imagehash.ImageHash | None]:
+            return name, None if name == "failed.jpg" else h
+
+        async def fake_candidate(
+            _download: object, item: PickedMediaItem, _tokens: object
+        ) -> tuple[str, imagehash.ImageHash | None]:
+            return item.id, None if item.id == "google-failed" else h
+
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_local_one", fake_local
+        )
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_candidate_one", fake_candidate
+        )
+
+        with capture_logs() as logs:
+            events = [
+                event
+                async for event in run_matching(
+                    clients=AsyncMock(),
+                    album_dir=tmp_path,
+                    media_by_step={1: ["matched.jpg", "failed.jpg"]},
+                    step_timestamps=[_match_dt(10).timestamp()],
+                    step_ids=[1],
+                    google_items=[
+                        _make_item("google-matched", _match_dt(10, 5).isoformat()),
+                        _make_item("google-failed", _match_dt(10, 6).isoformat()),
+                    ],
+                    tokens=_test_token,
+                )
+            ]
+
+        summary = events[-1]
+        assert isinstance(summary, MatchCompleted)
+        assert summary.matched == 1
+        completed = next(
+            log
+            for log in logs
+            if log.get("event") == "google_photos.matching.completed"
+        )
+        assert completed == {
+            "event": "google_photos.matching.completed",
+            "log_level": "info",
+            "picked": 2,
+            "matchable_picked": 2,
+            "relevant_local": 2,
+            "local_hashed": 1,
+            "candidate_hashed": 1,
+            "valid_edges": 1,
+            "matched": 1,
+            "unmatched_local": 0,
+            "nearest_13_to_15": 0,
+        }
+
+    async def test_matches_picked_item_outside_album_time_windows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        hashes = {
+            "inside.jpg": _make_hash(0),
+            "outside.jpg": _make_hash((1 << 64) - 1),
+        }
+
+        async def fake_local(
+            _album_dir: Path, name: str
+        ) -> tuple[str, imagehash.ImageHash]:
+            return name, hashes[name]
+
+        async def fake_candidate(
+            _download: object, item: PickedMediaItem, _tokens: object
+        ) -> tuple[str, imagehash.ImageHash]:
+            local_name = f"{item.id.removeprefix('google-')}.jpg"
+            return item.id, hashes[local_name]
+
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_local_one", fake_local
+        )
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_candidate_one", fake_candidate
+        )
+
+        events = [
+            event
+            async for event in run_matching(
+                clients=AsyncMock(),
+                album_dir=tmp_path,
+                media_by_step={1: ["inside.jpg", "outside.jpg"]},
+                step_timestamps=[_match_dt(10).timestamp()],
+                step_ids=[1],
+                google_items=[
+                    _make_item("google-inside", _match_dt(10, 5).isoformat()),
+                    _make_item("google-outside", "2024-01-20T10:00:00+00:00"),
+                ],
+                tokens=_test_token,
+            )
+        ]
+
+        summary = events[-1]
+        assert isinstance(summary, MatchCompleted)
+        assert {match.google_id for match in summary.matches} == {
+            "google-inside",
+            "google-outside",
+        }
+
     async def test_marks_matches_outside_upgrade_candidates_as_upgraded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -161,6 +161,18 @@ class TestMatchWithinWindow:
         assert len(rows) == count
         assert np.array_equal(rows, cols)
 
+    def test_thresholded_assignment_handles_observed_large_selection(self) -> None:
+        local_count = 401
+        candidate_count = 1_400
+        cost = np.full((local_count, candidate_count), 13, dtype=np.int16)
+        diagonal = np.arange(local_count)
+        cost[diagonal, diagonal] = 0
+
+        rows, cols = phash_matching._thresholded_assignment(cost, threshold=12)
+
+        assert np.array_equal(rows, diagonal)
+        assert np.array_equal(cols, diagonal)
+
     def test_global_matching_excludes_cross_type_edges_from_diagnostics(self) -> None:
         local = [_hm("photo.jpg", _make_hash(0))]
         candidates = [

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -11,6 +11,8 @@ import pytest
 from PIL import Image
 from PIL.ExifTags import Base as ExifBase
 
+from app.logic.media_upgrade import phash_matching
+
 if TYPE_CHECKING:
     import httpx
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -132,6 +134,48 @@ class TestComputePhash:
 
 
 class TestMatchWithinWindow:
+    def test_thresholded_assignment_maximizes_valid_pair_count(self) -> None:
+        cost = np.array([[0, 12], [12, 13]], dtype=np.int16)
+
+        rows, cols = phash_matching._thresholded_assignment(cost, threshold=12)
+
+        assert set(zip(rows.tolist(), cols.tolist(), strict=True)) == {
+            (0, 1),
+            (1, 0),
+        }
+
+    def test_thresholded_assignment_leaves_invalid_rows_unmatched(self) -> None:
+        cost = np.array([[13, 20], [0, 4]], dtype=np.int16)
+
+        rows, cols = phash_matching._thresholded_assignment(cost, threshold=12)
+
+        assert list(zip(rows.tolist(), cols.tolist(), strict=True)) == [(1, 0)]
+
+    def test_thresholded_assignment_handles_more_than_one_hundred_pairs(
+        self,
+    ) -> None:
+        count = 101
+        cost = np.full((count, count), 13, dtype=np.int16)
+        np.fill_diagonal(cost, 0)
+
+        rows, cols = phash_matching._thresholded_assignment(cost, threshold=12)
+
+        assert len(rows) == count
+        assert np.array_equal(rows, cols)
+
+    def test_global_matching_excludes_cross_type_edges_from_diagnostics(self) -> None:
+        local = [_hm("photo.jpg", _make_hash(0))]
+        candidates = [
+            _hm("google-video", _make_hash(0), video=True),
+            _hm("google-photo", _make_hash((1 << 13) - 1)),
+        ]
+
+        outcome = phash_matching.match_media_globally(local, candidates)
+
+        assert outcome.matches == []
+        assert outcome.diagnostics.valid_edges == 0
+        assert outcome.diagnostics.nearest_13_to_15 == 1
+
     def test_optimal_assignment_not_greedy(self) -> None:
         h_base = _make_hash(0)
 

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import imagehash
 import numpy as np
@@ -132,6 +132,30 @@ class TestComputePhash:
 
 
 class TestMatchWithinWindow:
+    def test_cost_matrix_uses_compact_numeric_storage(self) -> None:
+        matrix = phash_matching.build_cost_matrix(
+            [_hm("local.jpg", _make_hash(0))],
+            [_hm("google-photo", _make_hash(1))],
+        )
+
+        assert isinstance(matrix, np.ndarray)
+        assert matrix.dtype == np.int16
+        assert matrix.tolist() == [[1]]
+
+    def test_thresholded_assignment_does_not_allocate_augmented_dense_matrix(
+        self,
+    ) -> None:
+        cost = np.array([[0, 13, 12], [12, 0, 13]], dtype=np.int16)
+
+        with patch.object(phash_matching.np, "full", wraps=np.full) as full:
+            rows, cols = phash_matching._thresholded_assignment(cost, threshold=12)
+
+        assert all(call.args[0] != (2, 5) for call in full.call_args_list)
+        assert set(zip(rows.tolist(), cols.tolist(), strict=True)) == {
+            (0, 0),
+            (1, 1),
+        }
+
     def test_thresholded_assignment_maximizes_valid_pair_count(self) -> None:
         cost = np.array([[0, 12], [12, 13]], dtype=np.int16)
 
@@ -506,6 +530,113 @@ class TestRunMatching:
             "google-inside",
             "google-outside",
         }
+
+    async def test_hashes_all_album_media_when_every_pick_is_outside_windows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        hashes = {
+            "first.jpg": _make_hash(0),
+            "second.jpg": _make_hash((1 << 64) - 1),
+        }
+        hashed_local_names: list[str] = []
+
+        async def fake_local(
+            _album_dir: Path, name: str
+        ) -> tuple[str, imagehash.ImageHash]:
+            hashed_local_names.append(name)
+            return name, hashes[name]
+
+        async def fake_candidate(
+            _download: object, item: PickedMediaItem, _tokens: object
+        ) -> tuple[str, imagehash.ImageHash]:
+            return item.id, hashes["second.jpg"]
+
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_local_one", fake_local
+        )
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_candidate_one", fake_candidate
+        )
+
+        events = [
+            event
+            async for event in run_matching(
+                clients=AsyncMock(),
+                album_dir=tmp_path,
+                media_by_step={1: ["first.jpg"], 2: ["second.jpg"]},
+                step_timestamps=[
+                    _match_dt(10).timestamp(),
+                    _match_dt(14).timestamp(),
+                ],
+                step_ids=[1, 2],
+                google_items=[_make_item("google-second", "2024-01-20T10:00:00+00:00")],
+                tokens=_test_token,
+            )
+        ]
+
+        summary = events[-1]
+        assert isinstance(summary, MatchCompleted)
+        assert set(hashed_local_names) == {"first.jpg", "second.jpg"}
+        assert [(match.local_name, match.google_id) for match in summary.matches] == [
+            ("second.jpg", "google-second")
+        ]
+
+    async def test_excludes_processing_videos_from_candidate_hashing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        h = _make_hash(0)
+        hashed_candidate_ids: list[str] = []
+
+        async def fake_local(
+            _album_dir: Path, name: str
+        ) -> tuple[str, imagehash.ImageHash]:
+            return name, h
+
+        async def fake_candidate(
+            _download: object, item: PickedMediaItem, _tokens: object
+        ) -> tuple[str, imagehash.ImageHash]:
+            hashed_candidate_ids.append(item.id)
+            return item.id, h
+
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_local_one", fake_local
+        )
+        monkeypatch.setattr(
+            "app.logic.media_upgrade.pipeline._hash_candidate_one", fake_candidate
+        )
+
+        events = [
+            event
+            async for event in run_matching(
+                clients=AsyncMock(),
+                album_dir=tmp_path,
+                media_by_step={1: ["photo.jpg"]},
+                step_timestamps=[_match_dt(10).timestamp()],
+                step_ids=[1],
+                google_items=[
+                    _make_item(
+                        "processing-video",
+                        _match_dt(10, 5).isoformat(),
+                        item_type="VIDEO",
+                        video_processing_status="PROCESSING",
+                    ),
+                    _make_item("ready-photo", _match_dt(10, 6).isoformat()),
+                ],
+                tokens=_test_token,
+            )
+        ]
+
+        summary = events[-1]
+        assert isinstance(summary, MatchCompleted)
+        assert hashed_candidate_ids == ["ready-photo"]
+        assert summary.total_picked == 2
+        assert summary.matched == 1
+        assert summary.unmatched == 1
+        assert [
+            event.total
+            for event in events
+            if isinstance(event, MatchInProgress) and event.phase == "matching"
+        ] == [1]
 
     async def test_marks_matches_outside_upgrade_candidates_as_upgraded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -247,6 +247,23 @@ test.describe("Media Upgrade", () => {
     ).toBeVisible();
   });
 
+  test("match summary uses singular copy for one match", async ({
+    authedPage: page,
+  }) => {
+    await mockConnectedUser(page);
+    await mockPickerSession(page);
+    await mockMatchStream(page, round2MatchEvents);
+    await prepareOnboardedPopupFlow(page);
+
+    await page.goto("/editor");
+    await clickUpgradeMedia(page);
+
+    await expect(
+      page.getByText(/matched 1 album file from 2 selected google items/i),
+    ).toBeVisible();
+    await expect(page.getByText(/matched 1 album files/i)).toHaveCount(0);
+  });
+
   test("partial failure shows count in done message", async ({
     authedPage: page,
   }) => {

--- a/frontend/e2e/media-upgrade.test.ts
+++ b/frontend/e2e/media-upgrade.test.ts
@@ -234,6 +234,19 @@ test.describe("Media Upgrade", () => {
     await completeReadyUpgrade(page, upgradeEvents, /upgraded 2 files/i);
   });
 
+  test("match summary shows selected item coverage", async ({
+    authedPage: page,
+  }) => {
+    await setupUpgradeRoutes(page);
+    await prepareOnboardedPopupFlow(page);
+
+    await openReadyUpgradeSummary(page);
+
+    await expect(
+      page.getByText(/matched 2 album files from 3 selected google items/i),
+    ).toBeVisible();
+  });
+
   test("partial failure shows count in done message", async ({
     authedPage: page,
   }) => {

--- a/frontend/src/components/editor/UpgradeMatchDialog.vue
+++ b/frontend/src/components/editor/UpgradeMatchDialog.vue
@@ -37,16 +37,16 @@ const titleText = computed(() => {
 
 const bodyText = computed(() => {
   if (props.matched === 0) return t("upgrade.summary.noMatchBody");
-  if (props.newThisRound === 0 && props.matched > 0)
-    return t("upgrade.summary.noNewMatchBody");
-  if (toUpgrade.value === 0) return t("upgrade.summary.allUpgradedBody");
   if (props.alreadyUpgraded > 0)
-    return t(
-      "upgrade.summary.alreadyUpgraded",
-      { count: props.alreadyUpgraded },
-      props.alreadyUpgraded,
-    );
-  return "";
+    return t("upgrade.summary.matchCoverageWithUpgraded", {
+      matched: props.matched,
+      total: props.total,
+      upgraded: props.alreadyUpgraded,
+    });
+  return t("upgrade.summary.matchCoverage", {
+    matched: props.matched,
+    total: props.total,
+  });
 });
 
 const confirmLabel = computed(() => {

--- a/frontend/src/components/editor/UpgradeMatchDialog.vue
+++ b/frontend/src/components/editor/UpgradeMatchDialog.vue
@@ -37,16 +37,30 @@ const titleText = computed(() => {
 
 const bodyText = computed(() => {
   if (props.matched === 0) return t("upgrade.summary.noMatchBody");
+  const selected = t(
+    "upgrade.summary.selectedCount",
+    { count: props.total },
+    props.total,
+  );
   if (props.alreadyUpgraded > 0)
-    return t("upgrade.summary.matchCoverageWithUpgraded", {
-      matched: props.matched,
-      total: props.total,
-      upgraded: props.alreadyUpgraded,
-    });
-  return t("upgrade.summary.matchCoverage", {
-    matched: props.matched,
-    total: props.total,
-  });
+    return t(
+      "upgrade.summary.matchCoverageWithUpgraded",
+      {
+        matched: props.matched,
+        selected,
+        upgraded: t(
+          "upgrade.summary.alreadyUpgradedCount",
+          { count: props.alreadyUpgraded },
+          props.alreadyUpgraded,
+        ),
+      },
+      props.matched,
+    );
+  return t(
+    "upgrade.summary.matchCoverage",
+    { matched: props.matched, selected },
+    props.matched,
+  );
 });
 
 const confirmLabel = computed(() => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -384,8 +384,10 @@
       "noNewMatchTitle": "No new matches found",
       "allUpgradedTitle": "Already at original quality",
       "noMatchBody": "Make sure you selected photos from your trip.",
-      "matchCoverage": "Matched {matched} album files from {total} selected Google items.",
-      "matchCoverageWithUpgraded": "Matched {matched} album files from {total} selected Google items. {upgraded} were already at original quality.",
+      "selectedCount": "1 selected Google item | {count} selected Google items",
+      "alreadyUpgradedCount": "1 was already at original quality | {count} were already at original quality",
+      "matchCoverage": "Matched 1 album file from {selected}. | Matched {matched} album files from {selected}.",
+      "matchCoverageWithUpgraded": "Matched 1 album file from {selected}. {upgraded}. | Matched {matched} album files from {selected}. {upgraded}.",
       "confirm": "Upgrade 1 file | Upgrade {count} files",
       "selectMore": "Select More"
     },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -384,9 +384,8 @@
       "noNewMatchTitle": "No new matches found",
       "allUpgradedTitle": "Already at original quality",
       "noMatchBody": "Make sure you selected photos from your trip.",
-      "noNewMatchBody": "Try selecting different photos.",
-      "allUpgradedBody": "All matched files were already upgraded.",
-      "alreadyUpgraded": "1 already at original quality. | {count} already at original quality.",
+      "matchCoverage": "Matched {matched} album files from {total} selected Google items.",
+      "matchCoverageWithUpgraded": "Matched {matched} album files from {total} selected Google items. {upgraded} were already at original quality.",
       "confirm": "Upgrade 1 file | Upgrade {count} files",
       "selectMore": "Select More"
     },

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -384,8 +384,10 @@
       "noNewMatchTitle": "לא נמצאו התאמות חדשות",
       "allUpgradedTitle": "כבר באיכות המקורית",
       "noMatchBody": "ודאו שבחרתם תמונות מהטיול.",
-      "matchCoverage": "נמצאו {matched} קבצים מהאלבום מתוך {total} פריטים שנבחרו ב-Google Photos.",
-      "matchCoverageWithUpgraded": "נמצאו {matched} קבצים מהאלבום מתוך {total} פריטים שנבחרו ב-Google Photos. מתוכם, {upgraded} כבר היו באיכות המקורית.",
+      "selectedCount": "פריט אחד שנבחר ב-Google Photos | {count} פריטים שנבחרו ב-Google Photos",
+      "alreadyUpgradedCount": "אחד מהם כבר היה באיכות המקורית | {count} מהם כבר היו באיכות המקורית",
+      "matchCoverage": "נמצא קובץ אחד מהאלבום מתוך {selected}. | נמצאו {matched} קבצים מהאלבום מתוך {selected}.",
+      "matchCoverageWithUpgraded": "נמצא קובץ אחד מהאלבום מתוך {selected}. {upgraded}. | נמצאו {matched} קבצים מהאלבום מתוך {selected}. {upgraded}.",
       "confirm": "שדרגו קובץ אחד | שדרגו {count} קבצים",
       "selectMore": "בחרו עוד"
     },

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -384,9 +384,8 @@
       "noNewMatchTitle": "לא נמצאו התאמות חדשות",
       "allUpgradedTitle": "כבר באיכות המקורית",
       "noMatchBody": "ודאו שבחרתם תמונות מהטיול.",
-      "noNewMatchBody": "נסו לבחור תמונות אחרות.",
-      "allUpgradedBody": "כל הקבצים שנבחרו כבר שודרגו בעבר.",
-      "alreadyUpgraded": "אחד כבר באיכות המקורית. | {count} כבר באיכות המקורית.",
+      "matchCoverage": "נמצאו {matched} קבצים מהאלבום מתוך {total} פריטים שנבחרו ב-Google Photos.",
+      "matchCoverageWithUpgraded": "נמצאו {matched} קבצים מהאלבום מתוך {total} פריטים שנבחרו ב-Google Photos. מתוכם, {upgraded} כבר היו באיכות המקורית.",
       "confirm": "שדרגו קובץ אחד | שדרגו {count} קבצים",
       "selectMore": "בחרו עוד"
     },

--- a/frontend/tests/components/UpgradeMatchDialog.test.ts
+++ b/frontend/tests/components/UpgradeMatchDialog.test.ts
@@ -1,0 +1,47 @@
+import { mount } from "@vue/test-utils";
+import i18n from "@/i18n";
+import UpgradeMatchDialog from "@/components/editor/UpgradeMatchDialog.vue";
+
+function mountDialog() {
+  return mount(UpgradeMatchDialog, {
+    props: {
+      modelValue: true,
+      matched: 1,
+      total: 1,
+      unmatched: 0,
+      alreadyUpgraded: 1,
+      newThisRound: 1,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        PromptDialog: {
+          props: ["body"],
+          template: "<div>{{ body }}</div>",
+        },
+      },
+    },
+  });
+}
+
+describe("UpgradeMatchDialog", () => {
+  afterEach(() => {
+    i18n.global.locale.value = "en";
+  });
+
+  test("pluralizes every count in the English match summary", () => {
+    i18n.global.locale.value = "en";
+
+    expect(mountDialog().text()).toBe(
+      "Matched 1 album file from 1 selected Google item. 1 was already at original quality.",
+    );
+  });
+
+  test("pluralizes every count in the Hebrew match summary", () => {
+    i18n.global.locale.value = "he";
+
+    expect(mountDialog().text()).toBe(
+      "נמצא קובץ אחד מהאלבום מתוך פריט אחד שנבחר ב-Google Photos. אחד מהם כבר היה באיכות המקורית.",
+    );
+  });
+});


### PR DESCRIPTION
- replace ordered per-window matching and the 100-item fallback cap with one global threshold-aware assignment
- maximize valid one-to-one matches before minimizing perceptual-hash distance, while retaining the distance-12 safety threshold and media-type checks
- hash every ready Picker item and add aggregate Sentry/log diagnostics without media identifiers
- show selected-versus-matched coverage in the upgrade confirmation dialog