### PR TITLE
feat: add self-hosted Helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       docker: ${{ steps.filter.outputs.docker }}
+      helm: ${{ steps.filter.outputs.helm }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v7
@@ -61,6 +62,12 @@ jobs:
               - 'scripts/run_direct_upload_integration.sh'
               - 'PRIVACY.md'
               - 'TERMS.md'
+            helm:
+              - 'charts/wanderbound/**'
+              - 'scripts/check_helm_chart.py'
+              - 'mise.toml'
+              - 'mise.lock'
+              - '.github/workflows/**'
             ci:
               - '.github/workflows/**'
               - '.pre-commit-config.yaml'
@@ -78,6 +85,18 @@ jobs:
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar xz
           sudo mv gitleaks /usr/local/bin/
       - run: gitleaks git --no-banner --redact --verbose
+
+  helm:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.ci == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          version: 2026.7.11
+          install_args: python uv helm
+      - run: mise run test:helm
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,31 @@ jobs:
       - name: Push exact release tag
         run: docker push "$APP_IMAGE:${{ steps.version.outputs.value }}"
 
+      - uses: jdx/mise-action@v4
+        with:
+          version: 2026.7.11
+          install_args: helm
+
+      - name: Log Helm in to GHCR
+        run: >-
+          echo "${{ secrets.GITHUB_TOKEN }}" |
+          helm registry login ghcr.io
+          --username "${{ github.actor }}"
+          --password-stdin
+
+      - name: Package exact chart version
+        run: >-
+          helm package charts/wanderbound
+          --destination /tmp
+          --version "${{ steps.version.outputs.value }}"
+          --app-version "${{ steps.version.outputs.value }}"
+
+      - name: Push exact chart version
+        run: >-
+          helm push
+          "/tmp/wanderbound-${{ steps.version.outputs.value }}.tgz"
+          oci://ghcr.io/itay-raveh/charts
+
       - uses: taiki-e/install-action@v2
         if: steps.version.outputs.patch == '0'
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     hooks:
       - id: yamllint
         args: [-c, .yamllint]
+        exclude: ^charts/[^/]+/templates/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -18,6 +19,7 @@ repos:
       - id: check-toml
       - id: check-yaml
         args: [--unsafe]
+        exclude: ^charts/[^/]+/templates/
       - id: end-of-file-fixer
         exclude: ^frontend/src/client/
       - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ maps, photo pages - that you can edit in the browser and export to PDF.
 | **Object storage** | S3-compatible storage, Garage for Compose                           |
 | **External APIs**  | Open-Meteo (elevations + weather), Mapbox (tiles + routing), Google Photos Picker (photo upgrade), OpenStreetMap Overpass (named peaks) |
 
-## Self-Hosting
+## Self-Hosting with Compose
 
 Requires [Docker](https://docs.docker.com/get-docker/) with Compose.
 
@@ -71,6 +71,25 @@ Configure database and app data backups in your deployment infrastructure.
 The backend stores upload and processing progress in shared storage and Postgres,
 so multiple backend workers can serve the same user flow. All backend workers
 must use the same `DATA_FOLDER` volume and database.
+
+## Self-Hosting on Kubernetes
+
+The [Helm chart](charts/wanderbound/README.md) runs the Wanderbound application
+with a Service and persistent data volume. You supply the database, Secrets, and
+any ingress or storage infrastructure you want to use.
+
+```bash
+WANDERBOUND_VERSION='<MAJOR.MINOR.PATCH>'
+helm install wanderbound \
+  oci://ghcr.io/itay-raveh/charts/wanderbound \
+  --namespace wanderbound \
+  --version "$WANDERBOUND_VERSION" \
+  --values values.yaml
+```
+
+The chart keeps its values surface small and passes application configuration
+through without maintaining a second setting inventory. See the chart README
+for prerequisites and a complete first-install example.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ maps, photo pages - that you can edit in the browser and export to PDF.
 | **Object storage** | S3-compatible storage, Garage for Compose                           |
 | **External APIs**  | Open-Meteo (elevations + weather), Mapbox (tiles + routing), Google Photos Picker (photo upgrade), OpenStreetMap Overpass (named peaks) |
 
-## Self-Hosting with Compose
+## Self-Hosting
+
+### Docker Compose
 
 Requires [Docker](https://docs.docker.com/get-docker/) with Compose.
 
@@ -72,24 +74,9 @@ The backend stores upload and processing progress in shared storage and Postgres
 so multiple backend workers can serve the same user flow. All backend workers
 must use the same `DATA_FOLDER` volume and database.
 
-## Self-Hosting on Kubernetes
+### Kubernetes
 
-The [Helm chart](charts/wanderbound/README.md) runs the Wanderbound application
-with a Service and persistent data volume. You supply the database, Secrets, and
-any ingress or storage infrastructure you want to use.
-
-```bash
-WANDERBOUND_VERSION='<MAJOR.MINOR.PATCH>'
-helm install wanderbound \
-  oci://ghcr.io/itay-raveh/charts/wanderbound \
-  --namespace wanderbound \
-  --version "$WANDERBOUND_VERSION" \
-  --values values.yaml
-```
-
-The chart keeps its values surface small and passes application configuration
-through without maintaining a second setting inventory. See the chart README
-for prerequisites and a complete first-install example.
+See the [Helm chart installation guide](charts/wanderbound/README.md).
 
 ## Development
 

--- a/charts/wanderbound/Chart.yaml
+++ b/charts/wanderbound/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: wanderbound
+description: Turn a Polarsteps export into a print-ready photo album
+type: application
+version: 1.9.0
+appVersion: 1.9.0
+home: https://github.com/itay-raveh/wanderbound
+sources:
+  - https://github.com/itay-raveh/wanderbound

--- a/charts/wanderbound/README.md
+++ b/charts/wanderbound/README.md
@@ -1,0 +1,113 @@
+# Wanderbound Helm chart
+
+This chart runs one Wanderbound application pod with a Service and persistent
+application-data volume. It is intended as a short path to a homelab install and
+as a reusable application building block for operators who manage the rest of
+their stack themselves.
+
+## Prerequisites
+
+- Kubernetes
+- Helm 3.8 or newer
+- A PostgreSQL database
+- Any external services required by the settings you enable
+
+The chart does not create a namespace. It also does not install a database,
+object storage, backup tooling, an ingress controller, certificates, or
+cluster policy.
+
+## Install
+
+Create the namespace and a Secret containing the required private application
+settings. Replace every placeholder before running these commands.
+
+```bash
+kubectl create namespace wanderbound
+kubectl --namespace wanderbound create secret generic wanderbound-secrets \
+  --from-literal=SECRET_KEY='<YOUR_SECRET_KEY>' \
+  --from-literal=SQLALCHEMY_DATABASE_URI='<YOUR_POSTGRESQL_URI>'
+```
+
+Create `values.yaml`:
+
+```yaml
+config:
+  ENVIRONMENT: production
+  PUBLIC_URL: https://wanderbound.example.com
+
+existingSecrets:
+  - wanderbound-secrets
+
+persistence:
+  size: 20Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  host: wanderbound.example.com
+  tls:
+    - secretName: wanderbound-tls
+      hosts:
+        - wanderbound.example.com
+```
+
+Install an exact release:
+
+```bash
+WANDERBOUND_VERSION='<MAJOR.MINOR.PATCH>'
+helm install wanderbound \
+  oci://ghcr.io/itay-raveh/charts/wanderbound \
+  --namespace wanderbound \
+  --version "$WANDERBOUND_VERSION" \
+  --values values.yaml
+```
+
+If Ingress is disabled, access the service locally with:
+
+```bash
+kubectl --namespace wanderbound port-forward service/wanderbound 8000:8000
+```
+
+## Values
+
+The values surface is intentionally small.
+
+| Value | Purpose | Default |
+| --- | --- | --- |
+| `image.repository` | Wanderbound image repository | `ghcr.io/itay-raveh/wanderbound` |
+| `image.tag` | Exact image tag, or chart `appVersion` when empty | `""` |
+| `image.pullPolicy` | Kubernetes image pull policy | `IfNotPresent` |
+| `config` | Non-secret Wanderbound environment settings | `{}` |
+| `existingSecrets` | Secrets imported with `envFrom` | `[]` |
+| `secretEnv` | Individual environment variables sourced from Secret keys | `{}` |
+| `resources` | Application container requests and limits | `{}` |
+| `persistence.existingClaim` | Existing PVC to mount instead of creating one | `""` |
+| `persistence.size` | Size of the managed PVC | `10Gi` |
+| `persistence.storageClass` | Storage class, or the cluster default when empty | `""` |
+| `persistence.accessModes` | Managed PVC access modes | `[ReadWriteOnce]` |
+| `persistence.retain` | Keep the managed PVC when Helm removes the release | `true` |
+| `ingress` | Optional standard Kubernetes Ingress | disabled |
+| `sourceMaps` | Optional source-map upload init container using an existing Secret | disabled |
+
+`DATA_FOLDER` is fixed to `/data` and cannot be set through `config`. For the
+available application settings, required values, and examples, use the
+repository's [`.env.example`](../../.env.example) as the canonical reference.
+
+Use `secretEnv` when an operator-created Secret has a key name that differs from
+the environment variable Wanderbound expects:
+
+```yaml
+secretEnv:
+  SQLALCHEMY_DATABASE_URI:
+    secretName: application-database
+    key: uri
+```
+
+Set `sourceMaps.enabled: true` only when the application image contains the
+source-map uploader and `sourceMaps.existingSecret` names a Secret with its
+credentials. A failed upload blocks application startup so a broken release is
+visible immediately.
+
+The chart deliberately omits generic resource injection, scheduling knobs, and
+provider-specific resources. Operators can manage or patch the rendered
+resources with their normal deployment tooling.

--- a/charts/wanderbound/README.md
+++ b/charts/wanderbound/README.md
@@ -1,25 +1,17 @@
 # Wanderbound Helm chart
 
-This chart runs one Wanderbound application pod with a Service and persistent
-application-data volume. It is intended as a short path to a homelab install and
-as a reusable application building block for operators who manage the rest of
-their stack themselves.
+The chart installs one Wanderbound pod, a ClusterIP Service, and a persistent
+volume. You provide PostgreSQL, object storage, ingress, TLS, and backups.
 
 ## Prerequisites
 
-- Kubernetes
 - Helm 3.8 or newer
 - A PostgreSQL database
-- Any external services required by the settings you enable
-
-The chart does not create a namespace. It also does not install a database,
-object storage, backup tooling, an ingress controller, certificates, or
-cluster policy.
+- A Kubernetes namespace and Secret for Wanderbound
 
 ## Install
 
-Create the namespace and a Secret containing the required private application
-settings. Replace every placeholder before running these commands.
+Create the namespace and Secret:
 
 ```bash
 kubectl create namespace wanderbound
@@ -37,18 +29,6 @@ config:
 
 existingSecrets:
   - wanderbound-secrets
-
-persistence:
-  size: 20Gi
-
-ingress:
-  enabled: true
-  className: nginx
-  host: wanderbound.example.com
-  tls:
-    - secretName: wanderbound-tls
-      hosts:
-        - wanderbound.example.com
 ```
 
 Install an exact release:
@@ -62,39 +42,19 @@ helm install wanderbound \
   --values values.yaml
 ```
 
-If Ingress is disabled, access the service locally with:
+Access the service without Ingress:
 
 ```bash
 kubectl --namespace wanderbound port-forward service/wanderbound 8000:8000
 ```
 
-## Values
+## Configuration
 
-The values surface is intentionally small.
+`DATA_FOLDER` is fixed to `/data` and cannot be set through `config`. Use
+[`.env.example`](../../.env.example) as the application setting reference.
 
-| Value | Purpose | Default |
-| --- | --- | --- |
-| `image.repository` | Wanderbound image repository | `ghcr.io/itay-raveh/wanderbound` |
-| `image.tag` | Exact image tag, or chart `appVersion` when empty | `""` |
-| `image.pullPolicy` | Kubernetes image pull policy | `IfNotPresent` |
-| `config` | Non-secret Wanderbound environment settings | `{}` |
-| `existingSecrets` | Secrets imported with `envFrom` | `[]` |
-| `secretEnv` | Individual environment variables sourced from Secret keys | `{}` |
-| `resources` | Application container requests and limits | `{}` |
-| `persistence.existingClaim` | Existing PVC to mount instead of creating one | `""` |
-| `persistence.size` | Size of the managed PVC | `10Gi` |
-| `persistence.storageClass` | Storage class, or the cluster default when empty | `""` |
-| `persistence.accessModes` | Managed PVC access modes | `[ReadWriteOnce]` |
-| `persistence.retain` | Keep the managed PVC when Helm removes the release | `true` |
-| `ingress` | Optional standard Kubernetes Ingress | disabled |
-| `sourceMaps` | Optional source-map upload init container using an existing Secret | disabled |
-
-`DATA_FOLDER` is fixed to `/data` and cannot be set through `config`. For the
-available application settings, required values, and examples, use the
-repository's [`.env.example`](../../.env.example) as the canonical reference.
-
-Use `secretEnv` when an operator-created Secret has a key name that differs from
-the environment variable Wanderbound expects:
+`existingSecrets` imports complete Secrets with `envFrom`. Use `secretEnv` to
+map one environment variable to a Secret key:
 
 ```yaml
 secretEnv:
@@ -103,11 +63,8 @@ secretEnv:
     key: uri
 ```
 
-Set `sourceMaps.enabled: true` only when the application image contains the
-source-map uploader and `sourceMaps.existingSecret` names a Secret with its
-credentials. A failed upload blocks application startup so a broken release is
-visible immediately.
+The managed PVC defaults to `10Gi`, `ReadWriteOnce`, and the cluster's default
+storage class. Set `persistence.existingClaim` to use an existing PVC.
 
-The chart deliberately omits generic resource injection, scheduling knobs, and
-provider-specific resources. Operators can manage or patch the rendered
-resources with their normal deployment tooling.
+See [`values.yaml`](values.yaml) for all values and
+[`values.schema.json`](values.schema.json) for validation rules.

--- a/charts/wanderbound/templates/NOTES.txt
+++ b/charts/wanderbound/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{- if .Values.ingress.enabled }}
+Wanderbound Ingress host: {{ .Values.ingress.host }}
+{{- else }}
+Forward the service locally:
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "wanderbound.fullname" . }} 8000:8000
+{{- end }}

--- a/charts/wanderbound/templates/_helpers.tpl
+++ b/charts/wanderbound/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{- define "wanderbound.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "wanderbound.configName" -}}
+{{- printf "%s-config" (include "wanderbound.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "wanderbound.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-app-data" (include "wanderbound.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "wanderbound.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{- define "wanderbound.selectorLabels" -}}
+app: {{ include "wanderbound.fullname" . }}
+{{- end }}
+
+{{- define "wanderbound.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{ include "wanderbound.selectorLabels" . }}
+{{- end }}
+
+{{- define "wanderbound.containerSecurityContext" -}}
+allowPrivilegeEscalation: false
+capabilities:
+  drop:
+    - ALL
+readOnlyRootFilesystem: true
+runAsGroup: 999
+runAsNonRoot: true
+runAsUser: 999
+seccompProfile:
+  type: RuntimeDefault
+{{- end }}

--- a/charts/wanderbound/templates/configmap.yaml
+++ b/charts/wanderbound/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wanderbound.configName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wanderbound.labels" . | nindent 4 }}
+data:
+  DATA_FOLDER: /data
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}

--- a/charts/wanderbound/templates/deployment.yaml
+++ b/charts/wanderbound/templates/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wanderbound.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wanderbound.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "wanderbound.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "wanderbound.labels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 999
+      {{- if .Values.sourceMaps.enabled }}
+      initContainers:
+        - name: sourcemaps
+          image: {{ include "wanderbound.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /usr/local/bin/upload-sourcemaps
+          envFrom:
+            - configMapRef:
+                name: {{ include "wanderbound.configName" . }}
+            - secretRef:
+                name: {{ .Values.sourceMaps.existingSecret }}
+          env:
+            - name: HOME
+              value: /tmp
+            - name: SENTRY_DISABLE_UPDATE_CHECK
+              value: "true"
+          securityContext:
+            {{- include "wanderbound.containerSecurityContext" . | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      {{- end }}
+      containers:
+        - name: wanderbound
+          image: {{ include "wanderbound.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "wanderbound.configName" . }}
+            {{- range .Values.existingSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          {{- with .Values.secretEnv }}
+          env:
+            {{- range $name, $source := . }}
+            - name: {{ $name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $source.secretName }}
+                  key: {{ $source.key }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            periodSeconds: 5
+          securityContext:
+            {{- include "wanderbound.containerSecurityContext" . | nindent 12 }}
+          volumeMounts:
+            - name: app-data
+              mountPath: /data
+            - name: dshm
+              mountPath: /dev/shm
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: app-data
+          persistentVolumeClaim:
+            claimName: {{ include "wanderbound.pvcName" . }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+        - name: tmp
+          emptyDir: {}

--- a/charts/wanderbound/templates/ingress.yaml
+++ b/charts/wanderbound/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "wanderbound.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wanderbound.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress is enabled" .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "wanderbound.fullname" . }}
+                port:
+                  number: 8000
+{{- end }}

--- a/charts/wanderbound/templates/pvc.yaml
+++ b/charts/wanderbound/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if not .Values.persistence.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wanderbound.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wanderbound.labels" . | nindent 4 }}
+  {{- if .Values.persistence.retain }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/wanderbound/templates/service.yaml
+++ b/charts/wanderbound/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wanderbound.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wanderbound.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "wanderbound.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 8000
+      protocol: TCP
+      targetPort: 8000

--- a/charts/wanderbound/values.schema.json
+++ b/charts/wanderbound/values.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "tag", "pullPolicy"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string"},
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "propertyNames": {"not": {"const": "DATA_FOLDER"}},
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      }
+    },
+    "existingSecrets": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "secretEnv": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["secretName", "key"],
+        "properties": {
+          "secretName": {"type": "string", "minLength": 1},
+          "key": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "resources": {"type": "object"},
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["existingClaim", "size", "storageClass", "accessModes", "retain"],
+      "properties": {
+        "existingClaim": {"type": "string"},
+        "size": {"type": "string", "minLength": 1},
+        "storageClass": {"type": "string"},
+        "accessModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "retain": {"type": "boolean"}
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "className", "annotations", "host", "tls"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "className": {"type": "string"},
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "host": {"type": "string"},
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["secretName", "hosts"],
+            "properties": {
+              "secretName": {"type": "string", "minLength": 1},
+              "hosts": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "minLength": 1},
+                "uniqueItems": true
+              }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"enabled": {"const": true}}},
+          "then": {"properties": {"host": {"minLength": 1}}}
+        }
+      ]
+    },
+    "sourceMaps": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "existingSecret"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "existingSecret": {"type": "string"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"enabled": {"const": true}}},
+          "then": {"properties": {"existingSecret": {"minLength": 1}}}
+        }
+      ]
+    }
+  }
+}

--- a/charts/wanderbound/values.yaml
+++ b/charts/wanderbound/values.yaml
@@ -1,0 +1,31 @@
+image:
+  repository: ghcr.io/itay-raveh/wanderbound
+  tag: ""
+  pullPolicy: IfNotPresent
+
+config: {}
+
+existingSecrets: []
+
+secretEnv: {}
+
+resources: {}
+
+persistence:
+  existingClaim: ""
+  size: 10Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  retain: true
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: ""
+  tls: []
+
+sourceMaps:
+  enabled: false
+  existingSecret: ""

--- a/mise.lock
+++ b/mise.lock
@@ -107,6 +107,54 @@ checksum = "sha256:7fd7e0162c19408b25cc47f764ecd94248644e91549a53cf6db0756b25abf
 url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-pc-windows-gnu.zip"
 url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851651"
 
+[[tools.helm]]
+version = "4.2.3"
+backend = "aqua:helm/helm"
+
+[tools.helm."platforms.linux-arm64"]
+checksum = "sha256:21abd9354d39b2cd79a8d76be6912cd137a983cbf997193503fb8a6a6e2f2785"
+url = "https://get.helm.sh/helm-v4.2.3-linux-arm64.tar.gz"
+
+[tools.helm."platforms.linux-arm64-musl"]
+checksum = "sha256:21abd9354d39b2cd79a8d76be6912cd137a983cbf997193503fb8a6a6e2f2785"
+url = "https://get.helm.sh/helm-v4.2.3-linux-arm64.tar.gz"
+
+[tools.helm."platforms.linux-x64"]
+checksum = "sha256:e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c"
+url = "https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz"
+
+[tools.helm."platforms.linux-x64-baseline"]
+checksum = "sha256:e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c"
+url = "https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz"
+
+[tools.helm."platforms.linux-x64-musl"]
+checksum = "sha256:e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c"
+url = "https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz"
+
+[tools.helm."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c"
+url = "https://get.helm.sh/helm-v4.2.3-linux-amd64.tar.gz"
+
+[tools.helm."platforms.macos-arm64"]
+checksum = "sha256:048ecf5ad3160f83d918f9fe945238d2132b079640f7b106175331c25f242c64"
+url = "https://get.helm.sh/helm-v4.2.3-darwin-arm64.tar.gz"
+
+[tools.helm."platforms.macos-x64"]
+checksum = "sha256:ff3ac86755a45f3422473bc1200776aac0fe04c5766abe6ca66699f7b564b23b"
+url = "https://get.helm.sh/helm-v4.2.3-darwin-amd64.tar.gz"
+
+[tools.helm."platforms.macos-x64-baseline"]
+checksum = "sha256:ff3ac86755a45f3422473bc1200776aac0fe04c5766abe6ca66699f7b564b23b"
+url = "https://get.helm.sh/helm-v4.2.3-darwin-amd64.tar.gz"
+
+[tools.helm."platforms.windows-x64"]
+checksum = "sha256:02c6137bb5f050479193afad5a28804e9edc3beeab7e7b53a6e1499c9ba387ef"
+url = "https://get.helm.sh/helm-v4.2.3-windows-amd64.tar.gz"
+
+[tools.helm."platforms.windows-x64-baseline"]
+checksum = "sha256:02c6137bb5f050479193afad5a28804e9edc3beeab7e7b53a6e1499c9ba387ef"
+url = "https://get.helm.sh/helm-v4.2.3-windows-amd64.tar.gz"
+
 [[tools.prek]]
 version = "0.4.8"
 backend = "aqua:j178/prek"

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ task.source_freshness_hash_contents = true
 python = "3.14.6"
 bun = "1.3.14"
 uv = "0.11.26"
+helm = "4.2.3"
 "github:orhun/git-cliff" = "2"
 prek = "0.4.8"
 
@@ -68,7 +69,11 @@ run = "scripts/run_direct_upload_integration.sh"
 
 [tasks.test]
 description = "Run all tests"
-depends = ["test:backend", "test:frontend", "test:e2e"]
+depends = ["test:backend", "test:frontend", "test:e2e", "test:helm"]
+
+[tasks."test:helm"]
+description = "Validate and render the Helm chart contract"
+run = "uv run scripts/check_helm_chart.py"
 
 # -- Linting ------------------------------------------------------
 

--- a/scripts/check_helm_chart.py
+++ b/scripts/check_helm_chart.py
@@ -353,15 +353,13 @@ def assert_metadata() -> None:
 def assert_documentation() -> None:
     chart_readme = (CHART / "README.md").read_text()
     root_readme = (ROOT / "README.md").read_text()
-    for text in (chart_readme, root_readme):
-        assert "oci://ghcr.io/itay-raveh/charts/wanderbound" in text
+    assert "oci://ghcr.io/itay-raveh/charts/wanderbound" in chart_readme
     assert ".env.example" in chart_readme
-    assert "does not install a database" in chart_readme
+    assert "You provide PostgreSQL" in chart_readme
     assert "existingSecrets" in chart_readme
     assert "secretEnv" in chart_readme
     assert "existingClaim" in chart_readme
-    assert "sourceMaps" in chart_readme
-    assert "Self-Hosting on Kubernetes" in root_readme
+    assert "Helm chart installation guide" in root_readme
 
 
 def assert_workflows() -> None:

--- a/scripts/check_helm_chart.py
+++ b/scripts/check_helm_chart.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHART = ROOT / "charts" / "wanderbound"
+RELEASE = "wanderbound"
+NAMESPACE = "wanderbound"
+
+
+def run(*args: str, expect_success: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if expect_success and result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {' '.join(args)}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    if not expect_success and result.returncode == 0:
+        raise AssertionError(f"command unexpectedly passed: {' '.join(args)}")
+    return result
+
+
+def values_file(values: dict[str, Any]) -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", prefix="wanderbound-values-", delete=False
+    )
+    with handle:
+        yaml.safe_dump(values, handle, sort_keys=False)
+    return Path(handle.name)
+
+
+def render(values: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    args = [
+        "helm",
+        "template",
+        RELEASE,
+        str(CHART),
+        "--namespace",
+        NAMESPACE,
+    ]
+    path: Path | None = None
+    if values is not None:
+        path = values_file(values)
+        args.extend(("--values", str(path)))
+    try:
+        result = run(*args)
+    finally:
+        if path is not None:
+            path.unlink()
+    return [document for document in yaml.safe_load_all(result.stdout) if document]
+
+
+def expect_invalid(values: dict[str, Any]) -> None:
+    path = values_file(values)
+    try:
+        run(
+            "helm",
+            "template",
+            RELEASE,
+            str(CHART),
+            "--namespace",
+            NAMESPACE,
+            "--values",
+            str(path),
+            expect_success=False,
+        )
+    finally:
+        path.unlink()
+
+
+def resource(
+    documents: Iterable[dict[str, Any]], kind: str, name: str
+) -> dict[str, Any]:
+    matches = [
+        item
+        for item in documents
+        if item.get("kind") == kind and item.get("metadata", {}).get("name") == name
+    ]
+    assert len(matches) == 1, f"expected one {kind}/{name}, found {len(matches)}"
+    return matches[0]
+
+
+def container(
+    pod_spec: dict[str, Any], name: str, *, init: bool = False
+) -> dict[str, Any]:
+    key = "initContainers" if init else "containers"
+    matches = [item for item in pod_spec.get(key, []) if item.get("name") == name]
+    assert len(matches) == 1, f"expected one {key} entry named {name}"
+    return matches[0]
+
+
+def env_value(container_spec: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [
+        item for item in container_spec.get("env", []) if item.get("name") == name
+    ]
+    assert len(matches) == 1, f"expected one environment entry named {name}"
+    return matches[0]
+
+
+def assert_security_context(context: dict[str, Any]) -> None:
+    assert context == {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "readOnlyRootFilesystem": True,
+        "runAsGroup": 999,
+        "runAsNonRoot": True,
+        "runAsUser": 999,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+
+def assert_default_render() -> None:
+    documents = render()
+    kinds = {item["kind"] for item in documents}
+    assert kinds == {"ConfigMap", "Deployment", "PersistentVolumeClaim", "Service"}
+
+    config = resource(documents, "ConfigMap", "wanderbound-config")
+    assert config["metadata"]["namespace"] == NAMESPACE
+    assert config["data"] == {"DATA_FOLDER": "/data"}
+
+    deployment = resource(documents, "Deployment", "wanderbound")
+    assert deployment["spec"]["replicas"] == 1
+    assert deployment["spec"]["strategy"] == {"type": "Recreate"}
+    assert deployment["spec"]["selector"]["matchLabels"] == {"app": "wanderbound"}
+    template = deployment["spec"]["template"]
+    assert template["metadata"]["labels"]["app"] == "wanderbound"
+    assert template["metadata"]["annotations"]["checksum/config"]
+    pod_spec = template["spec"]
+    assert pod_spec["automountServiceAccountToken"] is False
+    assert pod_spec["securityContext"] == {"fsGroup": 999}
+    assert "initContainers" not in pod_spec
+
+    app = container(pod_spec, "wanderbound")
+    assert app["image"] == "ghcr.io/itay-raveh/wanderbound:1.9.0"
+    assert app["imagePullPolicy"] == "IfNotPresent"
+    assert app["resources"] == {}
+    assert "command" not in app
+    assert "args" not in app
+    assert app["envFrom"] == [{"configMapRef": {"name": "wanderbound-config"}}]
+    assert "env" not in app
+    assert_security_context(app["securityContext"])
+    assert app["startupProbe"] == {
+        "failureThreshold": 30,
+        "httpGet": {"path": "/api/v1/health", "port": 8000},
+        "periodSeconds": 2,
+    }
+    assert app["readinessProbe"]["periodSeconds"] == 5
+    assert app["livenessProbe"]["periodSeconds"] == 15
+    assert {item["mountPath"] for item in app["volumeMounts"]} == {
+        "/data",
+        "/dev/shm",
+        "/tmp",
+    }
+    volumes = {item["name"]: item for item in pod_spec["volumes"]}
+    assert volumes["app-data"]["persistentVolumeClaim"]["claimName"] == (
+        "wanderbound-app-data"
+    )
+    assert volumes["dshm"]["emptyDir"] == {"medium": "Memory", "sizeLimit": "256Mi"}
+    assert volumes["tmp"]["emptyDir"] == {}
+
+    service = resource(documents, "Service", "wanderbound")
+    assert service["spec"]["type"] == "ClusterIP"
+    assert service["spec"]["selector"] == {"app": "wanderbound"}
+    assert service["spec"]["ports"] == [
+        {"name": "http", "port": 8000, "protocol": "TCP", "targetPort": 8000}
+    ]
+
+    pvc = resource(documents, "PersistentVolumeClaim", "wanderbound-app-data")
+    assert pvc["metadata"]["annotations"]["helm.sh/resource-policy"] == "keep"
+    assert pvc["spec"] == {
+        "accessModes": ["ReadWriteOnce"],
+        "resources": {"requests": {"storage": "10Gi"}},
+    }
+
+
+def assert_configured_render() -> None:
+    values = {
+        "image": {
+            "repository": "registry.example/wanderbound",
+            "tag": "2.4.6",
+            "pullPolicy": "Always",
+        },
+        "config": {
+            "PUBLIC_URL": "https://photos.example.test",
+            "ENVIRONMENT": "production",
+            "WORKER_THREADS": 3,
+            "FEATURE_ENABLED": True,
+        },
+        "existingSecrets": ["wanderbound-secrets", "upload-secrets"],
+        "secretEnv": {
+            "SQLALCHEMY_DATABASE_URI": {
+                "secretName": "wanderbound-db-app",
+                "key": "uri",
+            }
+        },
+        "resources": {
+            "requests": {"cpu": "250m", "memory": "512Mi"},
+            "limits": {"cpu": "2", "memory": "2Gi"},
+        },
+        "persistence": {"existingClaim": "photos-data"},
+        "ingress": {
+            "enabled": True,
+            "className": "nginx",
+            "annotations": {"example.test/setting": "enabled"},
+            "host": "photos.example.test",
+            "tls": [
+                {
+                    "secretName": "photos-tls",
+                    "hosts": ["photos.example.test"],
+                }
+            ],
+        },
+        "sourceMaps": {
+            "enabled": True,
+            "existingSecret": "sentry-upload",
+        },
+    }
+    documents = render(values)
+    assert "PersistentVolumeClaim" not in {item["kind"] for item in documents}
+
+    config = resource(documents, "ConfigMap", "wanderbound-config")
+    assert config["data"] == {
+        "DATA_FOLDER": "/data",
+        "ENVIRONMENT": "production",
+        "FEATURE_ENABLED": "true",
+        "PUBLIC_URL": "https://photos.example.test",
+        "WORKER_THREADS": "3",
+    }
+
+    deployment = resource(documents, "Deployment", "wanderbound")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    app = container(pod_spec, "wanderbound")
+    assert app["image"] == "registry.example/wanderbound:2.4.6"
+    assert app["imagePullPolicy"] == "Always"
+    assert app["envFrom"] == [
+        {"configMapRef": {"name": "wanderbound-config"}},
+        {"secretRef": {"name": "wanderbound-secrets"}},
+        {"secretRef": {"name": "upload-secrets"}},
+    ]
+    assert env_value(app, "SQLALCHEMY_DATABASE_URI")["valueFrom"] == {
+        "secretKeyRef": {"key": "uri", "name": "wanderbound-db-app"}
+    }
+    assert app["resources"] == values["resources"]
+    app_data = next(item for item in pod_spec["volumes"] if item["name"] == "app-data")
+    assert app_data["persistentVolumeClaim"]["claimName"] == "photos-data"
+
+    source_maps = container(pod_spec, "sourcemaps", init=True)
+    assert [item["name"] for item in pod_spec["initContainers"]] == ["sourcemaps"]
+    assert source_maps["image"] == "registry.example/wanderbound:2.4.6"
+    assert source_maps["command"] == ["/usr/local/bin/upload-sourcemaps"]
+    assert source_maps["envFrom"] == [
+        {"configMapRef": {"name": "wanderbound-config"}},
+        {"secretRef": {"name": "sentry-upload"}},
+    ]
+    assert env_value(source_maps, "HOME")["value"] == "/tmp"
+    assert env_value(source_maps, "SENTRY_DISABLE_UPDATE_CHECK")["value"] == "true"
+    assert_security_context(source_maps["securityContext"])
+
+    ingress = resource(documents, "Ingress", "wanderbound")
+    assert ingress["apiVersion"] == "networking.k8s.io/v1"
+    assert ingress["metadata"]["annotations"] == {"example.test/setting": "enabled"}
+    assert ingress["spec"]["ingressClassName"] == "nginx"
+    assert ingress["spec"]["rules"][0]["host"] == "photos.example.test"
+    path = ingress["spec"]["rules"][0]["http"]["paths"][0]
+    assert path["path"] == "/"
+    assert path["pathType"] == "Prefix"
+    assert path["backend"]["service"] == {
+        "name": "wanderbound",
+        "port": {"number": 8000},
+    }
+    assert ingress["spec"]["tls"] == values["ingress"]["tls"]
+
+
+def assert_persistence_options() -> None:
+    documents = render(
+        {
+            "persistence": {
+                "size": "50Gi",
+                "storageClass": "fast-storage",
+                "accessModes": ["ReadWriteMany"],
+                "retain": False,
+            }
+        }
+    )
+    pvc = resource(documents, "PersistentVolumeClaim", "wanderbound-app-data")
+    assert "annotations" not in pvc["metadata"]
+    assert pvc["spec"] == {
+        "accessModes": ["ReadWriteMany"],
+        "resources": {"requests": {"storage": "50Gi"}},
+        "storageClassName": "fast-storage",
+    }
+
+
+def assert_invalid_values() -> None:
+    expect_invalid({"config": {"DATA_FOLDER": "/somewhere-else"}})
+    expect_invalid({"existingSecrets": [{"name": "not-a-string"}]})
+    expect_invalid({"secretEnv": {"DATABASE_URL": {"secretName": "db"}}})
+    expect_invalid({"persistence": {"size": ""}})
+    expect_invalid(
+        {
+            "ingress": {
+                "enabled": True,
+                "host": "photos.example.test",
+                "tls": [{"hosts": ["photos.example.test"]}],
+            }
+        }
+    )
+
+
+def assert_installation_neutral() -> None:
+    forbidden = (
+        "raveh.dev",
+        "hcloud",
+        "cloudnative-pg",
+        "cnpg",
+        "traefik",
+        "fluxcd",
+        "your-objectstorage.com",
+    )
+    for path in CHART.rglob("*"):
+        if not path.is_file():
+            continue
+        content = path.read_text().lower()
+        for token in forbidden:
+            assert token not in content, f"{path.relative_to(ROOT)} contains {token!r}"
+
+
+def assert_metadata() -> None:
+    chart = yaml.safe_load((CHART / "Chart.yaml").read_text())
+    assert chart["apiVersion"] == "v2"
+    assert chart["name"] == "wanderbound"
+    assert chart["type"] == "application"
+    assert chart["version"] == "1.9.0"
+    assert str(chart["appVersion"]) == "1.9.0"
+    schema = json.loads((CHART / "values.schema.json").read_text())
+    assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
+
+
+def assert_documentation() -> None:
+    chart_readme = (CHART / "README.md").read_text()
+    root_readme = (ROOT / "README.md").read_text()
+    for text in (chart_readme, root_readme):
+        assert "oci://ghcr.io/itay-raveh/charts/wanderbound" in text
+    assert ".env.example" in chart_readme
+    assert "does not install a database" in chart_readme
+    assert "existingSecrets" in chart_readme
+    assert "secretEnv" in chart_readme
+    assert "existingClaim" in chart_readme
+    assert "sourceMaps" in chart_readme
+    assert "Self-Hosting on Kubernetes" in root_readme
+
+
+def assert_workflows() -> None:
+    ci_path = ROOT / ".github" / "workflows" / "ci.yml"
+    publish_path = ROOT / ".github" / "workflows" / "publish.yml"
+    yaml.safe_load(ci_path.read_text())
+    yaml.safe_load(publish_path.read_text())
+
+    ci = ci_path.read_text()
+    assert "charts/wanderbound/**" in ci
+    assert "mise run test:helm" in ci
+    assert "install_args: python uv helm" in ci
+
+    publish = publish_path.read_text()
+    image_push = publish.index(
+        'docker push "$APP_IMAGE:${{ steps.version.outputs.value }}"'
+    )
+    chart_package = publish.index("helm package charts/wanderbound")
+    chart_push = publish.index("helm push")
+    assert image_push < chart_package < chart_push
+    assert '--version "${{ steps.version.outputs.value }}"' in publish
+    assert '--app-version "${{ steps.version.outputs.value }}"' in publish
+    assert "oci://ghcr.io/itay-raveh/charts" in publish
+
+
+def main() -> None:
+    assert CHART.is_dir(), f"chart directory does not exist: {CHART}"
+    run("helm", "lint", str(CHART), "--strict")
+    assert_metadata()
+    assert_default_render()
+    assert_configured_render()
+    assert_persistence_options()
+    assert_invalid_values()
+    assert_installation_neutral()
+    assert_documentation()
+    assert_workflows()
+    print("Helm chart contract passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- add a thin, application-only Helm chart for self-hosted Wanderbound
- expose generic configuration, existing Secret references, persistence, and optional standard Ingress without provider-specific infrastructure
- validate rendered resources and negative cases through a mise task and CI
- publish the chart to GHCR with the exact stable application version after the matching image is pushed
- document first-time Kubernetes installation and chart boundaries