### PR TITLE
feat: add typed step page layouts

### DIFF
--- a/backend/app/alembic/versions/c2d4e6f8a0b1_add_step_page_kind.py
+++ b/backend/app/alembic/versions/c2d4e6f8a0b1_add_step_page_kind.py
@@ -1,0 +1,28 @@
+"""add step page kind
+
+Revision ID: c2d4e6f8a0b1
+Revises: b6d2f9a31c74
+Create Date: 2026-07-26 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c2d4e6f8a0b1"
+down_revision = "b6d2f9a31c74"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "step_page_media",
+        sa.Column("page_kind", sa.String(length=16), nullable=False, server_default="grid"),
+    )
+    op.alter_column("step_page_media", "page_kind", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("step_page_media", "page_kind")

--- a/backend/app/api/v1/routes/google_photos.py
+++ b/backend/app/api/v1/routes/google_photos.py
@@ -492,7 +492,7 @@ async def match_media(
             album_dir = _album_dir(user, aid)
             step_ids = [s.id for s in step_rows]
             media_by_step = {
-                s.id: [name for page in s.pages for name in page] + s.unused
+                s.id: [name for page in s.pages for name in page.media] + s.unused
                 for s in step_rows
             }
 

--- a/backend/app/logic/reconcile.py
+++ b/backend/app/logic/reconcile.py
@@ -36,7 +36,7 @@ from app.logic.trip_processing import (
 from app.models.album import Album
 from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
 from app.models.polarsteps import PSStep
-from app.models.step import Step, StepRead
+from app.models.step import Step, StepPageLayout, StepRead
 from app.models.user import User
 
 logger = structlog.get_logger(__name__)
@@ -57,12 +57,12 @@ def _scan_step_media(trip_dir: Path, ps_step: PSStep) -> set[str]:
 
 
 def _pick_cover(
-    pages: list[list[str]],
+    pages: list[StepPageLayout],
     unused: list[str],
     media_by_name: dict[str, Media],
 ) -> str | None:
     """Pick a cover photo, preferring portraits."""
-    candidates = [f for pg in pages for f in pg] + unused
+    candidates = [name for page in pages for name in page.media] + unused
     portraits = [f for f in candidates if (m := media_by_name.get(f)) and m.is_portrait]
     return portraits[0] if portraits else (candidates[0] if candidates else None)
 
@@ -76,8 +76,8 @@ def _reconcile_step(
 ) -> StepRead:
     """Update a single step's media references and metadata."""
     old_media: set[str] = set()
-    for pg in step.pages:
-        old_media.update(pg)
+    for page in step.pages:
+        old_media.update(page.media)
     if step.cover:
         old_media.add(step.cover)
     old_media.update(step.unused)
@@ -87,7 +87,11 @@ def _reconcile_step(
     added = (disk_media - old_media) & all_on_disk
 
     step.pages = [
-        p for p in ([f for f in pg if f not in missing] for pg in step.pages) if p
+        page.model_copy(
+            update={"media": [name for name in page.media if name not in missing]}
+        )
+        for page in step.pages
+        if any(name not in missing for name in page.media)
     ]
     step.unused = [f for f in step.unused if f not in missing] + sorted(added)
 
@@ -110,8 +114,8 @@ async def _probe_media(
     """Probe dimensions for unknown media files, return full merged list."""
     to_probe: set[str] = set()
     for step_obj in steps:
-        for pg in step_obj.pages:
-            to_probe.update(f for f in pg if f not in known)
+        for page in step_obj.pages:
+            to_probe.update(name for name in page.media if name not in known)
         if step_obj.cover and step_obj.cover not in known:
             to_probe.add(step_obj.cover)
         to_probe.update(f for f in step_obj.unused if f not in known)
@@ -260,7 +264,10 @@ async def _process_new_steps(  # noqa: PLR0913
                 elevation=step.elevation,
                 weather=step.weather,
                 cover=step.cover_media_name,
-                pages=layout.pages if layout else [],
+                pages=[
+                    StepPageLayout(kind="grid", media=page)
+                    for page in (layout.pages if layout else [])
+                ],
                 unused=[],
             )
         )
@@ -290,9 +297,10 @@ def _step_read_to_rows(step: StepRead) -> list[DbRow]:
             page_index=page_index,
             position_index=position_index,
             media_name=media_name,
+            page_kind=page.kind,
         )
         for page_index, page in enumerate(step.pages)
