### PR TITLE
fix(frontend): account for contained photos in quality warnings

### DIFF
--- a/frontend/src/components/album/CoverPage.vue
+++ b/frontend/src/components/album/CoverPage.vue
@@ -34,6 +34,7 @@ const coverQuality = computed(() =>
     ? mediaQuality(
         coverMedia.value,
         COVER_FRACTION,
+        "cover",
         mediaByName.value,
         mediaResolutionWarningPreset.value,
       )

--- a/frontend/src/components/album/MediaItem.vue
+++ b/frontend/src/components/album/MediaItem.vue
@@ -319,8 +319,6 @@ function onVideoKey(e: KeyboardEvent) {
             { dpi: quality.dpi },
           )
         }}
-        <br />
-        {{ t("externalMedia.replaceQuality") }}
       </q-tooltip>
     </button>
   </div>

--- a/frontend/src/components/album/step/StepDescriptionPage.vue
+++ b/frontend/src/components/album/step/StepDescriptionPage.vue
@@ -23,6 +23,7 @@ const photoQuality = computed(() =>
     ? mediaQuality(
         props.photo,
         PHOTO_PANEL_FRACTION,
+        "cover",
         mediaByName.value,
         mediaResolutionWarningPreset.value,
       )

--- a/frontend/src/components/album/step/StepMainPage.vue
+++ b/frontend/src/components/album/step/StepMainPage.vue
@@ -24,6 +24,7 @@ const coverQuality = computed(() =>
     ? mediaQuality(
         props.step.cover,
         PHOTO_PANEL_FRACTION,
+        "cover",
         mediaByName.value,
         mediaResolutionWarningPreset.value,
       )

--- a/frontend/src/components/album/step/StepPhotoPage.vue
+++ b/frontend/src/components/album/step/StepPhotoPage.vue
@@ -8,6 +8,7 @@ import { isPortraitByName } from "@/utils/media";
 import { useElementVisibility } from "@vueuse/core";
 import {
   enforceOrientationOrder,
+  photoPageFit,
   photoPageFraction,
   resolveLayoutClass,
 } from "@/utils/photoLayout";
@@ -79,12 +80,14 @@ if (!printMode) {
 const layoutClass = computed(() =>
   resolveLayoutClass(localPage.value, isPortrait),
 );
+const photoFit = computed(() => photoPageFit(layoutClass.value));
 
 const photoQualities = computed(() =>
   localPage.value.map((name, i) =>
     mediaQuality(
       name,
       photoPageFraction(layoutClass.value, i),
+      photoFit.value,
       mediaByName.value,
       mediaResolutionWarningPreset.value,
     ),
@@ -94,7 +97,10 @@ const photoQualities = computed(() =>
 
 <template>
   <div class="page page-container">
-    <div ref="containerRef" :class="['container', layoutClass]">
+    <div
+      ref="containerRef"
+      :class="['container', layoutClass, `fit-${photoFit}`]"
+    >
       <MediaItem
         v-for="(photo, i) in localPage"
         :key="photo"
@@ -130,22 +136,20 @@ const photoQualities = computed(() =>
   justify-content: center;
 }
 
-// -- Default: cover. Layouts that need contain opt out. --
-
 .container :deep(img) {
   object-fit: cover;
 }
 
-// -- 1 photo: contain (show full image) --
+.container.fit-contain :deep(img) {
+  object-fit: contain;
+}
+
+// -- 1 photo --
 
 .layout-1p-0l,
 .layout-0p-1l {
   grid-template-columns: 1fr;
   grid-template-rows: 1fr;
-
-  :deep(img) {
-    object-fit: contain;
-  }
 }
 
 // -- 2 photos --
@@ -154,10 +158,6 @@ const photoQualities = computed(() =>
 .layout-1p-1l {
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr;
-
-  :deep(img) {
-    object-fit: contain;
-  }
 }
 
 .layout-2p-0l {
@@ -185,10 +185,6 @@ const photoQualities = computed(() =>
   .item:first-child {
     grid-row: 1 / 3;
   }
-
-  :deep(img) {
-    object-fit: contain;
-  }
 }
 
 // -- 3 photos: mixed (portraits sorted first) --
@@ -208,10 +204,6 @@ const photoQualities = computed(() =>
 
   .item:last-child {
     grid-column: 1 / 3;
-  }
-
-  :deep(img) {
-    object-fit: contain;
   }
 }
 

--- a/frontend/src/utils/photoLayout.ts
+++ b/frontend/src/utils/photoLayout.ts
@@ -3,7 +3,18 @@ export interface PageFraction {
   heightFrac: number;
 }
 
+export type PhotoFit = "contain" | "cover";
+
 export const FULL_PAGE_FRACTION: PageFraction = { widthFrac: 1, heightFrac: 1 };
+
+const CONTAIN_LAYOUTS = new Set([
+  "layout-1p-0l",
+  "layout-0p-1l",
+  "layout-0p-2l",
+  "layout-1p-1l",
+  "layout-0p-3l",
+  "layout-2p-1l",
+]);
 
 type FractionSpec = { uniform: PageFraction } | { byCellIndex: PageFraction[] };
 
@@ -84,6 +95,10 @@ export function photoPageFraction(
   return (
     spec.byCellIndex[cellIndex] ?? spec.byCellIndex[spec.byCellIndex.length - 1]
   );
+}
+
+export function photoPageFit(layoutClass: string): PhotoFit {
+  return CONTAIN_LAYOUTS.has(layoutClass) ? "contain" : "cover";
 }
 
 /**

--- a/frontend/src/utils/photoQuality.ts
+++ b/frontend/src/utils/photoQuality.ts
@@ -9,8 +9,10 @@ import {
 import {
   FULL_PAGE_FRACTION,
   enforceOrientationOrder,
+  photoPageFit,
   photoPageFraction,
   resolveLayoutClass,
+  type PhotoFit,
 } from "@/utils/photoLayout";
 import { isPortraitByName } from "@/utils/media";
 
@@ -55,10 +57,15 @@ export function computeDpi(
   widthPx: number,
   heightPx: number,
   cell: PageFraction,
+  fit: PhotoFit,
 ): number {
   const cellWidthInches = (cell.widthFrac * PAGE_WIDTH_MM) / MM_PER_INCH;
   const cellHeightInches = (cell.heightFrac * PAGE_HEIGHT_MM) / MM_PER_INCH;
-  return Math.min(widthPx / cellWidthInches, heightPx / cellHeightInches);
+  const widthDpi = widthPx / cellWidthInches;
+  const heightDpi = heightPx / cellHeightInches;
+  return fit === "contain"
+    ? Math.max(widthDpi, heightDpi)
+    : Math.min(widthDpi, heightDpi);
 }
 
 export function dpiTier(
@@ -74,12 +81,13 @@ export function dpiTier(
 export function mediaQuality(
   name: string,
   cell: PageFraction,
+  fit: PhotoFit,
   mediaByName: ReadonlyMap<string, MediaDimensions>,
   preset: MediaResolutionWarningPreset = DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET,
 ): PhotoQuality | null {
   const m = mediaByName.get(name);
   if (!m) return null;
-  const dpi = computeDpi(m.width, m.height, cell);
+  const dpi = computeDpi(m.width, m.height, cell, fit);
   return { tier: dpiTier(dpi, preset), dpi: Math.round(dpi) };
 }
 
@@ -100,13 +108,13 @@ export function summarizeQuality(
   // Cover photos
   if (frontCover)
     count(
-      mediaQuality(frontCover, COVER_FRACTION, mediaByName, preset)?.tier ??
-        "ok",
+      mediaQuality(frontCover, COVER_FRACTION, "cover", mediaByName, preset)
+        ?.tier ?? "ok",
     );
   if (backCover)
     count(
-      mediaQuality(backCover, COVER_FRACTION, mediaByName, preset)?.tier ??
-        "ok",
+      mediaQuality(backCover, COVER_FRACTION, "cover", mediaByName, preset)
+        ?.tier ?? "ok",
     );
 
   const isP = (name: string) => isPortraitByName(name, mediaByName);
@@ -115,8 +123,13 @@ export function summarizeQuality(
     // Step cover (right panel of StepMainPage)
     if (step.cover)
       count(
-        mediaQuality(step.cover, PHOTO_PANEL_FRACTION, mediaByName, preset)
-          ?.tier ?? "ok",
+        mediaQuality(
+          step.cover,
+          PHOTO_PANEL_FRACTION,
+          "cover",
+          mediaByName,
+          preset,
+        )?.tier ?? "ok",
       );
 
     // Photo pages
@@ -127,10 +140,12 @@ export function summarizeQuality(
 
       const ordered = enforceOrientationOrder(filtered, isP);
       const layoutClass = resolveLayoutClass(ordered, isP);
+      const fit = photoPageFit(layoutClass);
       for (let i = 0; i < ordered.length; i++) {
         const cell = photoPageFraction(layoutClass, i);
         count(
-          mediaQuality(ordered[i], cell, mediaByName, preset)?.tier ?? "ok",
+          mediaQuality(ordered[i], cell, fit, mediaByName, preset)?.tier ??
+            "ok",
         );
       }
     }

--- a/frontend/src/utils/photoQuality.ts
+++ b/frontend/src/utils/photoQuality.ts
@@ -33,7 +33,7 @@ type MediaDimensions = { width: number; height: number };
 
 const DPI_CAUTION_DEFAULT = 100;
 const DPI_WARNING_DEFAULT = 75;
-const DPI_CAUTION_PRINT = 300;
+const DPI_CAUTION_PRINT = 250;
 const DPI_WARNING_PRINT = 150;
 
 export const DEFAULT_MEDIA_RESOLUTION_WARNING_PRESET: MediaResolutionWarningPreset =

--- a/frontend/tests/utils/photoQuality.test.ts
+++ b/frontend/tests/utils/photoQuality.test.ts
@@ -16,14 +16,28 @@ type DpiTier = ReturnType<typeof dpiTier>;
 
 describe("computeDpi", () => {
   it("computes DPI for a full-page photo", () => {
-    const dpi = computeDpi(4000, 3000, { widthFrac: 1, heightFrac: 1 });
+    const dpi = computeDpi(4000, 3000, { widthFrac: 1, heightFrac: 1 }, "cover");
     expect(dpi).toBeCloseTo(4000 / (PAGE_WIDTH_MM / MM_PER_INCH), 0);
   });
 
   it("returns the minimum of width and height DPI", () => {
-    const dpi = computeDpi(4000, 1000, { widthFrac: 0.5, heightFrac: 1 });
+    const dpi = computeDpi(
+      4000,
+      1000,
+      { widthFrac: 0.5, heightFrac: 1 },
+      "cover",
+    );
     const heightDpi = 1000 / (PAGE_HEIGHT_MM / MM_PER_INCH);
     expect(dpi).toBeCloseTo(heightDpi, 1);
+  });
+
+  it("uses the rendered image size for contained portraits", () => {
+    const cell = { widthFrac: 1, heightFrac: 1 };
+    const coverDpi = computeDpi(1688, 3000, cell, "cover");
+    const containDpi = computeDpi(1688, 3000, cell, "contain");
+
+    expect(coverDpi).toBeCloseTo(1688 / (PAGE_WIDTH_MM / MM_PER_INCH), 1);
+    expect(containDpi).toBeCloseTo(3000 / (PAGE_HEIGHT_MM / MM_PER_INCH), 1);
   });
 });
 
@@ -134,6 +148,35 @@ describe("summarizeQuality", () => {
       "print",
     );
     expect(result).toEqual({ caution: 1, warning: 0 });
+  });
+
+  it("does not warn for a contained full-page portrait with print thresholds", () => {
+    const portrait = media("portrait.jpg", 1688, 3000);
+    const steps = [makeStep({ id: 1, pages: [[portrait.name]] })];
+
+    const result = summarizeQuality(
+      steps,
+      undefined,
+      undefined,
+      mediaMap(portrait),
+      "print",
+    );
+
+    expect(result).toEqual({ caution: 0, warning: 0 });
+  });
+
+  it("still warns when the same portrait is used as a full-bleed cover", () => {
+    const portrait = media("portrait.jpg", 1688, 3000);
+
+    const result = summarizeQuality(
+      [],
+      portrait.name,
+      undefined,
+      mediaMap(portrait),
+      "print",
+    );
+
+    expect(result).toEqual({ caution: 0, warning: 1 });
   });
 
   it("handles cover photo appearing in both cover and step.cover", () => {


### PR DESCRIPTION
- calculate effective PPI from the rendered image size for both `contain` and `cover` layouts
- use one photo-page fit helper for rendering and quality warnings
- preserve full-bleed cover warnings while removing false portrait warnings
- lower the Print-mode yellow caution boundary from 300 PPI to 250 PPI while keeping red at 150 PPI