### PR TITLE
fix: authorize Mapbox PDF tile requests

### DIFF
--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -348,6 +348,7 @@ async def render_pdf_file(  # noqa: C901, PLR0913, PLR0915
             viewport={"width": 1920, "height": 1080},
             device_scale_factor=2,
             bypass_csp=True,
+            extra_http_headers={"Referer": str(settings.PUBLIC_URL)},
         )
     try:
         await context.add_cookies(

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -88,13 +88,36 @@ async def test_pdf_browser_requests_use_public_url_as_referer(
     monkeypatch: Any,
     tmp_path: Path,
 ) -> None:
-    class BrowserContextCreatedError(Exception):
-        def __init__(self, options: dict[str, Any]) -> None:
-            self.options = options
+    calls: dict[str, Any] = {}
+
+    class PrintPageNavigatedError(Exception):
+        pass
+
+    class RecordingPage:
+        def on(self, _event: str, _handler: object) -> None:
+            pass
+
+        async def emulate_media(self, *, media: str) -> None:
+            calls["media"] = media
+
+        async def goto(self, url: str, *, wait_until: str) -> None:
+            calls["goto"] = (url, wait_until)
+            raise PrintPageNavigatedError
+
+    class RecordingContext:
+        async def add_cookies(self, cookies: list[dict[str, Any]]) -> None:
+            calls["cookies"] = cookies
+
+        async def new_page(self) -> RecordingPage:
+            return RecordingPage()
+
+        async def close(self) -> None:
+            calls["closed"] = True
 
     class RecordingBrowser:
-        async def new_context(self, **options: Any) -> None:
-            raise BrowserContextCreatedError(options)
+        async def new_context(self, **options: Any) -> RecordingContext:
+            calls["context_options"] = options
+            return RecordingContext()
 
     monkeypatch.setattr(
         pdf,
@@ -113,12 +136,24 @@ async def test_pdf_browser_requests_use_public_url_as_referer(
     )
 
     assert await anext(stream) == pdf.PdfProgress(phase="loading", done=0)
-    with pytest.raises(BrowserContextCreatedError) as created:
+    with pytest.raises(PrintPageNavigatedError):
         await anext(stream)
 
-    assert created.value.options["extra_http_headers"] == {
+    assert calls["context_options"]["extra_http_headers"] == {
         "Referer": "https://wanderbound.example/"
     }
+    assert calls["cookies"] == [
+        {
+            "name": "session",
+            "value": "session-cookie",
+            "url": "http://127.0.0.1:8000",
+        }
+    ]
+    assert calls["goto"] == (
+        "http://127.0.0.1:8000/print/trip-1?dark=false",
+        "domcontentloaded",
+    )
+    assert calls["closed"] is True
 
 
 async def test_render_queue_stops_waiting_after_one_minute(monkeypatch: Any) -> None:

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -4,6 +4,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -86,39 +87,7 @@ def test_render_capacity_uses_one_slot_per_available_cpu() -> None:
 
 async def test_pdf_browser_requests_use_public_url_as_referer(
     monkeypatch: Any,
-    tmp_path: Path,
 ) -> None:
-    calls: dict[str, Any] = {}
-
-    class PrintPageNavigatedError(Exception):
-        pass
-
-    class RecordingPage:
-        def on(self, _event: str, _handler: object) -> None:
-            pass
-
-        async def emulate_media(self, *, media: str) -> None:
-            calls["media"] = media
-
-        async def goto(self, url: str, *, wait_until: str) -> None:
-            calls["goto"] = (url, wait_until)
-            raise PrintPageNavigatedError
-
-    class RecordingContext:
-        async def add_cookies(self, cookies: list[dict[str, Any]]) -> None:
-            calls["cookies"] = cookies
-
-        async def new_page(self) -> RecordingPage:
-            return RecordingPage()
-
-        async def close(self) -> None:
-            calls["closed"] = True
-
-    class RecordingBrowser:
-        async def new_context(self, **options: Any) -> RecordingContext:
-            calls["context_options"] = options
-            return RecordingContext()
-
     monkeypatch.setattr(
         pdf,
         "get_settings",
@@ -127,33 +96,25 @@ async def test_pdf_browser_requests_use_public_url_as_referer(
             PUBLIC_URL="https://wanderbound.example/",
         ),
     )
+    browser = SimpleNamespace(new_context=AsyncMock(side_effect=RuntimeError))
     stream = pdf.render_pdf_file(
-        RecordingBrowser(),  # type: ignore[arg-type]
+        browser,  # type: ignore[arg-type]
         "trip-1",
-        tmp_path / "trip-1.pdf",
+        Path("unused.pdf"),
         session_cookie="session-cookie",
         dark=False,
     )
 
     assert await anext(stream) == pdf.PdfProgress(phase="loading", done=0)
-    with pytest.raises(PrintPageNavigatedError):
+    with pytest.raises(RuntimeError):
         await anext(stream)
 
-    assert calls["context_options"]["extra_http_headers"] == {
-        "Referer": "https://wanderbound.example/"
-    }
-    assert calls["cookies"] == [
-        {
-            "name": "session",
-            "value": "session-cookie",
-            "url": "http://127.0.0.1:8000",
-        }
-    ]
-    assert calls["goto"] == (
-        "http://127.0.0.1:8000/print/trip-1?dark=false",
-        "domcontentloaded",
+    browser.new_context.assert_awaited_once_with(
+        viewport={"width": 1920, "height": 1080},
+        device_scale_factor=2,
+        bypass_csp=True,
+        extra_http_headers={"Referer": "https://wanderbound.example/"},
     )
-    assert calls["closed"] is True
 
 
 async def test_render_queue_stops_waiting_after_one_minute(monkeypatch: Any) -> None:

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -85,17 +85,7 @@ def test_render_capacity_uses_one_slot_per_available_cpu() -> None:
     assert pdf.render_capacity(4) == 4
 
 
-async def test_pdf_browser_requests_use_public_url_as_referer(
-    monkeypatch: Any,
-) -> None:
-    monkeypatch.setattr(
-        pdf,
-        "get_settings",
-        lambda: SimpleNamespace(
-            INTERNAL_URL="http://127.0.0.1:8000",
-            PUBLIC_URL="https://wanderbound.example/",
-        ),
-    )
+async def test_pdf_browser_requests_use_public_url_as_referer() -> None:
     browser = SimpleNamespace(new_context=AsyncMock(side_effect=RuntimeError))
     stream = pdf.render_pdf_file(
         browser,  # type: ignore[arg-type]
@@ -109,12 +99,9 @@ async def test_pdf_browser_requests_use_public_url_as_referer(
     with pytest.raises(RuntimeError):
         await anext(stream)
 
-    browser.new_context.assert_awaited_once_with(
-        viewport={"width": 1920, "height": 1080},
-        device_scale_factor=2,
-        bypass_csp=True,
-        extra_http_headers={"Referer": "https://wanderbound.example/"},
-    )
+    assert browser.new_context.await_args.kwargs["extra_http_headers"] == {
+        "Referer": str(get_settings().PUBLIC_URL)
+    }
 
 
 async def test_render_queue_stops_waiting_after_one_minute(monkeypatch: Any) -> None:

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -84,6 +84,43 @@ def test_render_capacity_uses_one_slot_per_available_cpu() -> None:
     assert pdf.render_capacity(4) == 4
 
 
+async def test_pdf_browser_requests_use_public_url_as_referer(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    class BrowserContextCreatedError(Exception):
+        def __init__(self, options: dict[str, Any]) -> None:
+            self.options = options
+
+    class RecordingBrowser:
+        async def new_context(self, **options: Any) -> None:
+            raise BrowserContextCreatedError(options)
+
+    monkeypatch.setattr(
+        pdf,
+        "get_settings",
+        lambda: SimpleNamespace(
+            INTERNAL_URL="http://127.0.0.1:8000",
+            PUBLIC_URL="https://wanderbound.example/",
+        ),
+    )
+    stream = pdf.render_pdf_file(
+        RecordingBrowser(),  # type: ignore[arg-type]
+        "trip-1",
+        tmp_path / "trip-1.pdf",
+        session_cookie="session-cookie",
+        dark=False,
+    )
+
+    assert await anext(stream) == pdf.PdfProgress(phase="loading", done=0)
+    with pytest.raises(BrowserContextCreatedError) as created:
+        await anext(stream)
+
+    assert created.value.options["extra_http_headers"] == {
+        "Referer": "https://wanderbound.example/"
+    }
+
+
 async def test_render_queue_stops_waiting_after_one_minute(monkeypatch: Any) -> None:
     class Clock:
         now = 0.0


### PR DESCRIPTION
- send the public application URL as the Playwright PDF context referrer so URL-restricted Mapbox tiles authorize
- keep print navigation, session cookies, API calls, and media traffic on the internal URL
- add a focused regression test for the browser context referrer
