### PR TITLE
fix: run Playwright only during PDF renders

### DIFF
--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -123,8 +123,9 @@ async def apply_update[M: SQLModel](
     return obj
 
 
-async def _get_browser(request: Request) -> Browser:
-    return await request.app.state.browser_manager.get()
+async def _get_browser(request: Request) -> AsyncGenerator[Browser]:
+    async with request.app.state.browser_manager.acquire() as browser:
+        yield browser
 
 
 BrowserDep = Annotated[Browser, Depends(_get_browser)]

--- a/backend/app/api/v1/routes/health.py
+++ b/backend/app/api/v1/routes/health.py
@@ -64,4 +64,4 @@ def _check_disk() -> tuple[bool, int]:
 
 def _check_playwright(request: Request) -> bool:
     manager = getattr(request.app.state, "browser_manager", None)
-    return manager is not None and manager.connected
+    return manager is not None and manager.healthy

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -120,55 +120,87 @@ pdf_tokens = _PdfTokens()
 
 
 class BrowserManager:
-    """Lazy-reconnecting wrapper around a Playwright Chromium browser.
-
-    If Chromium crashes (OOM, segfault), the next call to `get()` relaunches it.
-    An asyncio.Lock ensures only one coroutine launches at a time.
-    """
+    """Share Chromium across active PDF renders and stop it while idle."""
 
     _LAUNCH_ARGS: ClassVar[list[str]] = ["--use-gl=angle", "--no-sandbox"]
 
-    def __init__(self, pw: Playwright) -> None:
-        self._pw = pw
+    def __init__(self) -> None:
+        self._pw: Playwright | None = None
         self._browser: Browser | None = None
+        self._leases = 0
+        self._healthy = False
         self._lock = asyncio.Lock()
 
-    async def launch(self) -> None:
-        self._browser = await self._pw.chromium.launch(args=self._LAUNCH_ARGS)
-        logger.info("playwright.browser_launched")
-
-    async def get(self) -> Browser:
+    async def _launch_locked(self) -> Browser:
         if self._browser is not None and self._browser.is_connected():
             return self._browser
+        if self._pw is not None:
+            await self._close_locked()
+
+        pw = await async_playwright().start()
+        try:
+            browser = await pw.chromium.launch(args=self._LAUNCH_ARGS)
+        except BaseException:
+            self._healthy = False
+            await pw.stop()
+            raise
+        self._pw = pw
+        self._browser = browser
+        self._healthy = True
+        logger.info("playwright.browser_launched")
+        return browser
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncGenerator[Browser]:
         async with self._lock:
-            if self._browser is None or not self._browser.is_connected():
-                logger.warning("playwright.browser_disconnected")
-                self._browser = await self._pw.chromium.launch(args=self._LAUNCH_ARGS)
-                logger.info("playwright.browser_relaunched")
-        return self._browser
+            browser = await self._launch_locked()
+            self._leases += 1
+        try:
+            yield browser
+        finally:
+            async with self._lock:
+                self._leases -= 1
+                if self._leases == 0:
+                    await self._close_locked()
+
+    async def probe(self) -> None:
+        async with self.acquire():
+            pass
 
     @property
-    def connected(self) -> bool:
-        return self._browser is not None and self._browser.is_connected()
+    def healthy(self) -> bool:
+        return self._healthy and (self._browser is None or self._browser.is_connected())
+
+    async def _close_locked(self) -> None:
+        browser = self._browser
+        pw = self._pw
+        if browser is None and pw is None:
+            return
+        self._browser = None
+        self._pw = None
+        try:
+            if browser is not None:
+                await browser.close()
+        finally:
+            if pw is not None:
+                await pw.stop()
+        logger.info("playwright.browser_closed")
 
     async def close(self) -> None:
-        if self._browser:
-            await self._browser.close()
+        async with self._lock:
+            await self._close_locked()
 
 
 @asynccontextmanager
 async def lifespan() -> AsyncGenerator[BrowserManager]:
     """Setup/teardown for PDF rendering: tmp dir cleanup + Playwright browser."""
     async with pdf_tokens.lifespan():
-        pw = await async_playwright().start()
-        manager = BrowserManager(pw)
-        await manager.launch()
+        manager = BrowserManager()
+        await manager.probe()
         try:
             yield manager
         finally:
             await manager.close()
-            await pw.stop()
-            logger.info("playwright.browser_closed")
 
 
 async def store_pdf_token(session: AsyncSession, path: Path, aid: str) -> str:

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -39,6 +40,15 @@ def _assert_step_layout(
     assert data["cover"] == cover
     assert data["pages"] == pages
     assert data["unused"] == unused
+
+
+@asynccontextmanager
+async def _browser_lease() -> AsyncIterator[object]:
+    yield object()
+
+
+def _browser_manager() -> SimpleNamespace:
+    return SimpleNamespace(acquire=_browser_lease)
 
 
 class TestReadAlbum:
@@ -837,10 +847,21 @@ class TestGenerateChapterPdf:
             ],
         )
         captured: dict[str, object] = {}
