### PR TITLE
feat: report storage usage metrics

### DIFF
--- a/backend/app/logic/eviction.py
+++ b/backend/app/logic/eviction.py
@@ -11,32 +11,14 @@ from app.core.config import get_settings
 from app.core.db import get_engine
 from app.core.observability import set_span_data, start_span
 from app.core.resources import MiB
+from app.logic.storage_metrics import (
+    capture_media_storage_metrics,
+    sizes_by_album as _sizes_by_album,
+)
 from app.models.album import Album
 from app.models.user import User
 
 logger = structlog.get_logger(__name__)
-
-
-def _sizes_by_album(users_folder: Path) -> tuple[int, dict[tuple[int, str], int]]:
-    if not users_folder.exists():
-        return 0, {}
-    by_album: dict[tuple[int, str], int] = {}
-    for user_folder in users_folder.iterdir():
-        try:
-            uid = int(user_folder.name)
-        except ValueError:
-            continue
-        trips_folder = user_folder / "trip"
-        if not trips_folder.is_dir():
-            continue
-        for album_folder in trips_folder.iterdir():
-            if album_folder.is_dir():
-                by_album[(uid, album_folder.name)] = sum(
-                    file.stat().st_size
-                    for file in album_folder.rglob("*")
-                    if file.is_file()
-                )
-    return sum(by_album.values()), by_album
 
 
 def _remove_tree(path: Path) -> None:
@@ -99,6 +81,7 @@ async def run_eviction(skip_uid: int) -> None:
                 "album.count": len(sizes),
             },
         )
+    capture_media_storage_metrics(total, cap)
     if total <= cap:
         return
 
@@ -182,4 +165,5 @@ async def run_eviction(skip_uid: int) -> None:
                 },
             )
 
+    capture_media_storage_metrics(total, cap)
     logger.info("eviction.completed", storage_mb=total // MiB)

--- a/backend/app/logic/storage_metrics.py
+++ b/backend/app/logic/storage_metrics.py
@@ -1,0 +1,60 @@
+import asyncio
+import shutil
+from pathlib import Path
+
+import sentry_sdk
+import structlog
+
+_CAPTURE_INTERVAL_SECONDS = 300
+logger = structlog.get_logger(__name__)
+
+
+def sizes_by_album(users_folder: Path) -> tuple[int, dict[tuple[int, str], int]]:
+    if not users_folder.exists():
+        return 0, {}
+    by_album: dict[tuple[int, str], int] = {}
+    for user_folder in users_folder.iterdir():
+        try:
+            uid = int(user_folder.name)
+        except ValueError:
+            continue
+        trips_folder = user_folder / "trip"
+        if not trips_folder.is_dir():
+            continue
+        for album_folder in trips_folder.iterdir():
+            if album_folder.is_dir():
+                by_album[(uid, album_folder.name)] = sum(
+                    file.stat().st_size
+                    for file in album_folder.rglob("*")
+                    if file.is_file()
+                )
+    return sum(by_album.values()), by_album
+
+
+def capture_media_storage_metrics(used_bytes: int, limit_bytes: int) -> None:
+    sentry_sdk.metrics.gauge("storage.media.used_bytes", used_bytes, unit="byte")
+    sentry_sdk.metrics.gauge("storage.media.limit_bytes", limit_bytes, unit="byte")
+    sentry_sdk.metrics.gauge(
+        "storage.media.utilization",
+        used_bytes / limit_bytes * 100,
+        unit="percent",
+    )
+
+
+def capture_filesystem_storage_metrics(data_folder: Path) -> None:
+    usage = shutil.disk_usage(data_folder)
+    sentry_sdk.metrics.gauge(
+        "storage.filesystem.available_bytes", usage.free, unit="byte"
+    )
+    sentry_sdk.metrics.gauge(
+        "storage.filesystem.capacity_bytes", usage.total, unit="byte"
+    )
+
+
+async def storage_metrics_loop(data_folder: Path) -> None:
+    while True:
+        try:
+            capture_filesystem_storage_metrics(data_folder)
+        except Exception:
+            logger.exception("storage.metrics_capture_failed")
+        await asyncio.sleep(_CAPTURE_INTERVAL_SECONDS)

--- a/backend/app/logic/storage_metrics.py
+++ b/backend/app/logic/storage_metrics.py
@@ -49,6 +49,11 @@ def capture_filesystem_storage_metrics(data_folder: Path) -> None:
     sentry_sdk.metrics.gauge(
         "storage.filesystem.capacity_bytes", usage.total, unit="byte"
     )
+    sentry_sdk.metrics.gauge(
+        "storage.filesystem.utilization",
+        usage.used / usage.total * 100,
+        unit="percent",
+    )
 
 
 async def storage_metrics_loop(data_folder: Path) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.logic.media_upgrade.pipeline import cleanup_orphaned_tmp
 from app.logic.pdf import lifespan as pdf_lifespan
 from app.logic.segment_routes import set_route_enrichment_http_clients
 from app.logic.session import cancel_all_sessions
+from app.logic.storage_metrics import storage_metrics_loop
 from app.logic.uploads.cleanup import upload_cleanup_loop
 from app.logic.workflows.media_hashes import (
     media_hash_reconciliation_loop,
@@ -109,6 +110,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:  # noqa: PLR0915
                         has_admin_server=lambda: admin_state.has_admin_server,
                     )
                 )
+                storage_metrics_task = asyncio.create_task(
+                    storage_metrics_loop(settings.DATA_FOLDER)
+                )
                 media_hash_reconciliation_task = asyncio.create_task(
                     media_hash_reconciliation_loop()
                 )
