### PR TITLE
feat: edit chapter front cover darkness

### DIFF
--- a/backend/app/models/album.py
+++ b/backend/app/models/album.py
@@ -31,6 +31,7 @@ class AlbumChapter(SQLModel):
     step_ids: list[int] = Field(default_factory=list)
     front_cover_photo: str = Field(max_length=255)
     back_cover_photo: str = Field(max_length=255)
+    front_cover_darkness: float = Field(default=0.45, ge=0.0, le=1.0)
 
 
 class AlbumBase(SQLModel):

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2594,6 +2594,13 @@
             "type": "string",
             "maxLength": 255,
             "title": "Back Cover Photo"
+          },
+          "front_cover_darkness": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Front Cover Darkness",
+            "default": 0.45
           }
         },
         "type": "object",

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -288,6 +288,61 @@ class TestUpdateAlbum:
         )
         assert data["chapters"][0]["front_cover_photo"] == "new_front.jpg"
         assert data["chapters"][0]["back_cover_photo"] == "new_back.jpg"
+        assert data["chapters"][0]["front_cover_darkness"] == 0.45
+
+    async def test_update_front_cover_darkness_persists(
+        self,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
+    ) -> None:
+        await insert_step(session, signed_album.uid, step_id=1)
+        await session.commit()
+
+        data = await album_routes.update_album_ok(
+            chapters=[
+                {
+                    "id": "chapter-1",
+                    "title": "Test Album",
+                    "subtitle": "A subtitle",
+                    "step_ids": [1],
+                    "front_cover_photo": "front.jpg",
+                    "back_cover_photo": "back.jpg",
+                    "front_cover_darkness": 0.2,
+                }
+            ],
+        )
+        assert data["chapters"][0]["front_cover_darkness"] == 0.2
+
+        response = await album_routes.get_album()
+        assert response.status_code == 200
+        assert response.json()["chapters"][0]["front_cover_darkness"] == 0.2
+
+    @pytest.mark.parametrize("darkness", [-0.01, 1.01])
+    async def test_update_chapters_rejects_invalid_front_cover_darkness(
+        self,
+        darkness: float,
+        session: AsyncSession,
+        signed_album: AlbumScenario,
+        album_routes: AlbumRoutes,
+    ) -> None:
+        await insert_step(session, signed_album.uid, step_id=1)
+        await session.commit()
+
+        response = await album_routes.update_album(
+            chapters=[
+                {
+                    "id": "chapter-1",
+                    "title": "Test Album",
+                    "subtitle": "A subtitle",
+                    "step_ids": [1],
+                    "front_cover_photo": "front.jpg",
+                    "back_cover_photo": "back.jpg",
+                    "front_cover_darkness": darkness,
+                }
+            ],
+        )
+        assert response.status_code == 422
 
     async def test_partial_update_preserves_other_fields(
         self,
@@ -345,6 +400,7 @@ class TestUpdateAlbum:
                 "step_ids": [1, 2],
                 "front_cover_photo": "front.jpg",
                 "back_cover_photo": "back.jpg",
+                "front_cover_darkness": 0.45,
             }
         ]
 

