### PR TITLE
fix: reload stale frontend across releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ COPY frontend ./
 COPY PRIVACY.md TERMS.md /app/
 COPY backend/openapi.json /app/backend/openapi.json
 
+ARG APP_VERSION
+ENV VITE_APP_VERSION=$APP_VERSION
 RUN bun run build
 
 COPY --from=sentry-cli /bin/sentry-cli /usr/local/bin/sentry-cli

--- a/backend/app/frontend.py
+++ b/backend/app/frontend.py
@@ -68,6 +68,8 @@ def install_frontend(app: FastAPI, settings: Settings) -> None:
     ) -> Response:
         response = await call_next(request)
         response.headers["Content-Security-Policy"] = content_security_policy
+        if settings.APP_VERSION:
+            response.headers["X-Wanderbound-Version"] = settings.APP_VERSION
         if request.url.path.startswith("/assets/") and response.status_code < 400:
             response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
         elif response.headers.get("Content-Type", "").startswith("text/html"):

--- a/frontend/smoke/smoke.test.ts
+++ b/frontend/smoke/smoke.test.ts
@@ -24,6 +24,18 @@ test.describe("Stack smoke tests", () => {
     expect(headers["cache-control"]).toBe("no-cache");
   });
 
+  test("API advertises the image version", async ({ page }) => {
+    const configResponse = page.waitForResponse((response) =>
+      response.url().endsWith("/api/v1/config"),
+    );
+
+    await page.goto("/");
+
+    const response = await configResponse;
+    const expected = process.env.APP_VERSION ?? "dev";
+    expect(response.headers()["x-wanderbound-version"]).toBe(expected);
+  });
+
   test("static assets have immutable cache headers", async ({ page }) => {
     const assetResponse = page.waitForResponse((r) =>
       r.url().includes("/assets/"),

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,11 +26,13 @@ import { useChunkErrorRecovery } from "@/composables/useChunkErrorRecovery";
 import { client } from "@/client/client.gen";
 import { loadSettings } from "@/config";
 import { setupSentry } from "@/plugins/sentry";
+import { setupVersionSkewRecovery } from "@/plugins/versionSkew";
 
 client.setConfig({
   baseUrl: "",
   credentials: "include",
 });
+setupVersionSkewRecovery(client);
 const settings = await loadSettings();
 
 const app = createApp(App);

--- a/frontend/src/plugins/sentry.ts
+++ b/frontend/src/plugins/sentry.ts
@@ -3,6 +3,7 @@ import type { Pinia } from "pinia";
 import type { App } from "vue";
 import type { Router } from "vue-router";
 import type { Settings } from "@/config";
+import { BUILD_VERSION } from "@/plugins/versionSkew";
 
 const PRELOAD_ERROR_PATTERNS = [
   "Failed to fetch dynamically imported module",
@@ -37,9 +38,7 @@ export function setupSentry(
     app,
     dsn: settings.PUBLIC_SENTRY_DSN ?? undefined,
     environment: settings.ENVIRONMENT,
-    release: settings.APP_VERSION
-      ? `wanderbound@${settings.APP_VERSION}`
-      : undefined,
+    release: BUILD_VERSION ? `wanderbound@${BUILD_VERSION}` : undefined,
     integrations: [
       Sentry.feedbackIntegration({
         autoInject: true,

--- a/frontend/src/plugins/versionSkew.ts
+++ b/frontend/src/plugins/versionSkew.ts
@@ -1,0 +1,22 @@
+import type { Client } from "@/client/client";
+
+const VERSION_HEADER = "X-Wanderbound-Version";
+export const BUILD_VERSION = import.meta.env.VITE_APP_VERSION || undefined;
+
+export function setupVersionSkewRecovery(
+  client: Client,
+  frontendVersion = BUILD_VERSION,
+  reload = () => window.location.reload(),
+): void {
+  if (!frontendVersion) return;
+
+  client.interceptors.response.use((response) => {
+    const serverVersion = response.headers.get(VERSION_HEADER);
+    if (!serverVersion || serverVersion === frontendVersion) return response;
+
+    reload();
+    throw new Error(
+      `Frontend ${frontendVersion} cannot use API ${serverVersion}; reloading`,
+    );
+  });
+}

--- a/frontend/tests/plugins/sentryUpload.test.ts
+++ b/frontend/tests/plugins/sentryUpload.test.ts
@@ -1,4 +1,21 @@
-import { isSensitiveUploadUrl } from "@/plugins/sentry";
+import { createPinia } from "pinia";
+import { createApp } from "vue";
+import { createRouter, createWebHistory } from "vue-router";
+import type { Settings } from "@/config";
+
+const sentry = vi.hoisted(() => ({
+  browserTracingIntegration: vi.fn(() => ({})),
+  createSentryPiniaPlugin: vi.fn(() => () => undefined),
+  feedbackIntegration: vi.fn(() => ({})),
+  init: vi.fn(),
+  replayIntegration: vi.fn(() => ({})),
+  thirdPartyErrorFilterIntegration: vi.fn(() => ({})),
+}));
+
+vi.mock("@sentry/vue", () => sentry);
+vi.mock("@/plugins/versionSkew", () => ({ BUILD_VERSION: "1.8.3" }));
+
+import { isSensitiveUploadUrl, setupSentry } from "@/plugins/sentry";
 
 it("recognizes upload bearer credentials without treating ordinary URLs as sensitive", () => {
   expect(
@@ -9,4 +26,22 @@ it("recognizes upload bearer credentials without treating ordinary URLs as sensi
   expect(
     isSensitiveUploadUrl("/api/v1/users/uploads/id?key=uploads%2Fid.zip"),
   ).toBe(false);
+});
+
+it("attributes events to the frontend build instead of the server version", () => {
+  const app = createApp({});
+  const router = createRouter({ history: createWebHistory(), routes: [] });
+  const pinia = createPinia();
+  const settings = {
+    APP_VERSION: "1.10.0",
+    ENVIRONMENT: "production",
+    PUBLIC_SENTRY_DSN: "https://public@example.invalid/1",
+    SENTRY_TRACES_SAMPLE_RATE: 0.1,
+  } as Settings;
+
+  setupSentry(app, router, pinia, settings);
+
+  expect(sentry.init).toHaveBeenCalledWith(
+    expect.objectContaining({ release: "wanderbound@1.8.3" }),
+  );
 });

--- a/frontend/tests/plugins/versionSkew.test.ts
+++ b/frontend/tests/plugins/versionSkew.test.ts
@@ -1,0 +1,49 @@
+import { createClient } from "@/client/client";
+import { setupVersionSkewRecovery } from "@/plugins/versionSkew";
+
+const responseHeaders = {
+  "Content-Type": "application/json",
+  "X-Wanderbound-Version": "1.11.0",
+};
+
+it("reloads and rejects an API response from an incompatible release", async () => {
+  const fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ pages: [{ kind: "grid", media: [] }] }), {
+        headers: responseHeaders,
+      }),
+    ),
+  );
+  const reload = vi.fn();
+  const client = createClient({
+    baseUrl: "https://example.invalid",
+    fetch,
+    throwOnError: true,
+  });
+  setupVersionSkewRecovery(client, "1.10.0", reload);
+
+  await expect(client.get({ url: "/api/v1/albums/1/steps" })).rejects.toThrow(
+    "Frontend 1.10.0 cannot use API 1.11.0; reloading",
+  );
+  expect(reload).toHaveBeenCalledOnce();
+});
+
+it("accepts responses from an unversioned local API", async () => {
+  const fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+  const reload = vi.fn();
+  const client = createClient({
+    baseUrl: "https://example.invalid",
+    fetch,
+    throwOnError: true,
+  });
+  setupVersionSkewRecovery(client, "1.11.0", reload);
+
+  await expect(client.get({ url: "/api/v1/health" })).resolves.toBeDefined();
+  expect(reload).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
- embed the image version into the frontend build and use it for Sentry releases
- advertise the running API version in one response header
- reload before an incompatible API payload reaches a stale frontend
