### PR TITLE
feat: add global panorama poster API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         with:
           version: 2026.7.11
           install_args: python uv
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - run: cp .env.example .env
       - run: uv run pytest
         working-directory: backend

--- a/backend/app/alembic/versions/d3e5f7a9b1c2_add_panorama_media.py
+++ b/backend/app/alembic/versions/d3e5f7a9b1c2_add_panorama_media.py
@@ -1,0 +1,27 @@
+"""add panorama media
+
+Revision ID: d3e5f7a9b1c2
+Revises: c2d4e6f8a0b1
+Create Date: 2026-07-26 14:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d3e5f7a9b1c2"
+down_revision = "c2d4e6f8a0b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("album_media", sa.Column("panorama", sa.JSON(), nullable=True))
+    op.add_column(
+        "album_media_undo_snapshot", sa.Column("panorama", sa.JSON(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("album_media_undo_snapshot", "panorama")
+    op.drop_column("album_media", "panorama")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -8,6 +8,7 @@ from .routes import (
     external_media,
     google_photos,
     health,
+    panoramas,
     uploads,
     users,
 )
@@ -20,5 +21,6 @@ router.include_router(uploads.router)
 router.include_router(albums.router)
 router.include_router(external_media.router)
 router.include_router(assets.router)
+router.include_router(panoramas.router)
 router.include_router(google_photos.router)
 router.include_router(config.router)

--- a/backend/app/api/v1/routes/assets.py
+++ b/backend/app/api/v1/routes/assets.py
@@ -1,7 +1,3 @@
-import asyncio
-import weakref
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated
 
@@ -15,6 +11,7 @@ from app.logic.layout.media import (
     delete_thumbnails,
     extract_frame,
     generate_thumbnail,
+    generation_lock,
     is_video,
 )
 
@@ -29,23 +26,6 @@ _CACHE_IMMUTABLE = "public, max-age=31536000, immutable"
 # Video posters (.jpg with a sibling .mp4) can change when the user
 # picks a new frame, so the browser must revalidate on each load.
 _CACHE_REVALIDATE = "public, no-cache"
-
-# Deduplicates concurrent lazy generation of the same file (poster or thumbnail).
-# WeakValueDictionary auto-collects locks when no coroutine holds a reference,
-# avoiding the race where manual cleanup deletes a lock while a waiter exists.
-_gen_locks: weakref.WeakValueDictionary[Path, asyncio.Lock] = (
-    weakref.WeakValueDictionary()
-)
-
-
-@asynccontextmanager
-async def _gen_lock(path: Path) -> AsyncIterator[None]:
-    lock = _gen_locks.get(path)
-    if lock is None:
-        lock = asyncio.Lock()
-        _gen_locks[path] = lock
-    async with lock:
-        yield
 
 
 @router.get("/{aid}/media/{name}")
@@ -65,7 +45,7 @@ async def get_media(
 
     # Lazy poster extraction: .jpg requested but only the .mp4 exists.
     if not source.is_file() and is_poster:
-        async with _gen_lock(source):
+        async with generation_lock(source):
             if not source.is_file():
                 await extract_frame(video)
                 logger.debug("asset.poster_extracted", media_name=name)
@@ -77,7 +57,7 @@ async def get_media(
     if w is not None and w in THUMB_WIDTHS:
         thumb = album_dir / ".thumbs" / str(w) / f"{Path(name).stem}.webp"
         if not thumb.is_file():
-            async with _gen_lock(thumb):
+            async with generation_lock(thumb):
                 if not thumb.is_file():
                     await generate_thumbnail(source, w)
         if thumb.is_file():

--- a/backend/app/api/v1/routes/panoramas.py
+++ b/backend/app/api/v1/routes/panoramas.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import FileResponse
+
+from app.core.worker_threads import run_sync
+from app.logic.layout.media import MediaName, generation_lock
+from app.logic.panorama import (
+    PanoramaRenderError,
+    PanoramaValidationError,
+    create_panorama_source,
+    panorama_render_path,
+    panorama_source_path,
+    remove_other_panorama_files,
+    remove_panorama_derivatives,
+    render_panorama,
+    resolve_panorama_source,
+)
+from app.models.album_media import AlbumMedia, PanoramaConfig
+
+from ..deps import SessionDep, UserDep, album_dir as _album_dir
+
+logger = structlog.get_logger(__name__)
+router = APIRouter(prefix="/albums", tags=["panoramas"])
+
+
+async def _panorama_media(
+    aid: str,
+    name: str,
+    user: UserDep,
+    session: SessionDep,
+    *,
+    lock: bool = False,
+) -> AlbumMedia:
+    media = await session.get(
+        AlbumMedia,
+        (user.id, aid, name),
+        with_for_update=lock,
+    )
+    if media is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if not media.panorama_candidate:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Media is not a panorama",
+        )
+    return media
+
+
+async def _render_or_error(
+    media: AlbumMedia,
+    config: PanoramaConfig,
+    source: Path,
+    output: Path,
+) -> None:
+    try:
+        await render_panorama(
+            source,
+            config,
+            output,
+            (media.width, media.height),
+        )
+    except PanoramaValidationError as error:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+    except PanoramaRenderError as error:
+        logger.exception(
+            "panorama.render_failed",
+            user_id=media.uid,
+            album_id=media.aid,
+            media_name=media.name,
+        )
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Panorama rendering failed",
+        ) from error
+
+
+def _source_or_404(album_dir: Path, name: str) -> Path:
+    try:
+        return resolve_panorama_source(album_dir, name)
+    except FileNotFoundError as error:
+        raise HTTPException(status.HTTP_404_NOT_FOUND) from error
+
+
+@router.put("/{aid}/media/{name}/panorama")
+async def update_panorama(
+    aid: str,
+    name: MediaName,
+    body: PanoramaConfig,
+    user: UserDep,
+    session: SessionDep,
+) -> AlbumMedia:
+    media = await _panorama_media(aid, name, user, session, lock=True)
+    album_dir = _album_dir(user, aid)
+    source = _source_or_404(album_dir, name)
+
+    output = panorama_render_path(album_dir, name, source, body)
+    output_existed = await run_sync(output.is_file)
+    media.panorama = body
+    await _render_or_error(media, body, source, output)
+    try:
+        media.updated_at = datetime.now(UTC)
+        session.add(media)
+        await session.commit()
+    except BaseException:
+        await session.rollback()
+        if not output_existed:
+            await run_sync(output.unlink, missing_ok=True)
+        raise
+
+    await run_sync(remove_other_panorama_files, output)
+    await session.refresh(media)
+    return media
+
+
+@router.delete("/{aid}/media/{name}/panorama")
+async def disable_panorama(
+    aid: str,
+    name: MediaName,
+    user: UserDep,
+    session: SessionDep,
+) -> AlbumMedia:
+    media = await _panorama_media(aid, name, user, session, lock=True)
+    if media.panorama is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST)
+    media.panorama = None
+    media.updated_at = datetime.now(UTC)
+    session.add(media)
+    await session.commit()
+    await run_sync(remove_panorama_derivatives, _album_dir(user, aid), name)
+    await session.refresh(media)
+    return media
+
+
+@router.get("/{aid}/media/{name}/panorama-source")
+async def get_panorama_source(
+    aid: str,
+    name: MediaName,
+    user: UserDep,
+    session: SessionDep,
+) -> FileResponse:
+    media = await _panorama_media(aid, name, user, session)
+    album_dir = _album_dir(user, aid)
+    source = _source_or_404(album_dir, name)
+    output = panorama_source_path(album_dir, name, source)
+    async with generation_lock(output):
+        if not await run_sync(output.is_file):
+            await create_panorama_source(source, output, media.width, media.height)
+    await run_sync(remove_other_panorama_files, output)
+    return FileResponse(
+        output,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, no-cache"},
+    )
+
+
+@router.get("/{aid}/media/{name}/panorama-render")
+async def get_panorama_render(
+    aid: str,
+    name: MediaName,
+    user: UserDep,
+    session: SessionDep,
+) -> FileResponse:
+    media = await _panorama_media(aid, name, user, session)
+    if media.panorama is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    album_dir = _album_dir(user, aid)
+    source = _source_or_404(album_dir, name)
+    output = panorama_render_path(album_dir, name, source, media.panorama)
+    async with generation_lock(output):
+        if not await run_sync(output.is_file):
+            await _render_or_error(media, media.panorama, source, output)
+    await run_sync(remove_other_panorama_files, output)
+    return FileResponse(
+        output,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, no-cache"},
+    )

--- a/backend/app/logic/external_media/album_media.py
+++ b/backend/app/logic/external_media/album_media.py
@@ -22,8 +22,9 @@ from app.logic.media_import import (
     process_saved_media,
 )
 from app.logic.media_upgrade.hashes import try_compute_serialized_media_hash
+from app.logic.panorama import remove_panorama_derivatives
 from app.models.album import Album
-from app.models.album_media import AlbumMedia
+from app.models.album_media import AlbumMedia, is_panorama_size
 
 from .undo import create_undo_snapshot
 
@@ -96,6 +97,9 @@ async def replace_album_media_from_saved(
             target,
             limiter=media_limiter,
         )
+        if not is_panorama_size(replacement.width, replacement.height):
+            row.panorama = None
+        await run_sync(remove_panorama_derivatives, album_dir, media_name)
         row.upgrade_candidate = False
         row.updated_at = datetime.now(UTC)
         session.add(row)

--- a/backend/app/logic/external_media/undo.py
+++ b/backend/app/logic/external_media/undo.py
@@ -156,6 +156,7 @@ async def create_undo_snapshot(
         media_name=media_name,
         snapshot_path=str(Path(UNDO_DIR) / media_name),
         perceptual_hashes=row.perceptual_hashes if row else None,
+        panorama=row.panorama if row else None,
         upgrade_candidate=row.upgrade_candidate if row else True,
         created_at=now,
         expires_at=now + UNDO_TTL,
@@ -206,6 +207,7 @@ async def restore_undo_snapshot(
     row.height = restored.height
     row.byte_size = target.stat().st_size
     row.perceptual_hashes = snap.perceptual_hashes
+    row.panorama = snap.panorama
     row.upgrade_candidate = snap.upgrade_candidate
     row.updated_at = datetime.now(UTC)
     session.add(row)

--- a/backend/app/logic/layout/media.py
+++ b/backend/app/logic/layout/media.py
@@ -1,5 +1,7 @@
-from collections.abc import Iterator
-from contextlib import contextmanager
+import asyncio
+import weakref
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from io import BytesIO
 from pathlib import Path
 from typing import Annotated, Self
@@ -32,6 +34,19 @@ _media_budget = max(256, detect_memory_mb() - _MEDIA_BASELINE_MB)
 media_limiter = anyio.CapacityLimiter(
     max(4, min(40, _media_budget // _PER_MEDIA_OP_MB))
 )
+_generation_locks: weakref.WeakValueDictionary[Path, asyncio.Lock] = (
+    weakref.WeakValueDictionary()
+)
+
+
+@asynccontextmanager
+async def generation_lock(path: Path) -> AsyncIterator[None]:
+    lock = _generation_locks.get(path)
+    if lock is None:
+        lock = asyncio.Lock()
+        _generation_locks[path] = lock
+    async with lock:
+        yield
 
 
 @contextmanager

--- a/backend/app/logic/media_upgrade/pipeline.py
+++ b/backend/app/logic/media_upgrade/pipeline.py
@@ -35,7 +35,7 @@ from app.core.observability import set_span_data, start_span
 from app.core.resources import detect_cpu_count, detect_memory_mb
 from app.core.worker_threads import run_sync
 from app.logic.layout.media import Media, MediaName, is_video, media_limiter
-from app.models.album_media import AlbumMedia
+from app.models.album_media import AlbumMedia, is_panorama_size
 from app.models.google_photos import (
     GoogleMediaBaseUrl,
     GoogleMediaId,
@@ -634,6 +634,8 @@ async def _persist_upgrade_in_session(  # noqa: PLR0913
             continue
         row.width = updated.width
         row.height = updated.height
+        if not is_panorama_size(updated.width, updated.height):
+            row.panorama = None
         row.byte_size = target.stat().st_size
         row.perceptual_hashes = None
         row.upgrade_candidate = False

--- a/backend/app/logic/media_upgrade/processing.py
+++ b/backend/app/logic/media_upgrade/processing.py
@@ -22,6 +22,8 @@ from app.logic.layout.media import (
     media_limiter,
     open_oriented,
 )
+from app.logic.panorama import MAX_PANORAMA_DIMENSION, remove_panorama_derivatives
+from app.models.album_media import is_panorama_size
 
 logger = structlog.get_logger(__name__)
 
@@ -44,8 +46,11 @@ def process_photo_sync(raw_path: Path, tmp_path: Path) -> tuple[int, int]:
         img = raw.convert("RGB")
 
         long_edge = max(img.size)
-        if long_edge > _MAX_LONG_EDGE:
-            scale = _MAX_LONG_EDGE / long_edge
+        limit = (
+            MAX_PANORAMA_DIMENSION if is_panorama_size(*img.size) else _MAX_LONG_EDGE
+        )
+        if long_edge > limit:
+            scale = limit / long_edge
             w, h = img.size
             img = img.resize(
                 (round(w * scale), round(h * scale)),
@@ -221,4 +226,5 @@ async def replace_photo(
         await run_sync(shutil.move, tmp, target)
 
     await run_sync(delete_thumbnails, target)
+    await run_sync(remove_panorama_derivatives, target.parent, name)
     return True

--- a/backend/app/logic/panorama.py
+++ b/backend/app/logic/panorama.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import secrets
+import shutil
+from contextlib import suppress
+from pathlib import Path
+
+from app.core.worker_threads import run_sync
+from app.logic.layout.media import media_limiter
+from app.models.album_media import PanoramaConfig, panorama_captured_fov
+
+MAX_PANORAMA_DIMENSION = 8192
+_PREVIEW_MAX_WIDTH = 2048
+_RENDER_TIMEOUT_SECONDS = 60
+
+
+class PanoramaRenderError(RuntimeError):
+    pass
+
+
+class PanoramaValidationError(ValueError):
+    pass
+
+
+def resolve_panorama_source(album_dir: Path, media_name: str) -> Path:
+    source = (album_dir / media_name).resolve()
+    if not source.is_relative_to(album_dir.resolve()) or not source.is_file():
+        raise FileNotFoundError(media_name)
+    return source
+
+
+def panorama_source_path(
+    album_dir: Path,
+    media_name: str,
+    source: Path,
+) -> Path:
+    return _panorama_dir(album_dir, media_name) / f"source-{_source_key(source)}.jpg"
+
+
+def panorama_render_path(
+    album_dir: Path,
+    media_name: str,
+    source: Path,
+    config: PanoramaConfig,
+) -> Path:
+    key = hashlib.sha256(
+        f"{_source_key(source)}:{config.model_dump_json()}".encode()
+    ).hexdigest()[:16]
+    return _panorama_dir(album_dir, media_name) / f"poster-{key}.jpg"
+
+
+def remove_panorama_derivatives(album_dir: Path, media_name: str) -> None:
+    shutil.rmtree(_panorama_dir(album_dir, media_name), ignore_errors=True)
+
+
+def remove_other_panorama_files(keep: Path) -> None:
+    prefix = keep.name.split("-", 1)[0]
+    for path in keep.parent.glob(f"{prefix}-*.jpg"):
+        if path != keep:
+            path.unlink(missing_ok=True)
+
+
+async def render_panorama(
+    source: Path,
+    config: PanoramaConfig,
+    output: Path,
+    source_size: tuple[int, int],
+) -> None:
+    source_width, source_height = source_size
+    output_size = _output_size(source_width, config.aspect_ratio)
+    _validate_frame(config, source_width, source_height, output_size)
+    await _render_image(
+        source,
+        _filter_graph(config, source_width, source_height, output_size),
+        output,
+    )
+
+
+async def create_panorama_source(
+    source: Path,
+    output: Path,
+    source_width: int,
+    source_height: int,
+) -> None:
+    captured_fov = panorama_captured_fov(source_width, source_height)
+    width = min(_PREVIEW_MAX_WIDTH, round(source_width * 360 / captured_fov))
+    width -= width % 2
+    vertical_fov = 2 * _source_vertical_half_fov(
+        source_width,
+        source_height,
+        captured_fov,
+    )
+    await _render_image(
+        source,
+        (
+            "v360=input=cylindrical:output=equirect:"
+            f"ih_fov={_number(captured_fov)}:"
+            f"iv_fov={_number(vertical_fov)}:"
+            f"w={width}:h={width // 2}"
+        ),
+        output,
+    )
+
+
+def _panorama_dir(album_dir: Path, media_name: str) -> Path:
+    return album_dir / ".panoramas" / Path(media_name).stem
+
+
+def _source_key(source: Path) -> str:
+    stat = source.stat()
+    return f"{stat.st_size:x}-{stat.st_mtime_ns:x}"
+
+
+def _output_size(source_width: int, aspect_ratio: float) -> tuple[int, int]:
+    width = min(source_width, MAX_PANORAMA_DIMENSION)
+    height = round(width / aspect_ratio)
+    if height > MAX_PANORAMA_DIMENSION:
+        height = MAX_PANORAMA_DIMENSION
+        width = round(height * aspect_ratio)
+    return max(2, width - width % 2), max(2, height - height % 2)
+
+
+def _validate_frame(
+    config: PanoramaConfig,
+    source_width: int,
+    source_height: int,
+    output_size: tuple[int, int],
+) -> None:
+    captured_fov = panorama_captured_fov(source_width, source_height)
+    if config.perspective_fov > captured_fov:
+        raise PanoramaValidationError("Perspective FOV exceeds the captured panorama")
+    if abs(config.yaw) > (captured_fov - config.perspective_fov) / 2:
+        raise PanoramaValidationError("Panorama yaw is outside the captured bounds")
+
+    source_vertical_half = _source_vertical_half_fov(
+        source_width,
+        source_height,
+        captured_fov,
+    )
+    output_vertical_half = _output_vertical_fov(config) / 2
+    if abs(config.pitch) > source_vertical_half - output_vertical_half:
+        raise PanoramaValidationError("Panorama pitch is outside the captured bounds")
+    if config.zoom > min(output_size):
+        raise PanoramaValidationError("Panorama zoom produces an empty crop")
+
+
+def _filter_graph(
+    config: PanoramaConfig,
+    source_width: int,
+    source_height: int,
+    output_size: tuple[int, int],
+) -> str:
+    width, height = output_size
+    captured_fov = panorama_captured_fov(source_width, source_height)
+    vertical_fov = 2 * _source_vertical_half_fov(
+        source_width,
+        source_height,
+        captured_fov,
+    )
+    projection = (
+        "v360=input=cylindrical:output=flat:"
+        f"ih_fov={_number(captured_fov)}:"
+        f"iv_fov={_number(vertical_fov)}:"
+        f"yaw={_number(config.yaw)}:"
+        f"pitch={_number(config.pitch)}:"
+        f"h_fov={_number(config.perspective_fov)}:"
+        f"v_fov={_number(_output_vertical_fov(config))}:"
+        f"w={width}:h={height}"
+    )
+    if config.zoom == 1:
+        return projection
+    zoom = _number(config.zoom)
+    return (
+        f"{projection},"
+        f"crop=iw/{zoom}:ih/{zoom}:(iw-iw/{zoom})/2:(ih-ih/{zoom})/2,"
+        f"scale={width}:{height}:flags=lanczos"
+    )
+
+
+def _source_vertical_half_fov(
+    source_width: int,
+    source_height: int,
+    captured_fov: float,
+) -> float:
+    focal_length = source_width / math.radians(captured_fov)
+    return math.degrees(math.atan(source_height / 2 / focal_length))
+
+
+def _output_vertical_fov(config: PanoramaConfig) -> float:
+    return 2 * math.degrees(
+        math.atan(
+            math.tan(math.radians(config.perspective_fov / 2)) / config.aspect_ratio
+        )
+    )
+
+
+async def _render_image(source: Path, filter_graph: str, output: Path) -> None:
+    async with media_limiter:
+        await run_sync(output.parent.mkdir, parents=True, exist_ok=True)
+        temporary = output.parent / f".{output.stem}.{secrets.token_hex(8)}.jpg"
+        process: asyncio.subprocess.Process | None = None
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-nostdin",
+                "-y",
+                "-i",
+                str(source),
+                "-frames:v",
+                "1",
+                "-vf",
+                filter_graph,
+                "-q:v",
+                "2",
+                str(temporary),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=_RENDER_TIMEOUT_SECONDS,
+                )
+            except TimeoutError as error:
+                raise PanoramaRenderError("Panorama rendering timed out") from error
+            await _check_render_result(process, stderr, temporary)
+            await run_sync(temporary.replace, output)
+        except OSError as error:
+            raise PanoramaRenderError(
+                "Unable to run FFmpeg panorama rendering"
+            ) from error
+        except BaseException:
+            await _kill_and_reap(process)
+            raise
+        finally:
+            await run_sync(temporary.unlink, missing_ok=True)
+
+
+async def _kill_and_reap(process: asyncio.subprocess.Process | None) -> None:
+    if process is None or process.returncode is not None:
+        return
+    with suppress(ProcessLookupError):
+        process.kill()
+    await process.communicate()
+
+
+async def _check_render_result(
+    process: asyncio.subprocess.Process,
+    stderr: bytes,
+    output: Path,
+) -> None:
+    if process.returncode != 0:
+        detail = stderr.decode(errors="replace").strip()
+        raise PanoramaRenderError(detail or "FFmpeg failed to render panorama")
+    if not await run_sync(output.is_file):
+        raise PanoramaRenderError("FFmpeg did not produce a panorama image")
+
+
+def _number(value: float) -> str:
+    return format(value, "g")

--- a/backend/app/logic/reconcile.py
+++ b/backend/app/logic/reconcile.py
@@ -34,7 +34,11 @@ from app.logic.trip_processing import (
     track_iter,
 )
 from app.models.album import Album
-from app.models.album_media import AlbumMedia, StepPageMedia, StepUnusedMedia
+from app.models.album_media import (
+    AlbumMedia,
+    StepPageMedia,
+    StepUnusedMedia,
+)
 from app.models.polarsteps import PSStep
 from app.models.step import Step, StepPageLayout, StepRead
 from app.models.user import User
@@ -141,9 +145,8 @@ def _retained_media_state(
     trip_dir: Path,
     all_on_disk: set[str],
     existing_media_rows: list[AlbumMedia],
-) -> tuple[dict[str, list[str]], dict[str, bool]]:
-    retained_hashes: dict[str, list[str]] = {}
-    retained_candidates: dict[str, bool] = {}
+) -> dict[str, AlbumMedia]:
+    retained: dict[str, AlbumMedia] = {}
     for row in existing_media_rows:
         if row.name not in all_on_disk:
             continue
@@ -152,10 +155,8 @@ def _retained_media_state(
         except OSError:
             continue
         if current_size == row.byte_size:
-            retained_candidates[row.name] = row.upgrade_candidate
-            if row.perceptual_hashes is not None:
-                retained_hashes[row.name] = row.perceptual_hashes
-    return retained_hashes, retained_candidates
+            retained[row.name] = row
+    return retained
 
 
 def _fix_album_covers(
@@ -395,7 +396,7 @@ async def reconcile_trip(  # noqa: PLR0913
     merged_media = await _probe_media(
         trip_dir, [*new_step_objects, *reconciled_steps], known_media
     )
-    perceptual_hashes_by_name, upgrade_candidate_by_name = await run_sync(
+    retained_media = await run_sync(
         _retained_media_state, trip_dir, all_on_disk, existing_media_rows
     )
     album_media = build_album_media_rows(
@@ -403,9 +404,16 @@ async def reconcile_trip(  # noqa: PLR0913
         aid,
         trip_dir,
         merged_media,
-        upgrade_candidate_by_name,
-        perceptual_hashes_by_name,
+        {name: row.upgrade_candidate for name, row in retained_media.items()},
+        {
+            name: row.perceptual_hashes
+            for name, row in retained_media.items()
+            if row.perceptual_hashes is not None
+        },
     )
+    for media in album_media:
+        if previous := retained_media.get(media.name):
+            media.panorama = previous.panorama
 
     # Rebuild segments from GPS data (segments are not persisted across
     # re-uploads; always rebuild from GPS locations).

--- a/backend/app/models/album_media.py
+++ b/backend/app/models/album_media.py
@@ -6,10 +6,30 @@ from typing import Literal
 import sqlalchemy as sa
 
 # Pydantic resolves this annotation while constructing the SQLModel.
+from pydantic import BaseModel, Field as PydanticField, computed_field
 from pydantic.json_schema import SkipJsonSchema  # noqa: TC002
 from sqlmodel import Field, SQLModel
 
+from app.core.db import PydanticJSON
+
 type StepPageKind = Literal["grid", "panorama_spread"]
+MIN_PANORAMA_ASPECT_RATIO = 2
+
+
+def is_panorama_size(width: int, height: int) -> bool:
+    return height > 0 and width / height >= MIN_PANORAMA_ASPECT_RATIO
+
+
+def panorama_captured_fov(width: int, height: int) -> float:
+    return min(359, 90 * width / height)
+
+
+class PanoramaConfig(BaseModel):
+    yaw: float = PydanticField(default=0, ge=-360, le=360)
+    pitch: float = PydanticField(default=0, ge=-90, le=90)
+    perspective_fov: float = PydanticField(default=70, gt=0, lt=180)
+    zoom: float = PydanticField(default=1, ge=1)
+    aspect_ratio: float = PydanticField(default=2, gt=0, le=10)
 
 
 class AlbumMedia(SQLModel, table=True):
@@ -34,6 +54,10 @@ class AlbumMedia(SQLModel, table=True):
         exclude=True,
         sa_column=sa.Column(sa.JSON(none_as_null=True), nullable=True),
     )
+    panorama: PanoramaConfig | None = Field(
+        default=None,
+        sa_column=sa.Column(PydanticJSON(PanoramaConfig), nullable=True),
+    )
     upgrade_candidate: bool = Field(default=True)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
@@ -43,6 +67,11 @@ class AlbumMedia(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=sa.Column(sa.DateTime(timezone=True), nullable=False),
     )
+
+    @computed_field
+    @property
+    def panorama_candidate(self) -> bool:
+        return self.kind == "photo" and is_panorama_size(self.width, self.height)
 
 
 class StepPageMedia(SQLModel, table=True):
@@ -111,6 +140,10 @@ class AlbumMediaUndoSnapshot(SQLModel, table=True):
         default=None,
         exclude=True,
         sa_column=sa.Column(sa.JSON(none_as_null=True), nullable=True),
+    )
+    panorama: PanoramaConfig | None = Field(
+        default=None,
+        sa_column=sa.Column(PydanticJSON(PanoramaConfig), nullable=True),
     )
     upgrade_candidate: bool
     created_at: datetime = Field(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2105,6 +2105,218 @@
         }
       }
     },
+    "/api/v1/albums/{aid}/media/{name}/panorama": {
+      "put": {
+        "tags": [
+          "panoramas"
+        ],
+        "summary": "Update Panorama",
+        "operationId": "update_panorama",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|mp4)$",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PanoramaConfig"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumMedia"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "panoramas"
+        ],
+        "summary": "Disable Panorama",
+        "operationId": "disable_panorama",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|mp4)$",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumMedia"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/albums/{aid}/media/{name}/panorama-source": {
+      "get": {
+        "tags": [
+          "panoramas"
+        ],
+        "summary": "Get Panorama Source",
+        "operationId": "get_panorama_source",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|mp4)$",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/albums/{aid}/media/{name}/panorama-render": {
+      "get": {
+        "tags": [
+          "panoramas"
+        ],
+        "summary": "Get Panorama Render",
+        "operationId": "get_panorama_render",
+        "parameters": [
+          {
+            "name": "aid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Aid"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|mp4)$",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/google-photos/authorize": {
       "get": {
         "tags": [
@@ -2644,6 +2856,16 @@
             "type": "integer",
             "title": "Byte Size"
           },
+          "panorama": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PanoramaConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "upgrade_candidate": {
             "type": "boolean",
             "title": "Upgrade Candidate",
@@ -2658,6 +2880,11 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "panorama_candidate": {
+            "type": "boolean",
+            "title": "Panorama Candidate",
+            "readOnly": true
           }
         },
         "type": "object",
@@ -2668,7 +2895,8 @@
           "kind",
           "width",
           "height",
-          "byte_size"
+          "byte_size",
+          "panorama_candidate"
         ],
         "title": "AlbumMedia"
       },
@@ -3631,6 +3859,46 @@
           "distance"
         ],
         "title": "MatchResult"
+      },
+      "PanoramaConfig": {
+        "properties": {
+          "yaw": {
+            "type": "number",
+            "maximum": 360.0,
+            "minimum": -360.0,
+            "title": "Yaw",
+            "default": 0
+          },
+          "pitch": {
+            "type": "number",
+            "maximum": 90.0,
+            "minimum": -90.0,
+            "title": "Pitch",
+            "default": 0
+          },
+          "perspective_fov": {
+            "type": "number",
+            "exclusiveMaximum": 180.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Perspective Fov",
+            "default": 70
+          },
+          "zoom": {
+            "type": "number",
+            "minimum": 1.0,
+            "title": "Zoom",
+            "default": 1
+          },
+          "aspect_ratio": {
+            "type": "number",
+            "maximum": 10.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Aspect Ratio",
+            "default": 2
+          }
+        },
+        "type": "object",
+        "title": "PanoramaConfig"
       },
       "PdfDone": {
         "properties": {

--- a/backend/tests/test_albums_media.py
+++ b/backend/tests/test_albums_media.py
@@ -32,6 +32,8 @@ async def test_read_media_returns_album_media_rows(
             "height": 1080,
             "byte_size": 1234,
             "upgrade_candidate": True,
+            "panorama_candidate": False,
+            "panorama": None,
             "created_at": media.created_at.isoformat().replace("+00:00", "Z"),
             "updated_at": media.updated_at.isoformat().replace("+00:00", "Z"),
         }

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -2,8 +2,8 @@ import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.api.v1.routes.assets import _gen_lock, get_media, update_video_frame
-from app.logic.layout.media import THUMB_WIDTHS, generate_thumbnail
+from app.api.v1.routes.assets import get_media, update_video_frame
+from app.logic.layout.media import THUMB_WIDTHS, generate_thumbnail, generation_lock
 from tests.factories import create_test_jpeg
 
 _AID = "test-album-id"
@@ -128,7 +128,7 @@ class TestGenLockConcurrency:
         gate = asyncio.Event()
 
         async def worker(n: int) -> None:
-            async with _gen_lock(path):
+            async with generation_lock(path):
                 order.append(n)
                 if n == 1:
                     # Hold the lock until we've verified #2 and #3 are queued.

--- a/backend/tests/test_external_media_operations.py
+++ b/backend/tests/test_external_media_operations.py
@@ -19,7 +19,7 @@ from app.logic.external_media.undo import (
 from app.logic.layout.media import Media
 from app.logic.media_import import SavedInput
 from app.models.album import Album
-from app.models.album_media import AlbumMedia, AlbumMediaUndoSnapshot
+from app.models.album_media import AlbumMedia, AlbumMediaUndoSnapshot, PanoramaConfig
 
 from .factories import (
     AID,
@@ -218,9 +218,12 @@ async def test_replace_preserves_media_name_and_creates_undo(
     uid = 1
     album_dir = tmp_path
     album, media = await _album_with_photo(session, album_dir, uid=uid)
+    media.width = 4000
+    media.height = 1000
+    media.panorama = PanoramaConfig(aspect_ratio=2)
     media.perceptual_hashes = ["0000000000000000"]
     session.add(media)
-    replacement = create_test_jpeg(tmp_path / "replacement.jpg", 1600, 1200)
+    replacement = create_test_jpeg(tmp_path / "replacement.jpg", 3200, 1000)
     await session.commit()
 
     result = await replace_album_media_from_saved(
@@ -233,8 +236,9 @@ async def test_replace_preserves_media_name_and_creates_undo(
 
     assert result.name == VALID_NAME
     row = await session.get_one(AlbumMedia, (uid, AID, VALID_NAME))
-    assert row.width == 1600
-    assert row.height == 1200
+    assert row.width == 3200
+    assert row.height == 1000
+    assert row.panorama == PanoramaConfig(aspect_ratio=2)
     assert row.upgrade_candidate is False
     assert row.perceptual_hashes not in (None, ["0000000000000000"])
     snap = await session.get_one(AlbumMediaUndoSnapshot, (uid, AID, VALID_NAME))

--- a/backend/tests/test_media_upgrade.py
+++ b/backend/tests/test_media_upgrade.py
@@ -41,6 +41,7 @@ from app.logic.media_upgrade.processing import (
     process_photo_sync,
     process_video,
 )
+from app.models.album_media import PanoramaConfig
 from app.models.google_photos import GoogleMediaFile, GoogleMediaType, PickedMediaItem
 
 from .factories import AID, create_test_jpeg, insert_album, insert_album_media
@@ -316,6 +317,15 @@ class TestProcessPhoto:
         with Image.open(out) as result:
             assert result.size == expected_size
 
+    def test_retains_more_resolution_for_panorama(self, tmp_path: Path) -> None:
+        raw = tmp_path / "in.jpg"
+        out = tmp_path / "out.jpg"
+        _write_jpeg(raw, 9000, 3000)
+
+        size = process_photo_sync(raw, out)
+
+        assert size == (8192, 2731)
+
     def test_converts_png_to_jpeg(self, tmp_path: Path) -> None:
         raw = tmp_path / "in.png"
         out = tmp_path / "out.jpg"
@@ -410,9 +420,12 @@ class TestPersistUpgrade:
         await insert_album(session, uid)
         media = await insert_album_media(session, uid, name="photo.jpg")
         media.byte_size = 1
+        media.width = 4000
+        media.height = 1000
+        media.panorama = PanoramaConfig(aspect_ratio=2)
         media.perceptual_hashes = ["0123456789abcdef"]
         session.add(media)
-        target = create_test_jpeg(tmp_path / "photo.jpg", 1200, 800)
+        target = create_test_jpeg(tmp_path / "photo.jpg", 3200, 1000)
         await session.commit()
 
         await _persist_upgrade_in_session(
@@ -428,6 +441,7 @@ class TestPersistUpgrade:
         await session.refresh(media)
 
         assert media.byte_size == target.stat().st_size
+        assert media.panorama == PanoramaConfig(aspect_ratio=2)
         assert media.perceptual_hashes is None
         assert media.upgrade_candidate is False
 

--- a/backend/tests/test_panorama_render.py
+++ b/backend/tests/test_panorama_render.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app.logic.panorama import (
+    PanoramaValidationError,
+    _filter_graph,
+    _output_size,
+    _validate_frame,
+    create_panorama_source,
+    panorama_render_path,
+    panorama_source_path,
+    render_panorama,
+    resolve_panorama_source,
+)
+from app.models.album_media import PanoramaConfig, panorama_captured_fov
+
+
+def _config(**updates: float) -> PanoramaConfig:
+    return PanoramaConfig.model_validate(
+        {
+            "yaw": 0,
+            "pitch": 0,
+            "perspective_fov": 60,
+            "zoom": 1,
+            "aspect_ratio": 2,
+        }
+        | updates
+    )
+
+
+def _source(path: Path) -> None:
+    Image.new("RGB", (400, 200), "steelblue").save(path)
+
+
+def test_captured_fov_is_derived_from_aspect_ratio() -> None:
+    assert panorama_captured_fov(400, 200) == 180
+    assert panorama_captured_fov(1200, 200) == 359
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        _config(yaw=61),
+        _config(pitch=30),
+        _config(zoom=201),
+    ],
+)
+def test_frame_rejects_views_outside_source(config: PanoramaConfig) -> None:
+    with pytest.raises(PanoramaValidationError):
+        _validate_frame(config, 400, 200, _output_size(400, config.aspect_ratio))
+
+
+def test_filter_keeps_perspective_and_zoom_independent() -> None:
+    config = _config(perspective_fov=55, zoom=1.8)
+
+    graph = _filter_graph(config, 400, 200, _output_size(400, config.aspect_ratio))
+
+    assert "h_fov=55" in graph
+    assert "crop=iw/1.8:ih/1.8" in graph
+
+
+async def test_source_and_poster_render_with_ffmpeg(tmp_path: Path) -> None:
+    source = tmp_path / "source.jpg"
+    preview = tmp_path / "preview.jpg"
+    output = tmp_path / "frame.jpg"
+    _source(source)
+
+    await create_panorama_source(source, preview, 400, 200)
+    await render_panorama(source, _config(), output, (400, 200))
+
+    with Image.open(preview) as image:
+        assert image.size == (800, 400)
+    with Image.open(output) as image:
+        assert image.size == (400, 200)
+
+
+def test_cached_files_track_source_and_frame(tmp_path: Path) -> None:
+    source = tmp_path / "source.jpg"
+    _source(source)
+    initial_source = panorama_source_path(tmp_path, "source.jpg", source)
+    initial_poster = panorama_render_path(tmp_path, "source.jpg", source, _config())
+
+    source.write_bytes(source.read_bytes() + b"x")
+
+    assert panorama_source_path(tmp_path, "source.jpg", source) != initial_source
+    assert (
+        panorama_render_path(tmp_path, "source.jpg", source, _config())
+        != initial_poster
+    )
+    assert (
+        panorama_render_path(
+            tmp_path,
+            "source.jpg",
+            source,
+            _config(aspect_ratio=1.5),
+        )
+        != initial_poster
+    )
+
+
+def test_source_must_stay_inside_album(tmp_path: Path) -> None:
+    album = tmp_path / "album"
+    album.mkdir()
+    outside = tmp_path / "outside.jpg"
+    _source(outside)
+
+    with pytest.raises(FileNotFoundError):
+        resolve_panorama_source(album, "../outside.jpg")

--- a/backend/tests/test_panoramas_api.py
+++ b/backend/tests/test_panoramas_api.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.worker_threads import run_sync
+from app.logic.panorama import PanoramaRenderError
+from app.models.album_media import AlbumMedia, PanoramaConfig
+from tests.factories import AID, sign_in_with_album_media
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+def _body() -> dict[str, Any]:
+    return {
+        "yaw": 10,
+        "pitch": 2,
+        "perspective_fov": 55,
+        "zoom": 1.5,
+        "aspect_ratio": 2,
+    }
+
+
+async def _scenario(
+    client: AsyncClient,
+    session: AsyncSession,
+    *,
+    width: int = 1600,
+    height: int = 800,
+) -> tuple[AlbumMedia, Path]:
+    scenario = await sign_in_with_album_media(
+        client,
+        session,
+        width=width,
+        height=height,
+        write_media=True,
+    )
+    row = await session.get_one(
+        AlbumMedia,
+        (scenario.uid, AID, scenario.media_name),
+    )
+    return row, scenario.album_dir
+
+
+async def _write_render(
+    _source: Path,
+    _config: PanoramaConfig,
+    output: Path,
+    _source_size: tuple[int, int],
+) -> None:
+    await run_sync(output.parent.mkdir, parents=True, exist_ok=True)
+    await run_sync(output.write_bytes, b"rendered")
+
+
+async def test_put_saves_one_global_poster(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    row, album_dir = await _scenario(client, session)
+
+    with patch(
+        "app.api.v1.routes.panoramas.render_panorama", side_effect=_write_render
+    ) as render:
+        response = await client.put(
+            f"/api/v1/albums/{AID}/media/{row.name}/panorama",
+            json=_body(),
+        )
+        poster = await client.get(
+            f"/api/v1/albums/{AID}/media/{row.name}/panorama-render"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["panorama"] == _body()
+    assert poster.status_code == 200
+    assert poster.content == b"rendered"
+    assert render.call_count == 1
+    assert len(list((album_dir / ".panoramas").rglob("poster-*.jpg"))) == 1
+
+
+async def test_failed_put_preserves_saved_frame(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    row, _album_dir = await _scenario(client, session)
+    row.panorama = PanoramaConfig(aspect_ratio=2)
+    key = (row.uid, row.aid, row.name)
+    session.add(row)
+    await session.commit()
+
+    with patch(
+        "app.api.v1.routes.panoramas.render_panorama",
+        side_effect=PanoramaRenderError("failed"),
+    ):
+        response = await client.put(
+            f"/api/v1/albums/{AID}/media/{row.name}/panorama",
+            json=_body(),
+        )
+
+    assert response.status_code == 500
+    async with AsyncSession(
+        bind=session.bind,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    ) as check_session:
+        stored = await check_session.get_one(AlbumMedia, key)
+    assert stored.panorama == PanoramaConfig(aspect_ratio=2)
+
+
+async def test_source_is_available_before_a_frame_is_saved(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    row, album_dir = await _scenario(client, session)
+
+    response = await client.get(
+        f"/api/v1/albums/{AID}/media/{row.name}/panorama-source"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    assert next((album_dir / ".panoramas").rglob("source-*.jpg")).is_file()
+
+
+async def test_delete_returns_panorama_to_normal_photo(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    row, album_dir = await _scenario(client, session)
+    row.panorama = PanoramaConfig(aspect_ratio=2)
+    session.add(row)
+    await session.commit()
+    derivatives = album_dir / ".panoramas" / Path(row.name).stem
+    derivatives.mkdir(parents=True)
+    (derivatives / "poster-old.jpg").write_bytes(b"rendered")
+
+    response = await client.delete(f"/api/v1/albums/{AID}/media/{row.name}/panorama")
+
+    assert response.status_code == 200
+    assert response.json()["panorama"] is None
+    assert not derivatives.exists()
+    assert (album_dir / row.name).is_file()
+
+
+async def test_regular_photo_is_not_a_panorama_candidate(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    row, _album_dir = await _scenario(client, session, width=1200, height=800)
+
+    source = await client.get(f"/api/v1/albums/{AID}/media/{row.name}/panorama-source")
+    update = await client.put(
+        f"/api/v1/albums/{AID}/media/{row.name}/panorama",
+        json=_body(),
+    )
+
+    assert source.status_code == 400
+    assert update.status_code == 400


### PR DESCRIPTION
- recognize phone panoramas once in the backend and expose candidacy with media
- save one global frame and one cached poster per source and configuration
- render through FFmpeg v360 while ordinary layouts crop the poster like any photo
- preserve panorama frames across same-kind replacements and invalidate derived files
- reuse the existing media generation lock instead of adding panorama-specific cache machinery