### PR TITLE
fix: delete evicted demo users

### DIFF
--- a/backend/app/logic/eviction.py
+++ b/backend/app/logic/eviction.py
@@ -12,6 +12,7 @@ from app.core.db import get_engine
 from app.core.observability import set_span_data, start_span
 from app.core.resources import MiB
 from app.models.album import Album
+from app.models.user import User
 
 logger = structlog.get_logger(__name__)
 
@@ -38,20 +39,51 @@ def _sizes_by_album(users_folder: Path) -> tuple[int, dict[tuple[int, str], int]
     return sum(by_album.values()), by_album
 
 
-def _remove_album(path: Path) -> None:
+def _remove_tree(path: Path) -> None:
     with suppress(FileNotFoundError):
         shutil.rmtree(path)
+
+
+def _stage_demo_eviction(users_folder: Path, uid: int) -> Path:
+    pending = users_folder / ".evictions" / str(uid)
+    pending.parent.mkdir(exist_ok=True)
+    (users_folder / str(uid)).rename(pending)
+    return pending
+
+
+async def _resume_demo_evictions(users_folder: Path, skip_uid: int) -> None:
+    pending_root = users_folder / ".evictions"
+    if not pending_root.exists():
+        return
+
+    async with AsyncSession(get_engine()) as session:
+        for pending in pending_root.iterdir():
+            uid = int(pending.name)
+            if uid == skip_uid:
+                continue
+            if (users_folder / str(uid)).exists():
+                await asyncio.to_thread(_remove_tree, pending)
+                continue
+            user = await session.get(User, uid)
+            if user is not None:
+                if not user.is_demo:
+                    raise RuntimeError(f"Pending eviction belongs to user {uid}")
+                await session.delete(user)
+                await session.commit()
+            await asyncio.to_thread(_remove_tree, pending)
 
 
 async def run_eviction(skip_uid: int) -> None:
     """Delete LRU album media until total storage is under MAX_STORAGE_BYTES.
 
     Skips the user identified by skip_uid (the one who just uploaded).
-    Database records and album edits are preserved.
+    Demo users are deleted completely. Other database records and edits are preserved.
     """
     s = get_settings()
     users_folder = s.USERS_FOLDER
     cap = s.MAX_STORAGE_BYTES
+
+    await _resume_demo_evictions(users_folder, skip_uid)
 
     with start_span(
         "eviction.scan",
@@ -76,46 +108,78 @@ async def run_eviction(skip_uid: int) -> None:
         cap_mb=cap // MiB,
     )
 
-    async with AsyncSession(get_engine()) as session:
+    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
         result = await session.exec(
-            select(Album).order_by(col(Album.last_active_at).asc())
+            select(Album, User)
+            .join(User, col(Album.uid) == col(User.id))
+            .order_by(col(Album.last_active_at).asc())
         )
         candidates = result.all()
+        removed_albums = 0
+        removed_demo_users: set[int] = set()
 
-    removed = 0
-    with start_span(
-        "eviction.delete",
-        "Delete evicted album media",
-        **{
-            "app.workflow": "eviction",
-            "storage.used_bytes": total,
-            "storage.limit_bytes": cap,
-            "candidate.count": len(candidates),
-        },
-    ) as span:
-        for album in candidates:
-            if total <= cap:
-                break
-            if album.uid == skip_uid:
-                continue
-            key = (album.uid, album.id)
-            folder_size = sizes.get(key, 0)
-            if folder_size == 0:
-                continue
+        with start_span(
+            "eviction.delete",
+            "Delete evicted album media",
+            **{
+                "app.workflow": "eviction",
+                "storage.used_bytes": total,
+                "storage.limit_bytes": cap,
+                "candidate.count": len(candidates),
+            },
+        ) as span:
+            for album, user in candidates:
+                if total <= cap:
+                    break
+                if album.uid == skip_uid or album.uid in removed_demo_users:
+                    continue
 
-            folder = users_folder / str(album.uid) / "trip" / album.id
-            await asyncio.to_thread(_remove_album, folder)
-            total -= folder_size
-            removed += 1
-            logger.info(
-                "eviction.album_removed",
-                user_id=album.uid,
-                album_id=album.id,
-                album_size_mb=folder_size // MiB,
+                if user.is_demo:
+                    user_sizes = [
+                        size for (uid, _), size in sizes.items() if uid == album.uid
+                    ]
+                    user_size = sum(user_sizes)
+                    if user_size == 0:
+                        continue
+                    pending = await asyncio.to_thread(
+                        _stage_demo_eviction, users_folder, album.uid
+                    )
+                    await session.delete(user)
+                    await session.commit()
+                    await asyncio.to_thread(_remove_tree, pending)
+                    total -= user_size
+                    removed_albums += len(user_sizes)
+                    removed_demo_users.add(album.uid)
+                    logger.info(
+                        "eviction.demo_user_removed",
+                        user_id=album.uid,
+                        album_count=len(user_sizes),
+                        media_size_mb=user_size // MiB,
+                    )
+                    continue
+
+                key = (album.uid, album.id)
+                folder_size = sizes.get(key, 0)
+                if folder_size == 0:
+                    continue
+                folder = users_folder / str(album.uid) / "trip" / album.id
+                await asyncio.to_thread(_remove_tree, folder)
+                total -= folder_size
+                removed_albums += 1
+                logger.info(
+                    "eviction.album_removed",
+                    user_id=album.uid,
+                    album_id=album.id,
+                    album_size_mb=folder_size // MiB,
+                )
+
+            set_span_data(
+                span,
+                **{
+                    "album.removed": removed_albums,
+                    "demo_user.removed": len(removed_demo_users),
+                    "storage.remaining_bytes": total,
+                },
             )
-        set_span_data(
-            span,
-            **{"album.removed": removed, "storage.remaining_bytes": total},
-        )
 
     logger.info("eviction.completed", storage_mb=total // MiB)

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.core.config import get_settings
 from app.logic.eviction import _sizes_by_album, run_eviction
 from app.models.album import Album
 
-from .factories import make_album, make_async_session_mock
-
-if TYPE_CHECKING:
-    import pytest
+from .factories import make_album, make_async_session_mock, make_user
 
 
 def _make_file(path: Path, size: int) -> Path:
@@ -36,7 +34,9 @@ def _configure_storage(
 
 def _mock_eviction_albums(*albums: Album) -> patch:
     mock_result = MagicMock()
-    mock_result.all.return_value = list(albums)
+    mock_result.all.return_value = [
+        (album, MagicMock(id=album.uid, is_demo=False)) for album in albums
+    ]
     mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
     return patch("app.logic.eviction.AsyncSession", return_value=mock_session)
 
@@ -85,6 +85,184 @@ class TestRunEviction:
         assert (users_dir / "1").exists()
         assert not (users_dir / "1" / "trip" / "old").exists()
         assert (users_dir / "1" / "trip" / "recent" / "data.bin").exists()
+
+    async def test_evicts_entire_demo_user(
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_storage(tmp_path, monkeypatch, 100)
+
+        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
+        _make_file(users_dir / "1" / "trip" / "recent" / "data.bin", 80)
+        _make_file(users_dir / "2" / "trip" / "real" / "data.bin", 80)
+
+        demo_user = make_user(1, album_ids=["old", "recent"], is_demo=True)
+        real_user = make_user(2, album_ids=["real"])
+        old_album = _make_album(1, "old", hours_ago=48)
+        recent_album = _make_album(1, "recent", hours_ago=1)
+        real_album = _make_album(2, "real", hours_ago=24)
+        mock_result = MagicMock()
+        mock_result.all.return_value = [
+            (old_album, demo_user),
+            (real_album, real_user),
+            (recent_album, demo_user),
+        ]
+        mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
+
+        with patch("app.logic.eviction.AsyncSession", return_value=mock_session):
+            await run_eviction(skip_uid=999)
+
+        mock_session.delete.assert_awaited_once_with(demo_user)
+        mock_session.commit.assert_awaited_once()
+        assert not (users_dir / "1").exists()
+        assert (users_dir / "2" / "trip" / "real" / "data.bin").exists()
+
+    async def test_resumes_demo_eviction_after_commit_failure(
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_storage(tmp_path, monkeypatch, 50)
+
+        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
+        demo_user = make_user(1, album_ids=["old"], is_demo=True)
+        old_album = _make_album(1, "old", hours_ago=48)
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(old_album, demo_user)]
+        failed_session = make_async_session_mock(
+            exec=AsyncMock(return_value=mock_result),
+            commit=AsyncMock(side_effect=OSError("commit failed")),
+        )
+
+        with (
+            patch("app.logic.eviction.AsyncSession", return_value=failed_session),
+            pytest.raises(OSError, match="commit failed"),
+        ):
+            await run_eviction(skip_uid=999)
+
+        pending = next((users_dir / ".evictions").iterdir())
+        assert pending.exists()
+        assert not (users_dir / "1").exists()
+
+        skipped_session = make_async_session_mock(get=AsyncMock(return_value=demo_user))
+        with patch("app.logic.eviction.AsyncSession", return_value=skipped_session):
+            await run_eviction(skip_uid=1)
+
+        skipped_session.delete.assert_not_awaited()
+        assert pending.exists()
+
+        recovery_session = make_async_session_mock(
+            get=AsyncMock(return_value=demo_user)
+        )
+        with patch("app.logic.eviction.AsyncSession", return_value=recovery_session):
+            await run_eviction(skip_uid=999)
+
+        recovery_session.delete.assert_awaited_once_with(demo_user)
+        recovery_session.commit.assert_awaited_once()
+        assert not pending.exists()
+
+    async def test_resumes_demo_eviction_after_cleanup_failure(
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_storage(tmp_path, monkeypatch, 50)
+
+        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
+        demo_user = make_user(1, album_ids=["old"], is_demo=True)
+        old_album = _make_album(1, "old", hours_ago=48)
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(old_album, demo_user)]
+        failed_session = make_async_session_mock(
+            exec=AsyncMock(return_value=mock_result)
+        )
+
+        with (
+            patch("app.logic.eviction.AsyncSession", return_value=failed_session),
+            patch(
+                "app.logic.eviction._remove_tree",
+                side_effect=OSError("cleanup failed"),
+            ),
+            pytest.raises(OSError, match="cleanup failed"),
+        ):
+            await run_eviction(skip_uid=999)
+
+        pending = next((users_dir / ".evictions").iterdir())
+        failed_session.commit.assert_awaited_once()
+        assert pending.exists()
+
+        recovery_session = make_async_session_mock(get=AsyncMock(return_value=None))
+        with patch("app.logic.eviction.AsyncSession", return_value=recovery_session):
+            await run_eviction(skip_uid=999)
+
+        recovery_session.delete.assert_not_awaited()
+        assert not pending.exists()
+
+    async def test_does_not_delete_newer_demo_session_during_recovery(
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_storage(tmp_path, monkeypatch, 50)
+
+        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
+        demo_user = make_user(1, album_ids=["old"], is_demo=True)
+        old_album = _make_album(1, "old", hours_ago=48)
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(old_album, demo_user)]
+        failed_session = make_async_session_mock(
+            exec=AsyncMock(return_value=mock_result),
+            commit=AsyncMock(side_effect=OSError("commit failed")),
+        )
+
+        with (
+            patch("app.logic.eviction.AsyncSession", return_value=failed_session),
+            pytest.raises(OSError, match="commit failed"),
+        ):
+            await run_eviction(skip_uid=999)
+
+        pending = next((users_dir / ".evictions").iterdir())
+        newer_user = make_user(
+            1,
+            album_ids=["new"],
+            is_demo=True,
+            last_active_at=demo_user.last_active_at + timedelta(hours=1),
+        )
+        recovery_session = make_async_session_mock(
+            get=AsyncMock(return_value=newer_user)
+        )
+        with patch("app.logic.eviction.AsyncSession", return_value=recovery_session):
+            await run_eviction(skip_uid=999)
+
+        recovery_session.delete.assert_not_awaited()
+        assert not pending.exists()
+        assert (users_dir / "1").exists()
+
+    async def test_activity_change_does_not_abandon_pending_demo_delete(
+        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_storage(tmp_path, monkeypatch, 50)
+
+        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
+        demo_user = make_user(1, album_ids=["old"], is_demo=True)
+        old_album = _make_album(1, "old", hours_ago=48)
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(old_album, demo_user)]
+        failed_session = make_async_session_mock(
+            exec=AsyncMock(return_value=mock_result),
+            commit=AsyncMock(side_effect=OSError("commit failed")),
+        )
+
+        with (
+            patch("app.logic.eviction.AsyncSession", return_value=failed_session),
+            pytest.raises(OSError, match="commit failed"),
+        ):
+            await run_eviction(skip_uid=999)
+
+        pending = next((users_dir / ".evictions").iterdir())
+        demo_user.last_active_at += timedelta(hours=1)
+        recovery_session = make_async_session_mock(
+            get=AsyncMock(return_value=demo_user)
+        )
+        with patch("app.logic.eviction.AsyncSession", return_value=recovery_session):
+            await run_eviction(skip_uid=999)
+
+        recovery_session.delete.assert_awaited_once_with(demo_user)
+        recovery_session.commit.assert_awaited_once()
+        assert not pending.exists()
 
     async def test_skips_uploading_user(
         self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -9,6 +9,7 @@ import pytest
 from app.core.config import get_settings
 from app.logic.eviction import _sizes_by_album, run_eviction
 from app.models.album import Album
+from app.models.user import User
 
 from .factories import make_album, make_async_session_mock, make_user
 
@@ -39,6 +40,20 @@ def _mock_eviction_albums(*albums: Album) -> patch:
     ]
     mock_session = make_async_session_mock(exec=AsyncMock(return_value=mock_result))
     return patch("app.logic.eviction.AsyncSession", return_value=mock_session)
+
+
+def _single_demo_eviction(
+    users_dir: Path, *, commit_error: Exception | None = None
+) -> tuple[User, MagicMock]:
+    _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
+    user = make_user(1, album_ids=["old"], is_demo=True)
+    result = MagicMock()
+    result.all.return_value = [(_make_album(1, "old", hours_ago=48), user)]
+    session = make_async_session_mock(
+        exec=AsyncMock(return_value=result),
+        commit=AsyncMock(side_effect=commit_error),
+    )
+    return user, session
 
 
 class TestSizesByAlbum:
@@ -121,14 +136,8 @@ class TestRunEviction:
     ) -> None:
         _configure_storage(tmp_path, monkeypatch, 50)
 
-        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
-        demo_user = make_user(1, album_ids=["old"], is_demo=True)
-        old_album = _make_album(1, "old", hours_ago=48)
-        mock_result = MagicMock()
-        mock_result.all.return_value = [(old_album, demo_user)]
-        failed_session = make_async_session_mock(
-            exec=AsyncMock(return_value=mock_result),
-            commit=AsyncMock(side_effect=OSError("commit failed")),
+        demo_user, failed_session = _single_demo_eviction(
+            users_dir, commit_error=OSError("commit failed")
         )
 
         with (
@@ -163,14 +172,7 @@ class TestRunEviction:
     ) -> None:
         _configure_storage(tmp_path, monkeypatch, 50)
 
-        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
-        demo_user = make_user(1, album_ids=["old"], is_demo=True)
-        old_album = _make_album(1, "old", hours_ago=48)
-        mock_result = MagicMock()
-        mock_result.all.return_value = [(old_album, demo_user)]
-        failed_session = make_async_session_mock(
-            exec=AsyncMock(return_value=mock_result)
-        )
+        _, failed_session = _single_demo_eviction(users_dir)
 
         with (
             patch("app.logic.eviction.AsyncSession", return_value=failed_session),
@@ -198,14 +200,8 @@ class TestRunEviction:
     ) -> None:
         _configure_storage(tmp_path, monkeypatch, 50)
 
-        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
-        demo_user = make_user(1, album_ids=["old"], is_demo=True)
-        old_album = _make_album(1, "old", hours_ago=48)
-        mock_result = MagicMock()
-        mock_result.all.return_value = [(old_album, demo_user)]
-        failed_session = make_async_session_mock(
-            exec=AsyncMock(return_value=mock_result),
-            commit=AsyncMock(side_effect=OSError("commit failed")),
+        demo_user, failed_session = _single_demo_eviction(
+            users_dir, commit_error=OSError("commit failed")
         )
 
         with (
@@ -230,39 +226,6 @@ class TestRunEviction:
         recovery_session.delete.assert_not_awaited()
         assert not pending.exists()
         assert (users_dir / "1").exists()
-
-    async def test_activity_change_does_not_abandon_pending_demo_delete(
-        self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        _configure_storage(tmp_path, monkeypatch, 50)
-
-        _make_file(users_dir / "1" / "trip" / "old" / "data.bin", 80)
-        demo_user = make_user(1, album_ids=["old"], is_demo=True)
-        old_album = _make_album(1, "old", hours_ago=48)
-        mock_result = MagicMock()
-        mock_result.all.return_value = [(old_album, demo_user)]
-        failed_session = make_async_session_mock(
-            exec=AsyncMock(return_value=mock_result),
-            commit=AsyncMock(side_effect=OSError("commit failed")),
-        )
-
-        with (
-            patch("app.logic.eviction.AsyncSession", return_value=failed_session),
-            pytest.raises(OSError, match="commit failed"),
-        ):
-            await run_eviction(skip_uid=999)
-
-        pending = next((users_dir / ".evictions").iterdir())
-        demo_user.last_active_at += timedelta(hours=1)
-        recovery_session = make_async_session_mock(
-            get=AsyncMock(return_value=demo_user)
-        )
-        with patch("app.logic.eviction.AsyncSession", return_value=recovery_session):
-            await run_eviction(skip_uid=999)
-
-        recovery_session.delete.assert_awaited_once_with(demo_user)
-        recovery_session.commit.assert_awaited_once()
-        assert not pending.exists()
 
     async def test_skips_uploading_user(
         self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
- delete an entire demo user when one of their albums is selected for storage eviction
- keep album-only LRU eviction for non-demo users
- stage demo directories under `.evictions/` so DBOS retries recover cleanly across database or filesystem failures
- preserve protected uploads and recreated live demo sessions during recovery