-        for position_index, media_name in enumerate(page)
+        for position_index, media_name in enumerate(page.media)
     )
     rows.extend(
         StepUnusedMedia(

--- a/backend/app/logic/step_media.py
+++ b/backend/app/logic/step_media.py
@@ -4,8 +4,13 @@ from typing import TYPE_CHECKING
 from sqlalchemy import delete
 from sqlmodel import col, select
 
-from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
-from app.models.step import Step, StepMediaLayout, StepRead
+from app.models.album_media import (
+    AlbumMedia,
+    StepPageKind,
+    StepPageMedia,
+    StepUnusedMedia,
+)
+from app.models.step import Step, StepMediaLayout, StepPageLayout, StepRead
 
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -16,9 +21,10 @@ def _step_to_read(
     page_rows: list[StepPageMedia],
     unused_rows: list[StepUnusedMedia],
 ) -> StepRead:
-    pages_by_index: dict[int, list[str]] = defaultdict(list)
-    for row in sorted(page_rows, key=lambda r: (r.page_index, r.position_index)):
-        pages_by_index[row.page_index].append(row.media_name)
+    pages_by_index: dict[int, tuple[StepPageKind, list[str]]] = {}
+    for row in page_rows:
+        _, media = pages_by_index.setdefault(row.page_index, (row.page_kind, []))
+        media.append(row.media_name)
 
     return StepRead(
         uid=step.uid,
@@ -32,11 +38,11 @@ def _step_to_read(
         elevation=step.elevation,
         weather=step.weather,
         cover=step.cover_media_name,
-        pages=[pages_by_index[i] for i in sorted(pages_by_index)],
-        unused=[
-            row.media_name
-            for row in sorted(unused_rows, key=lambda r: r.position_index)
+        pages=[
+            StepPageLayout(kind=kind, media=media)
+            for kind, media in pages_by_index.values()
         ],
+        unused=[row.media_name for row in unused_rows],
     )
 
 
@@ -158,7 +164,7 @@ async def _validate_media_names(
 
 
 def _layout_names(layout: StepMediaLayout) -> set[str]:
-    names = {name for page in layout.pages for name in page}
+    names = {name for page in layout.pages for name in page.media}
     names.update(layout.unused)
     if layout.cover is not None:
         names.add(layout.cover)
@@ -189,11 +195,10 @@ async def replace_step_media_layout(
             col(StepUnusedMedia.step_id) == step_id,
         )
     )
-
     step.cover_media_name = layout.cover
     session.add(step)
     for page_index, page in enumerate(layout.pages):
-        for position_index, media_name in enumerate(page):
+        for position_index, media_name in enumerate(page.media):
             session.add(
                 StepPageMedia(
                     uid=uid,
@@ -202,6 +207,7 @@ async def replace_step_media_layout(
                     page_index=page_index,
                     position_index=position_index,
                     media_name=media_name,
+                    page_kind=page.kind,
                 )
             )
     for position_index, media_name in enumerate(layout.unused):

--- a/backend/app/models/album_media.py
+++ b/backend/app/models/album_media.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Literal
 
 import sqlalchemy as sa
 
 # Pydantic resolves this annotation while constructing the SQLModel.
 from pydantic.json_schema import SkipJsonSchema  # noqa: TC002
 from sqlmodel import Field, SQLModel
+
+type StepPageKind = Literal["grid", "panorama_spread"]
 
 
 class AlbumMedia(SQLModel, table=True):
@@ -63,6 +66,9 @@ class StepPageMedia(SQLModel, table=True):
     page_index: int = Field(primary_key=True)
     position_index: int = Field(primary_key=True)
     media_name: str = Field(max_length=255)
+    page_kind: StepPageKind = Field(
+        default="grid", sa_column=sa.Column(sa.String(16), nullable=False)
+    )
 
 
 class StepUnusedMedia(SQLModel, table=True):

--- a/backend/app/models/step.py
+++ b/backend/app/models/step.py
@@ -1,11 +1,13 @@
 from datetime import datetime
+from typing import Self
 from zoneinfo import ZoneInfo
 
-from pydantic import AwareDatetime, computed_field
+from pydantic import AwareDatetime, computed_field, model_validator
 from sqlalchemy import ForeignKeyConstraint
 from sqlmodel import Column, Field, SQLModel
 
 from app.core.db import PydanticJSON, all_optional
+from app.models.album_media import StepPageKind
 from app.models.polarsteps import Location
 from app.models.weather import Weather
 
@@ -20,9 +22,20 @@ class StepUpdate(StepBase):
     pass
 
 
+class StepPageLayout(SQLModel):
+    kind: StepPageKind
+    media: list[str]
+
+    @model_validator(mode="after")
+    def validate_panorama_spread_media(self) -> Self:
+        if self.kind == "panorama_spread" and len(self.media) != 1:
+            raise ValueError("A panorama spread must contain exactly one media item")
+        return self
+
+
 class StepMediaLayout(SQLModel):
     cover: str | None = Field(max_length=255)
-    pages: list[list[str]]
+    pages: list[StepPageLayout]
     unused: list[str]
 
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4268,10 +4268,7 @@
           },
           "pages": {
             "items": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
+              "$ref": "#/components/schemas/StepPageLayout"
             },
             "type": "array",
             "title": "Pages"
@@ -4292,6 +4289,33 @@
         ],
         "title": "StepMediaLayout"
       },
+      "StepPageKind": {
+        "type": "string",
+        "enum": [
+          "grid",
+          "panorama_spread"
+        ]
+      },
+      "StepPageLayout": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StepPageKind"
+          },
+          "media": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Media"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "media"
+        ],
+        "title": "StepPageLayout"
+      },
       "StepRead": {
         "properties": {
           "cover": {
@@ -4308,10 +4332,7 @@
           },
           "pages": {
             "items": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
+              "$ref": "#/components/schemas/StepPageLayout"
             },
             "type": "array",
             "title": "Pages"

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -25,7 +25,7 @@ from app.models.album_media import (
 )
 from app.models.polarsteps import Location, Point, PSStep
 from app.models.segment import Segment, SegmentKind
-from app.models.step import Step, StepRead
+from app.models.step import Step, StepPageLayout, StepRead
 from app.models.user import PSUser, User
 from app.models.weather import Weather, WeatherData
 
@@ -487,7 +487,7 @@ def make_step_read(
     elevation: int = 0,
     weather: Weather | None = None,
     cover: str | None = None,
-    pages: list[list[str]] | None = None,
+    pages: list[StepPageLayout] | None = None,
     unused: list[str] | None = None,
 ) -> StepRead:
     return StepRead(

--- a/backend/tests/helpers/albums.py
+++ b/backend/tests/helpers/albums.py
@@ -73,7 +73,7 @@ class AlbumRoutes:
         *,
         step_id: int = 1,
         cover: str | None,
-        pages: list[list[str]],
+        pages: list[dict[str, object]],
         unused: list[str],
     ) -> Response:
         return await self.client.put(

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -33,7 +33,7 @@ def _assert_step_layout(
     data: dict[str, object],
     *,
     cover: str | None,
-    pages: list[list[str]],
+    pages: list[dict[str, object]],
     unused: list[str],
 ) -> None:
     assert data["cover"] == cover
@@ -527,7 +527,7 @@ class TestUpdateStep:
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "New Name"
-        assert data["pages"] == [["photo1.jpg"]]
+        assert data["pages"] == [{"kind": "grid", "media": ["photo1.jpg"]}]
         assert data["unused"] == ["photo2.jpg"]
         assert data["description"] == "A test step."
         assert data["cover"] is None
@@ -540,7 +540,10 @@ class TestUpdateStep:
     ) -> None:
         expected_layout = {
             "cover": "cover.jpg",
-            "pages": [["a.jpg", "b.jpg"], ["c.jpg"]],
+            "pages": [
+                {"kind": "grid", "media": ["a.jpg", "b.jpg"]},
+                {"kind": "panorama_spread", "media": ["c.jpg"]},
+            ],
             "unused": ["unused.jpg"],
         }
         for name in ("a.jpg", "b.jpg", "c.jpg", "cover.jpg", "unused.jpg"):
@@ -557,6 +560,21 @@ class TestUpdateStep:
         assert get_resp.status_code == 200
         _assert_step_layout(get_resp.json()[0], **expected_layout)
 
+    @pytest.mark.usefixtures("signed_album")
+    @pytest.mark.parametrize("media", [[], ["a.jpg", "b.jpg"]])
+    async def test_panorama_spread_requires_one_media(
+        self,
+        album_routes: AlbumRoutes,
+        media: list[str],
+    ) -> None:
+        resp = await album_routes.update_media_layout(
+            cover=None,
+            pages=[{"kind": "panorama_spread", "media": media}],
+            unused=[],
+        )
+
+        assert resp.status_code == 422
+
     async def test_media_layout_update_rejects_missing_album_media(
         self,
         session: AsyncSession,
@@ -567,7 +585,9 @@ class TestUpdateStep:
         await session.commit()
 
         resp = await album_routes.update_media_layout(
-            cover=None, pages=[["missing.jpg"]], unused=[]
+            cover=None,
+            pages=[{"kind": "grid", "media": ["missing.jpg"]}],
+            unused=[],
         )
 
         assert resp.status_code == 400

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -238,7 +238,7 @@ class TestExportUserData:
         steps = _read_zip_json(path, _export_path("albums", AID, "steps.json"))
 
         assert steps[0]["cover"] == "photo1.jpg"
-        assert steps[0]["pages"] == [["page.jpg"]]
+        assert steps[0]["pages"] == [{"kind": "grid", "media": ["page.jpg"]}]
         assert steps[0]["unused"] == ["unused.jpg"]
         assert "cover_media_name" not in steps[0]
         path.unlink(missing_ok=True)

--- a/backend/tests/test_google_photos_routes.py
+++ b/backend/tests/test_google_photos_routes.py
@@ -29,6 +29,7 @@ from app.logic.media_upgrade.pipeline import (
     UpgradeFailed,
     _clear_caches,
 )
+from app.models.step import StepPageLayout
 from app.models.user import User
 from app.services.google_photos import _clear_media_items_cache
 
@@ -241,7 +242,7 @@ class TestMatchMedia:
             description="",
             timezone_id="UTC",
             weather=make_weather(icon="clear"),
-            pages=[["photo.jpg"]],
+            pages=[StepPageLayout(kind="grid", media=["photo.jpg"])],
         )
         http = pin_http_clients()
         http.gphotos_oauth.refresh_token.return_value = OAuth2Token(

--- a/backend/tests/test_reconcile.py
+++ b/backend/tests/test_reconcile.py
@@ -19,7 +19,7 @@ from app.models.album import Album
 from app.models.album_media import AlbumMedia
 from app.models.polarsteps import Location, PSStep
 from app.models.segment import Segment
-from app.models.step import StepRead
+from app.models.step import StepPageLayout, StepRead
 from app.models.user import User
 from tests.factories import (
     collect_async,
@@ -56,7 +56,7 @@ def _ps_step(step_id: int, slug: str = "step", *, location: Location = _LOC) -> 
 def _step(
     step_id: int = 1,
     *,
-    pages: list[list[str]] | None = None,
+    pages: list[StepPageLayout] | None = None,
     unused: list[str] | None = None,
     cover: str | None = None,
     name: str = "Old Name",
@@ -124,7 +124,7 @@ def _media(name: str, *, portrait: bool) -> Media:
 
 class TestPickCover:
     def test_prefers_portrait(self) -> None:
-        pages = [["a.jpg", "b.jpg"]]
+        pages = [StepPageLayout(kind="grid", media=["a.jpg", "b.jpg"])]
         unused = ["c.jpg"]
         media = {
             n: _media(n, portrait=p)
@@ -133,7 +133,7 @@ class TestPickCover:
         assert _pick_cover(pages, unused, media) == "b.jpg"
 
     def test_portrait_in_unused(self) -> None:
-        pages = [["land.jpg"]]
+        pages = [StepPageLayout(kind="grid", media=["land.jpg"])]
         unused = ["port.jpg"]
         media = {
             "land.jpg": _media("land.jpg", portrait=False),
@@ -144,25 +144,39 @@ class TestPickCover:
 
 class TestReconcileStep:
     def test_missing_media_removed_from_pages(self) -> None:
-        step = _step(pages=[["a.jpg", "b.jpg"], ["c.jpg"]], cover="a.jpg")
+        step = _step(
+            pages=[
+                StepPageLayout(kind="grid", media=["a.jpg", "b.jpg"]),
+                StepPageLayout(kind="grid", media=["c.jpg"]),
+            ],
+            cover="a.jpg",
+        )
         ps = _ps_step(1)
         all_on_disk = {"a.jpg", "c.jpg"}
         disk_media = {"a.jpg", "c.jpg"}
 
         result = _reconcile_step(step, ps, disk_media, all_on_disk, {})
-        assert result.pages == [["a.jpg"], ["c.jpg"]]
+        assert result.pages == [
+            StepPageLayout(kind="grid", media=["a.jpg"]),
+            StepPageLayout(kind="grid", media=["c.jpg"]),
+        ]
 
     def test_empty_page_dropped(self) -> None:
-        step = _step(pages=[["a.jpg"], ["b.jpg"]])
+        step = _step(
+            pages=[
+                StepPageLayout(kind="grid", media=["a.jpg"]),
+                StepPageLayout(kind="grid", media=["b.jpg"]),
+            ]
+        )
         ps = _ps_step(1)
         all_on_disk = {"a.jpg"}
         disk_media = {"a.jpg"}
 
         result = _reconcile_step(step, ps, disk_media, all_on_disk, {})
-        assert result.pages == [["a.jpg"]]
+        assert result.pages == [StepPageLayout(kind="grid", media=["a.jpg"])]
 
     def test_new_media_added_to_unused(self) -> None:
-        step = _step(pages=[["a.jpg"]])
+        step = _step(pages=[StepPageLayout(kind="grid", media=["a.jpg"])])
         ps = _ps_step(1)
         all_on_disk = {"a.jpg", "new.jpg"}
         disk_media = {"a.jpg", "new.jpg"}
@@ -171,7 +185,10 @@ class TestReconcileStep:
         assert "new.jpg" in result.unused
 
     def test_missing_cover_picks_new(self) -> None:
-        step = _step(pages=[["remain.jpg"]], cover="gone.jpg")
+        step = _step(
+            pages=[StepPageLayout(kind="grid", media=["remain.jpg"])],
+            cover="gone.jpg",
+        )
         ps = _ps_step(1)
         all_on_disk = {"remain.jpg"}
         disk_media = {"remain.jpg"}
@@ -181,7 +198,11 @@ class TestReconcileStep:
         assert result.cover == "remain.jpg"
 
     def test_cover_none_when_all_media_gone(self) -> None:
-        step = _step(pages=[["a.jpg"]], unused=["b.jpg"], cover="a.jpg")
+        step = _step(
+            pages=[StepPageLayout(kind="grid", media=["a.jpg"])],
+            unused=["b.jpg"],
+            cover="a.jpg",
+        )
         ps = _ps_step(1)
 
         result = _reconcile_step(step, ps, set(), set(), {})
@@ -201,14 +222,14 @@ class TestReconcileStep:
         assert result.location == _LOC2
 
     def test_new_media_not_on_disk_ignored(self) -> None:
-        step = _step(pages=[["a.jpg"]])
+        step = _step(pages=[StepPageLayout(kind="grid", media=["a.jpg"])])
         ps = _ps_step(1)
         disk_media = {"a.jpg", "ghost.jpg"}
         all_on_disk = {"a.jpg"}  # ghost.jpg not in flattened dir
 
         result = _reconcile_step(step, ps, disk_media, all_on_disk, {})
         assert "ghost.jpg" not in result.unused
-        assert result.pages == [["a.jpg"]]
+        assert result.pages == [StepPageLayout(kind="grid", media=["a.jpg"])]
 
 
 class TestFixAlbumCovers:
@@ -353,7 +374,13 @@ class TestReconcileTripRebuildsSegments:
         )
         (trip_dir / media_name).write_bytes(b"\xff\xd8")
 
-        existing_steps = [_existing_step(1, pages=[[media_name]], cover=media_name)]
+        existing_steps = [
+            _existing_step(
+                1,
+                pages=[StepPageLayout(kind="grid", media=[media_name])],
+                cover=media_name,
+            )
+        ]
         existing_media = make_album_media(
             _UID,
             _RECONCILE_AID,
@@ -411,7 +438,13 @@ class TestReconcileTripRebuildsSegments:
         _, db_out = await _collect_reconcile(
             trip_dir,
             _existing_album(front_cover_photo=media_name, back_cover_photo=media_name),
-            [_existing_step(1, pages=[[media_name]], cover=media_name)],
+            [
+                _existing_step(
+                    1,
+                    pages=[StepPageLayout(kind="grid", media=[media_name])],
+                    cover=media_name,
+                )
+            ],
             existing_media_rows=[existing_media],
         )
 

--- a/frontend/e2e/large-album-performance.test.ts
+++ b/frontend/e2e/large-album-performance.test.ts
@@ -58,7 +58,10 @@ function makeLargeSteps(photosPerStep = PHOTOS_PER_STEP) {
       cover: photos[0],
       pages: Array.from(
         { length: Math.ceil(photos.length / 4) },
-        (_, pageIndex) => photos.slice(pageIndex * 4, pageIndex * 4 + 4),
+        (_, pageIndex) => ({
+          kind: "grid",
+          media: photos.slice(pageIndex * 4, pageIndex * 4 + 4),
+        }),
       ),
       unused: [],
       datetime: new Date(timestamp * 1000).toISOString(),

--- a/frontend/src/components/album/stepPages.ts
+++ b/frontend/src/components/album/stepPages.ts
@@ -1,4 +1,4 @@
-import type { AlbumMedia, StepRead as Step } from "@/client";
+import type { AlbumMedia, StepPageLayout, StepRead as Step } from "@/client";
 import {
   layoutDescription,
   type JustifiedLine,
@@ -21,16 +21,16 @@ export type StepPagePlan = {
 };
 
 export function filterCoverFromPages(
-  pages: string[][],
+  pages: StepPageLayout[],
   cover: string | null | undefined,
 ): IndexedPage[] {
   if (!cover) {
-    return pages.map((page, i) => ({ originalIdx: i, page }));
+    return pages.map((page, i) => ({ originalIdx: i, page: page.media }));
   }
   return pages
     .map((page, i) => ({
       originalIdx: i,
-      page: page.filter((p) => p !== cover),
+      page: page.media.filter((p) => p !== cover),
     }))
     .filter(({ page }) => page.length > 0);
 }
@@ -74,7 +74,8 @@ export function planStepPages(
         .filter(({ page }) => page.length > 0)
     : rawPhotoPages;
   const totalPhotos =
-    step.pages.reduce((n, page) => n + page.length, 0) + step.unused.length;
+    step.pages.reduce((n, page) => n + page.media.length, 0) +
+    step.unused.length;
 
   return {
     sidebarLines: descriptionPages[0] ?? [],

--- a/frontend/src/composables/useOverview.ts
+++ b/frontend/src/composables/useOverview.ts
@@ -35,7 +35,8 @@ export function computeOverview(
   homeLocation: { lat: number; lon: number } | null,
 ): Overview {
   const totalPhotos = steps.reduce(
-    (sum, s) => sum + s.pages.reduce((ps, page) => ps + page.length, 0),
+    (sum, s) =>
+      sum + s.pages.reduce((ps, page) => ps + page.media.length, 0),
     0,
   );
 

--- a/frontend/src/composables/usePhotoFocus.ts
+++ b/frontend/src/composables/usePhotoFocus.ts
@@ -27,7 +27,7 @@ let awaitingStepTransition = false;
 
 /** Cover is shown on StepMainPage (not focusable) - skip it in navigation. */
 function pagedPhotos(step: Step): string[] {
-  const all = step.pages.flat();
+  const all = step.pages.flatMap((page) => page.media);
   return step.cover ? all.filter((p) => p !== step.cover) : all;
 }
 

--- a/frontend/src/composables/useStepLayout.ts
+++ b/frontend/src/composables/useStepLayout.ts
@@ -16,8 +16,11 @@ const STEP_MUTATE_KEY: InjectionKey<StepMutateFn> = Symbol("step-mutate");
 function stripPhotos(step: Step, photoSet: Set<string>) {
   return {
     pages: step.pages
-      .map((page) => page.filter((p) => !photoSet.has(p)))
-      .filter((page) => page.length > 0),
+      .map((page) => ({
+        ...page,
+        media: page.media.filter((name) => !photoSet.has(name)),
+      }))
+      .filter((page) => page.media.length > 0),
     unused: step.unused.filter((p) => !photoSet.has(p)),
   };
 }
@@ -86,7 +89,9 @@ export function useStepLayout(
 
   function onPageUpdate(idx: number, page: string[]) {
     const s = step.value;
-    const existing = new Set(s.pages[idx]);
+    const target = s.pages[idx];
+    if (!target) return;
+    const existing = new Set(target.media);
     const added = page.filter((p) => !existing.has(p));
 
     if (added.length > 0) {
@@ -96,14 +101,19 @@ export function useStepLayout(
       const addedSet = new Set(added);
       const pages = s.pages
         .map((p, i) =>
-          i === idx ? page : p.filter((photo) => !addedSet.has(photo)),
+          i === idx
+            ? { ...p, media: page }
+            : {
+                ...p,
+                media: p.media.filter((photo) => !addedSet.has(photo)),
+              },
         )
-        .filter((p) => p.length > 0);
+        .filter((p) => p.media.length > 0);
       const unused = s.unused.filter((p) => !addedSet.has(p));
       saveField({ pages, unused });
     } else {
       const pages = [...s.pages];
-      pages[idx] = page;
+      pages[idx] = { ...target, media: page };
       saveField({ pages });
     }
   }
@@ -124,7 +134,10 @@ export function useStepLayout(
         const photos = [...dropZoneList.value];
         dropZoneList.value = [];
         const cleaned = withoutPhotos(new Set(photos));
-        saveField({ ...cleaned, pages: [...cleaned.pages, photos] });
+        saveField({
+          ...cleaned,
+          pages: [...cleaned.pages, { kind: "grid", media: photos }],
+        });
       },
     });
     watch(dropZoneRef, (el) => {

--- a/frontend/src/utils/photoQuality.ts
+++ b/frontend/src/utils/photoQuality.ts
@@ -135,7 +135,9 @@ export function summarizeQuality(
     // Photo pages
     for (const page of step.pages) {
       // Skip the cover photo (it's displayed on StepMainPage, not photo pages)
-      const filtered = step.cover ? page.filter((p) => p !== step.cover) : page;
+      const filtered = step.cover
+        ? page.media.filter((p) => p !== step.cover)
+        : page.media;
       if (filtered.length === 0) continue;
 
       const ordered = enforceOrientationOrder(filtered, isP);

--- a/frontend/tests/composables/useStepLayout.test.ts
+++ b/frontend/tests/composables/useStepLayout.test.ts
@@ -39,14 +39,38 @@ function lastUpdate(
 describe("onCoverUpdate", () => {
   it.each([
     [
-      { cover: null, pages: [["p1", "p2"], ["p3"]], unused: [] },
+      {
+        cover: null,
+        pages: [
+          { kind: "grid" as const, media: ["p1", "p2"] },
+          { kind: "grid" as const, media: ["p3"] },
+        ],
+        unused: [],
+      },
       "p2",
-      { cover: "p2", pages: [["p1"], ["p3"]], unused: [] },
+      {
+        cover: "p2",
+        pages: [
+          { kind: "grid", media: ["p1"] },
+          { kind: "grid", media: ["p3"] },
+        ],
+        unused: [],
+      },
     ],
     [
-      { cover: "old_cover", pages: [["p1", "new_cover"]], unused: ["u1"] },
+      {
+        cover: "old_cover",
+        pages: [
+          { kind: "grid" as const, media: ["p1", "new_cover"] },
+        ],
+        unused: ["u1"],
+      },
       "new_cover",
-      { cover: "new_cover", pages: [["p1"]], unused: ["u1", "old_cover"] },
+      {
+        cover: "new_cover",
+        pages: [{ kind: "grid", media: ["p1"] }],
+        unused: ["u1", "old_cover"],
+      },
     ],
     [
       { cover: null, pages: [], unused: ["u1", "new_cover", "u2"] },
@@ -69,23 +93,41 @@ describe("onPageUpdate", () => {
     [
       {
         pages: [
-          ["a", "b"],
-          ["c", "d"],
+          { kind: "grid" as const, media: ["a", "b"] },
+          { kind: "grid" as const, media: ["c", "d"] },
         ],
         unused: [],
       },
       ["a", "b", "c"],
-      { pages: [["a", "b", "c"], ["d"]], unused: [] },
+      {
+        pages: [
+          { kind: "grid", media: ["a", "b", "c"] },
+          { kind: "grid", media: ["d"] },
+        ],
+        unused: [],
+      },
     ],
     [
-      { pages: [["a"]], unused: ["u1", "u2"] },
+      {
+        pages: [{ kind: "grid" as const, media: ["a"] }],
+        unused: ["u1", "u2"],
+      },
       ["a", "u1"],
-      { pages: [["a", "u1"]], unused: ["u2"] },
+      {
+        pages: [{ kind: "grid", media: ["a", "u1"] }],
+        unused: ["u2"],
+      },
     ],
     [
-      { pages: [["a"], ["b"]], unused: [] },
+      {
+        pages: [
+          { kind: "grid" as const, media: ["a"] },
+          { kind: "grid" as const, media: ["b"] },
+        ],
+        unused: [],
+      },
       ["a", "b"],
-      { pages: [["a", "b"]] },
+      { pages: [{ kind: "grid", media: ["a", "b"] }] },
     ],
   ])("updates page placement", (stepPatch, page, expected) => {
     const { result, mutateSpy } = mountStepLayout(

--- a/frontend/tests/fixtures/mocks.ts
+++ b/frontend/tests/fixtures/mocks.ts
@@ -79,7 +79,7 @@ export const mockStep = {
     night: null,
   },
   cover: "photo1.jpg",
-  pages: [["photo1.jpg", "photo2.jpg"]],
+  pages: [{ kind: "grid", media: ["photo1.jpg", "photo2.jpg"] }],
   unused: [],
   datetime: "2024-01-01T12:00:00+01:00",
 };
@@ -126,7 +126,12 @@ export const mockFocusSteps = [
     elevation: 25,
     weather: { day: { temp: 28, feels_like: 30, icon: "clear-day" }, night: null },
     cover: focusPhotos[0],
-    pages: [[focusPhotos[0], focusPhotos[1], focusPhotos[2], focusPhotos[3]]],
+    pages: [
+      {
+        kind: "grid",
+        media: [focusPhotos[0], focusPhotos[1], focusPhotos[2], focusPhotos[3]],
+      },
+    ],
     unused: [],
     datetime: "2024-01-01T12:00:00-03:00",
   },
@@ -140,7 +145,13 @@ export const mockFocusSteps = [
     elevation: 15,
     weather: { day: { temp: 10, feels_like: 7, icon: "cloudy" }, night: null },
     cover: focusPhotos[4],
-    pages: [[focusPhotos[4], focusPhotos[5], focusPhotos[6]], [focusPhotos[7]]],
+    pages: [
+      {
+        kind: "grid",
+        media: [focusPhotos[4], focusPhotos[5], focusPhotos[6]],
+      },
+      { kind: "grid", media: [focusPhotos[7]] },
+    ],
     unused: [],
     datetime: "2024-01-03T10:00:00-03:00",
   },
@@ -154,7 +165,18 @@ export const mockFocusSteps = [
     elevation: 520,
     weather: { day: { temp: 32, feels_like: 34, icon: "clear-day" }, night: null },
     cover: focusPhotos[8],
-    pages: [[focusPhotos[8], focusPhotos[9], FOCUS_VIDEO, focusPhotos[10], focusPhotos[11]]],
+    pages: [
+      {
+        kind: "grid",
+        media: [
+          focusPhotos[8],
+          focusPhotos[9],
+          FOCUS_VIDEO,
+          focusPhotos[10],
+          focusPhotos[11],
+        ],
+      },
+    ],
     unused: [],
     datetime: "2024-01-06T14:00:00-03:00",
   },

--- a/frontend/tests/logic/albumSections.test.ts
+++ b/frontend/tests/logic/albumSections.test.ts
@@ -33,15 +33,28 @@ const drivingSegment = (start_time: number, end_time: number) =>
 describe("filterCoverFromPages", () => {
   it.each([
     [
-      [["cover", "p1"], ["p2"]],
+      [
+        { kind: "grid" as const, media: ["cover", "p1"] },
+        { kind: "grid" as const, media: ["p2"] },
+      ],
       [
         { originalIdx: 0, page: ["p1"] },
         { originalIdx: 1, page: ["p2"] },
       ],
     ],
-    [[["cover"], ["p1", "p2"]], [{ originalIdx: 1, page: ["p1", "p2"] }]],
     [
-      [["cover", "p1"], ["cover", "p2"], ["p3"]],
+      [
+        { kind: "grid" as const, media: ["cover"] },
+        { kind: "grid" as const, media: ["p1", "p2"] },
+      ],
+      [{ originalIdx: 1, page: ["p1", "p2"] }],
+    ],
+    [
+      [
+        { kind: "grid" as const, media: ["cover", "p1"] },
+        { kind: "grid" as const, media: ["cover", "p2"] },
+        { kind: "grid" as const, media: ["p3"] },
+      ],
       [
         { originalIdx: 0, page: ["p1"] },
         { originalIdx: 1, page: ["p2"] },
@@ -58,7 +71,10 @@ describe("stepPageCount", () => {
     const step = makeStep({
       description: "x".repeat(120),
       cover: null,
-      pages: [["portrait.jpg"], ["landscape.jpg"]],
+      pages: [
+        { kind: "grid", media: ["portrait.jpg"] },
+        { kind: "grid", media: ["landscape.jpg"] },
+      ],
     });
     const mediaByName = new Map([
       ["portrait.jpg", { name: "portrait.jpg", width: 800, height: 1200 }],

--- a/frontend/tests/utils/photoQuality.test.ts
+++ b/frontend/tests/utils/photoQuality.test.ts
@@ -152,7 +152,12 @@ describe("summarizeQuality", () => {
 
   it("does not warn for a contained full-page portrait with print thresholds", () => {
     const portrait = media("portrait.jpg", 1688, 3000);
-    const steps = [makeStep({ id: 1, pages: [[portrait.name]] })];
+    const steps = [
+      makeStep({
+        id: 1,
+        pages: [{ kind: "grid", media: [portrait.name] }],
+      }),
+    ];
 
     const result = summarizeQuality(
       steps,
@@ -181,7 +186,11 @@ describe("summarizeQuality", () => {
 
   it("handles cover photo appearing in both cover and step.cover", () => {
     const steps: Step[] = [
-      makeStep({ id: 1, cover: "lo.jpg", pages: [["lo.jpg"]] }),
+      makeStep({
+        id: 1,
+        cover: "lo.jpg",
+        pages: [{ kind: "grid", media: ["lo.jpg"] }],
+      }),
     ];
     const result = summarizeQuality(
       steps,
@@ -199,7 +208,12 @@ describe("summarizeQuality", () => {
     const steps = [
       makeStep({
         id: 1,
-        pages: [["landscape.jpg", "portrait.jpg", "landscape.jpg"]],
+        pages: [
+          {
+            kind: "grid",
+            media: ["landscape.jpg", "portrait.jpg", "landscape.jpg"],
+          },
+        ],
       }),
     ];
     const result = summarizeQuality(


### PR DESCRIPTION
- represent step pages as `{ kind, media }` while keeping the existing page-media table
- update the ordinary grid editor and API contract