--- a/frontend/src/components/album/CoverPage.vue
+++ b/frontend/src/components/album/CoverPage.vue
@@ -69,6 +69,11 @@ function saveText(field: "title" | "subtitle", value: string) {
       fit-cover
       :quality="coverQuality"
       :class="['fit', { 'cover-dimmed': !isBack }]"
+      :style="
+        !isBack
+          ? { '--cover-darkness': chapter.front_cover_darkness ?? 0.45 }
+          : undefined
+      "
     />
 
     <!-- ═══ FRONT COVER ═══ -->
@@ -107,7 +112,8 @@ function saveText(field: "title" | "subtitle", value: string) {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: black;
+  opacity: var(--cover-darkness);
   pointer-events: none;
 }
 

--- a/frontend/src/components/editor/InspectorDrawer.vue
+++ b/frontend/src/components/editor/InspectorDrawer.vue
@@ -19,7 +19,7 @@ import {
 import { parseChapterHeaderSectionKey } from "../album/albumSections";
 import { useUserQuery } from "@/queries/useUserQuery";
 import { useI18n } from "vue-i18n";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 const { t } = useI18n();
 
@@ -69,19 +69,33 @@ const context = computed<Context>(() => {
 
 // ── Cover photo selection ──────────────────────────────────────────────
 const albumMutation = useAlbumMutation(() => props.album.id);
-const coverContext = computed(() => parseChapterHeaderSectionKey(props.sectionKey));
+const coverContext = computed(() =>
+  parseChapterHeaderSectionKey(props.sectionKey),
+);
 const activeChapter = computed(() =>
   (props.album.chapters ?? []).find(
     (chapter) => chapter.id === coverContext.value?.chapterId,
   ),
 );
-const isCoverBack = computed(() => coverContext.value?.headerKey === "cover-back");
+const isCoverBack = computed(
+  () => coverContext.value?.headerKey === "cover-back",
+);
 const coverField = computed(() =>
   isCoverBack.value
     ? ("back_cover_photo" as const)
     : ("front_cover_photo" as const),
 );
-const activeCoverPhoto = computed(() => activeChapter.value?.[coverField.value] ?? "");
+const activeCoverPhoto = computed(
+  () => activeChapter.value?.[coverField.value] ?? "",
+);
+const coverDarknessPercent = ref(45);
+watch(
+  () => activeChapter.value?.front_cover_darkness,
+  (darkness) => {
+    coverDarknessPercent.value = Math.round((darkness ?? 0.45) * 100);
+  },
+  { immediate: true },
+);
 
 const landscapeMedia = computed(() =>
   props.media.filter((m) => !isPortrait(m) && !isVideo(m.name)),
@@ -106,9 +120,27 @@ function selectCoverPhoto(name: string) {
   if (!chapterId) return;
   albumMutation.mutate({
     chapters: (props.album.chapters ?? []).map((chapter) =>
-      chapter.id === chapterId ? { ...chapter, [coverField.value]: name } : chapter,
+      chapter.id === chapterId
+        ? { ...chapter, [coverField.value]: name }
+        : chapter,
     ),
   });
+}
+
+function updateCoverDarkness(value: number | null) {
+  const chapterId = activeChapter.value?.id;
+  if (!chapterId || value === null) return;
+  albumMutation.mutate({
+    chapters: (props.album.chapters ?? []).map((chapter) =>
+      chapter.id === chapterId
+        ? { ...chapter, front_cover_darkness: value / 100 }
+        : chapter,
+    ),
+  });
+}
+
+function previewCoverDarkness(value: number | null) {
+  if (value !== null) coverDarknessPercent.value = value;
 }
 
 function coverPhotoIndex(
@@ -200,6 +232,27 @@ const importTargetLabel = computed<string | null>(() => {
           <span>{{ panelLabel }}</span>
           <span class="text-faint">{{ landscapeMedia.length }}</span>
         </div>
+        <div v-if="!isCoverBack" class="cover-darkness-control">
+          <div class="cover-darkness-header">
+            <span>{{ t("album.coverDarkness") }}</span>
+            <span class="cover-darkness-value"
+              >{{ coverDarknessPercent }}%</span
+            >
+          </div>
+          <q-slider
+            class="cover-darkness-slider"
+            :model-value="coverDarknessPercent"
+            :min="0"
+            :max="100"
+            :step="1"
+            :label-value="`${coverDarknessPercent}%`"
+            :aria-label="t('album.coverDarkness')"
+            color="primary"
+            label
+            @update:model-value="previewCoverDarkness"
+            @change="updateCoverDarkness"
+          />
+        </div>
         <q-virtual-scroll
           v-if="landscapeMedia.length"
           class="cover-grid"
@@ -284,6 +337,29 @@ const importTargetLabel = computed<string | null>(() => {
   min-height: 2rem;
   padding-block-end: var(--gap-sm);
   letter-spacing: var(--tracking-wide);
+}
+
+.cover-darkness-control {
+  padding: var(--gap-sm) var(--gap-xs) var(--gap-md);
+}
+
+.cover-darkness-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-md);
+  font-size: var(--type-xs);
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.cover-darkness-value {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.cover-darkness-slider {
+  padding-inline: var(--gap-xs);
 }
 
 .panel-hint {

--- a/frontend/src/components/editor/nav/chapterEditing.ts
+++ b/frontend/src/components/editor/nav/chapterEditing.ts
@@ -59,6 +59,7 @@ export function splitChapter(
     step_ids: nextStepIds,
     front_cover_photo: cover,
     back_cover_photo: cover,
+    front_cover_darkness: source.front_cover_darkness ?? 0.45,
   };
 
   const result = cloneChapters(chapters);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -156,6 +156,7 @@
     "dropPhotoToAdd": "Drop a photo to add a page",
     "frontCover": "Front Cover",
     "backCover": "Back Cover",
+    "coverDarkness": "Cover darkness",
     "noLandscapePhotos": "No landscape photos available",
     "unused": "Unused",
     "unusedHint": "Photos from this step - drag to a page to place",

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -156,6 +156,7 @@
     "dropPhotoToAdd": "גררו תמונה להוספת עמוד",
     "frontCover": "שער קדמי",
     "backCover": "שער אחורי",
+    "coverDarkness": "כהות השער",
     "noLandscapePhotos": "אין תמונות מתאימות",
     "unused": "לא בשימוש",
     "unusedHint": "תמונות מהצעד הזה. גררו לעמוד כדי להוסיף",

--- a/frontend/tests/components/AlbumNav.test.ts
+++ b/frontend/tests/components/AlbumNav.test.ts
@@ -256,6 +256,7 @@ describe("AlbumNav", () => {
           step_ids: [3],
           front_cover_photo: "three.jpg",
           back_cover_photo: "three.jpg",
+          front_cover_darkness: 0.45,
         },
       ],
     });

--- a/frontend/tests/components/CoverPage.test.ts
+++ b/frontend/tests/components/CoverPage.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/queries/useUserQuery", () => ({
   }),
 }));
 
-function mountCoverPage() {
+function mountCoverPage(isBack = false) {
   const chapter = {
     id: "chapter-2",
     title: "",
@@ -23,6 +23,7 @@ function mountCoverPage() {
     step_ids: [1],
     front_cover_photo: "cover.jpg",
     back_cover_photo: "cover.jpg",
+    front_cover_darkness: 0.2,
   };
   const album = { ...mockAlbum, chapters: [mockAlbum.chapters[0], chapter] };
   const Wrapper = defineComponent({
@@ -35,6 +36,7 @@ function mountCoverPage() {
           album,
           chapter,
           steps: [makeStep({ id: 1, datetime: "2024-01-01T00:00:00Z" })],
+          isBack,
         });
     },
   });
@@ -69,5 +71,17 @@ describe("CoverPage", () => {
     expect(wrapper.get(".front-subtitle").attributes("data-placeholder")).toBe(
       "Chapter subtitle",
     );
+  });
+
+  test("dims only the front cover with the chapter darkness", () => {
+    const front = mountCoverPage();
+    const frontMedia = front.get(".media-item-stub");
+
+    expect(frontMedia.classes()).toContain("cover-dimmed");
+    expect(frontMedia.attributes("style")).toContain("--cover-darkness: 0.2");
+
+    const backMedia = mountCoverPage(true).get(".media-item-stub");
+    expect(backMedia.classes()).not.toContain("cover-dimmed");
+    expect(backMedia.attributes("style")).toBeUndefined();
   });
 });

--- a/frontend/tests/components/InspectorDrawer.test.ts
+++ b/frontend/tests/components/InspectorDrawer.test.ts
@@ -4,6 +4,12 @@ import { makeAlbumMedia, mountWithPlugins } from "../helpers";
 import InspectorDrawer from "@/components/editor/InspectorDrawer.vue";
 import { defaultAlbum, defaultSteps } from "../mocks/handlers";
 
+const mutate = vi.fn();
+
+vi.mock("@/queries/useAlbumMutation", () => ({
+  useAlbumMutation: () => ({ mutate }),
+}));
+
 const CoverCellStub = defineComponent({
   name: "CoverCell",
   props: {
@@ -41,7 +47,49 @@ const VirtualScrollStub = defineComponent({
     '<div class="virtual-scroll-stub"><template v-for="(item, index) in items.slice(0, virtualScrollSliceSize)" :key="index"><slot :item="item" :index="index" /></template></div>',
 });
 
+const SliderStub = defineComponent({
+  name: "QSlider",
+  props: {
+    modelValue: { type: Number, required: true },
+  },
+  emits: ["change", "update:modelValue"],
+  template: '<input class="slider-stub" type="range" :value="modelValue" />',
+});
+
+function mountCoverInspector(sectionKey: string) {
+  return mountWithPlugins(InspectorDrawer, {
+    props: {
+      album: defaultAlbum,
+      sectionKey,
+      steps: defaultSteps,
+      media: [
+        makeAlbumMedia({
+          name: "cover.jpg",
+          aid: defaultAlbum.id,
+        }),
+      ],
+    },
+    global: {
+      stubs: {
+        AlbumProperties: true,
+        CoverCell: CoverCellStub,
+        MediaPanel: true,
+        QSlider: SliderStub,
+        QVirtualScroll: VirtualScrollStub,
+        QExpansionItem: ExpansionItemStub,
+        QIcon: true,
+        QSeparator: true,
+        UnusedDrawer: true,
+      },
+    },
+  });
+}
+
 describe("InspectorDrawer", () => {
+  beforeEach(() => {
+    mutate.mockReset();
+  });
+
   it("keeps only properties and external media in the primary accordion", () => {
     const wrapper = mountWithPlugins(InspectorDrawer, {
       props: {
@@ -140,5 +188,34 @@ describe("InspectorDrawer", () => {
     });
 
     expect(wrapper.findAll(".cover-cell").length).toBeLessThan(media.length);
+  });
+
+  it("updates the active chapter darkness from the front cover", async () => {
+    const wrapper = mountCoverInspector("chapter-chapter-1-cover-front");
+
+    expect(wrapper.get(".cover-darkness-value").text()).toBe("45%");
+
+    wrapper.getComponent(SliderStub).vm.$emit("update:modelValue", 20);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get(".cover-darkness-value").text()).toBe("20%");
+    expect(mutate).not.toHaveBeenCalled();
+
+    wrapper.getComponent(SliderStub).vm.$emit("change", 20);
+    await wrapper.vm.$nextTick();
+
+    expect(mutate).toHaveBeenCalledOnce();
+    expect(mutate.mock.calls[0][0].chapters).toEqual([
+      {
+        ...defaultAlbum.chapters[0],
+        front_cover_darkness: 0.2,
+      },
+    ]);
+  });
+
+  it("does not show chapter darkness for the back cover", () => {
+    const wrapper = mountCoverInspector("chapter-chapter-1-cover-back");
+
+    expect(wrapper.find(".cover-darkness-control").exists()).toBe(false);
   });
 });

--- a/frontend/tests/logic/chapterEditing.test.ts
+++ b/frontend/tests/logic/chapterEditing.test.ts
@@ -27,6 +27,7 @@ describe("chapterEditing", () => {
         step_ids: [1, 2, 3, 4],
         front_cover_photo: "old.jpg",
         back_cover_photo: "old.jpg",
+        front_cover_darkness: 0.2,
       }),
     ];
     const steps = [
@@ -48,6 +49,7 @@ describe("chapterEditing", () => {
         step_ids: [3, 4],
         front_cover_photo: "three.jpg",
         back_cover_photo: "three.jpg",
+        front_cover_darkness: 0.2,
       },
     ]);
   });


### PR DESCRIPTION
- persist a validated per-chapter front-cover darkness factor with the current 45% default
- add a front-cover-only slider that previews locally and saves on release
- render the overlay with PDF-safe CSS opacity and preserve it when splitting chapters