@@ -137,6 +141,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:  # noqa: PLR0915
                 try:
                     yield
                 finally:
+                    storage_metrics_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await storage_metrics_task
                     upload_cleanup_task.cancel()
                     with suppress(asyncio.CancelledError):
                         await upload_cleanup_task

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -79,9 +79,15 @@ class TestRunEviction:
 
         _make_file(users_dir / "1" / "trip" / "a" / "data.bin", 100)
 
-        await run_eviction(skip_uid=999)
+        with patch("sentry_sdk.metrics.gauge") as gauge:
+            await run_eviction(skip_uid=999)
 
         assert (users_dir / "1" / "trip" / "a" / "data.bin").exists()
+        assert gauge.call_args_list == [
+            call("storage.media.used_bytes", 100, unit="byte"),
+            call("storage.media.limit_bytes", 1000, unit="byte"),
+            call("storage.media.utilization", 10.0, unit="percent"),
+        ]
 
     async def test_evicts_lru_album_without_removing_its_user(
         self, tmp_path: Path, users_dir: Path, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/test_main_lifespan.py
+++ b/backend/tests/test_main_lifespan.py
@@ -29,6 +29,7 @@ async def test_lifespan_initializes_workflow_clients_before_launch(
     app = SimpleNamespace(state=SimpleNamespace())
     launch_calls: list[bool | None] = []
     reconciliation_calls: list[list[bool | None]] = []
+    metrics_calls: list[Path] = []
 
     def locked(_key: str) -> object:
         acquired = True
@@ -50,6 +51,10 @@ async def test_lifespan_initializes_workflow_clients_before_launch(
     async def reconcile_hashes() -> None:
         reconciliation_calls.append(list(launch_calls))
 
+    async def capture_storage_metrics(data_folder: Path) -> None:
+        metrics_calls.append(data_folder)
+        await asyncio.Event().wait()
+
     upload_store = SimpleNamespace(close=lambda: None)
 
     monkeypatch.setattr(settings, "DATA_FOLDER", tmp_path)
@@ -70,13 +75,16 @@ async def test_lifespan_initializes_workflow_clients_before_launch(
     monkeypatch.setattr("app.main.workflow_recovery_loop", _forever)
     monkeypatch.setattr("app.main.media_hash_reconciliation_loop", _forever)
     monkeypatch.setattr("app.main.upload_cleanup_loop", _forever)
+    monkeypatch.setattr("app.main.storage_metrics_loop", capture_storage_metrics)
 
     async with lifespan(app):
+        await asyncio.sleep(0)
         assert app.state.http is http
         assert app.state.upload_store is upload_store
 
     assert launch_calls == [True]
     assert reconciliation_calls == [[True]]
+    assert metrics_calls == [tmp_path]
 
 
 async def _noop_cleanup(_path: Path) -> None:

--- a/backend/tests/test_storage_metrics.py
+++ b/backend/tests/test_storage_metrics.py
@@ -1,0 +1,72 @@
+import asyncio
+import shutil
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+
+from app.logic import storage_metrics
+
+
+def test_capture_filesystem_storage_metrics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    usage = shutil._ntuple_diskusage(total=50_000, used=12_000, free=38_000)
+    monkeypatch.setattr(shutil, "disk_usage", lambda _path: usage)
+
+    with patch("sentry_sdk.metrics.gauge") as gauge:
+        storage_metrics.capture_filesystem_storage_metrics(tmp_path)
+
+    assert gauge.call_args_list == [
+        call("storage.filesystem.available_bytes", 38_000, unit="byte"),
+        call("storage.filesystem.capacity_bytes", 50_000, unit="byte"),
+    ]
+
+
+async def test_storage_metrics_loop_reports_immediately_and_repeats(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    filesystem_captures: list[Path] = []
+
+    def capture_filesystem(path: Path) -> None:
+        filesystem_captures.append(path)
+
+    async def sleep(_seconds: float) -> None:
+        if len(filesystem_captures) == 2:
+            raise RuntimeError("stop loop")
+
+    monkeypatch.setattr(
+        storage_metrics, "capture_filesystem_storage_metrics", capture_filesystem
+    )
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="stop loop"):
+        await storage_metrics.storage_metrics_loop(tmp_path)
+
+    assert filesystem_captures == [tmp_path, tmp_path]
+
+
+async def test_storage_metrics_loop_recovers_after_capture_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    attempts = 0
+
+    def capture_filesystem(_path: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("storage unavailable")
+
+    async def sleep(_seconds: float) -> None:
+        if attempts == 2:
+            raise RuntimeError("stop loop")
+
+    monkeypatch.setattr(
+        storage_metrics, "capture_filesystem_storage_metrics", capture_filesystem
+    )
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="stop loop"):
+        await storage_metrics.storage_metrics_loop(tmp_path)
+
+    assert attempts == 2

--- a/backend/tests/test_storage_metrics.py
+++ b/backend/tests/test_storage_metrics.py
@@ -20,6 +20,7 @@ def test_capture_filesystem_storage_metrics(
     assert gauge.call_args_list == [
         call("storage.filesystem.available_bytes", 38_000, unit="byte"),
         call("storage.filesystem.capacity_bytes", 50_000, unit="byte"),
+        call("storage.filesystem.utilization", 24.0, unit="percent"),
     ]
 
 


### PR DESCRIPTION
- emit logical media used, limit, and utilization gauges from the existing eviction scan
- emit filesystem available bytes, capacity bytes, and utilization percentage every five minutes
- keep periodic filesystem reporting alive after capture failures