+        lease_active = False
+
+        @asynccontextmanager
+        async def browser_lease() -> AsyncIterator[object]:
+            nonlocal lease_active
+            lease_active = True
+            try:
+                yield object()
+            finally:
+                lease_active = False
 
         async def render_zip(
             *args: object, **kwargs: object
         ) -> AsyncIterator[PdfEvent]:
+            assert lease_active
             captured["args"] = args
             captured["kwargs"] = kwargs
             download_id = "zip-token"
@@ -849,7 +870,7 @@ class TestGenerateChapterPdf:
         monkeypatch.setattr(
             app.state,
             "browser_manager",
-            SimpleNamespace(get=AsyncMock(return_value=object())),
+            SimpleNamespace(acquire=browser_lease),
             raising=False,
         )
         with patch(
@@ -862,6 +883,7 @@ class TestGenerateChapterPdf:
         args = captured["args"]
         assert isinstance(args, tuple)
         assert args[3] == ["first", "second"]
+        assert not lease_active
 
     async def test_generate_chapters_pdf_uses_selected_chapters_in_album_order(
         self,
@@ -914,7 +936,7 @@ class TestGenerateChapterPdf:
         monkeypatch.setattr(
             app.state,
             "browser_manager",
-            SimpleNamespace(get=AsyncMock(return_value=object())),
+            _browser_manager(),
             raising=False,
         )
         with patch(
@@ -953,7 +975,7 @@ class TestGenerateChapterPdf:
         monkeypatch.setattr(
             app.state,
             "browser_manager",
-            SimpleNamespace(get=AsyncMock(return_value=object())),
+            _browser_manager(),
             raising=False,
         )
 
@@ -985,7 +1007,7 @@ class TestGenerateChapterPdf:
         monkeypatch.setattr(
             app.state,
             "browser_manager",
-            SimpleNamespace(get=AsyncMock(return_value=object())),
+            _browser_manager(),
             raising=False,
         )
 

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -2,11 +2,54 @@ import zipfile
 from collections.abc import AsyncGenerator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
+from app.api.v1.routes import health
 from app.core.config import get_settings
 from app.logic import pdf, pdf_chapters
 from tests.factories import collect_async
+
+
+class FakeBrowser:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def is_connected(self) -> bool:
+        return not self.closed
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeChromium:
+    def __init__(self) -> None:
+        self.browsers: list[FakeBrowser] = []
+
+    async def launch(self, *, args: list[str]) -> FakeBrowser:
+        assert args == ["--use-gl=angle", "--no-sandbox"]
+        browser = FakeBrowser()
+        self.browsers.append(browser)
+        return browser
+
+
+class FakePlaywright:
+    def __init__(self) -> None:
+        self.chromium = FakeChromium()
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class FakePlaywrightStarter:
+    def __init__(self, runtimes: list[FakePlaywright]) -> None:
+        self._runtimes = runtimes
+
+    async def start(self) -> FakePlaywright:
+        runtime = FakePlaywright()
+        self._runtimes.append(runtime)
+        return runtime
 
 
 def write_fake_pdf(dest: Path, chapter: str | None) -> int:
@@ -31,6 +74,57 @@ def test_print_url_omits_chapter_for_full_album() -> None:
         pdf._print_url("https://frontend.example", "trip-1", dark=True, chapter=None)
         == "https://frontend.example/print/trip-1?dark=true"
     )
+
+
+async def test_browser_manager_shares_browser_until_last_lease_closes(
+    monkeypatch: Any,
+) -> None:
+    runtimes: list[FakePlaywright] = []
+    monkeypatch.setattr(
+        pdf,
+        "async_playwright",
+        lambda: FakePlaywrightStarter(runtimes),
+    )
+    manager = pdf.BrowserManager()
+
+    first_lease = manager.acquire()
+    first_browser = await first_lease.__aenter__()
+    second_lease = manager.acquire()
+    second_browser = await second_lease.__aenter__()
+
+    assert first_browser is second_browser
+    assert len(runtimes) == 1
+    await first_lease.__aexit__(None, None, None)
+    assert first_browser.is_connected()
+    assert not runtimes[0].stopped
+
+    await second_lease.__aexit__(None, None, None)
+    assert not first_browser.is_connected()
+    assert runtimes[0].stopped
+
+
+async def test_browser_manager_probe_is_healthy_without_idle_runtime(
+    monkeypatch: Any,
+) -> None:
+    runtimes: list[FakePlaywright] = []
+    monkeypatch.setattr(
+        pdf,
+        "async_playwright",
+        lambda: FakePlaywrightStarter(runtimes),
+    )
+    manager = pdf.BrowserManager()
+
+    await manager.probe()
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(browser_manager=manager),
+        )
+    )
+    assert health._check_playwright(request)
+    assert len(runtimes) == 1
+    assert not runtimes[0].chromium.browsers[0].is_connected()
+    assert runtimes[0].stopped
 
 
 async def test_render_album_chapters_zip_stream_creates_zip_artifact(


### PR DESCRIPTION
- replace the startup-resident Playwright driver and Chromium process tree with an on-demand browser lease
- share one browser across overlapping PDF requests, while keeping each render in its existing isolated browser context
- close Chromium and the Playwright driver when the final active request finishes
- launch and close Chromium once during startup so health checks still verify that the runtime is usable
- keep the browser lease alive through the complete SSE response lifecycle