### PR TITLE
fix: match multi-digit release tags

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -21,7 +21,7 @@ filter_unconventional = true
 split_commits = false
 protect_breaking_commits = false
 filter_commits = false
-tag_pattern = "v[0-9].[0-9].0"
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.0$"
 topo_order = false
 sort_commits = "oldest"
 


### PR DESCRIPTION
- allow git-cliff to recognize minor releases with multi-digit version components
- restores release-note generation for tags such as `v1.10.0`

Verified by reproducing the original `git cliff --current` failure at `v1.10.0`, then generating the release notes successfully after the change.