### PR TITLE
fix: Sentry storage percentage scale

### DIFF
--- a/backend/app/logic/storage_metrics.py
+++ b/backend/app/logic/storage_metrics.py
@@ -36,7 +36,7 @@ def capture_media_storage_metrics(used_bytes: int, limit_bytes: int) -> None:
     sentry_sdk.metrics.gauge("storage.media.limit_bytes", limit_bytes, unit="byte")
     sentry_sdk.metrics.gauge(
         "storage.media.utilization",
-        used_bytes / limit_bytes * 100,
+        used_bytes / limit_bytes,
         unit="percent",
     )
 
@@ -51,7 +51,7 @@ def capture_filesystem_storage_metrics(data_folder: Path) -> None:
     )
     sentry_sdk.metrics.gauge(
         "storage.filesystem.utilization",
-        usage.used / usage.total * 100,
+        usage.used / usage.total,
         unit="percent",
     )
 

--- a/backend/tests/test_eviction.py
+++ b/backend/tests/test_eviction.py
@@ -86,7 +86,7 @@ class TestRunEviction:
         assert gauge.call_args_list == [
             call("storage.media.used_bytes", 100, unit="byte"),
             call("storage.media.limit_bytes", 1000, unit="byte"),
-            call("storage.media.utilization", 10.0, unit="percent"),
+            call("storage.media.utilization", 0.1, unit="percent"),
         ]
 
     async def test_evicts_lru_album_without_removing_its_user(

--- a/backend/tests/test_storage_metrics.py
+++ b/backend/tests/test_storage_metrics.py
@@ -20,7 +20,7 @@ def test_capture_filesystem_storage_metrics(
     assert gauge.call_args_list == [
         call("storage.filesystem.available_bytes", 38_000, unit="byte"),
         call("storage.filesystem.capacity_bytes", 50_000, unit="byte"),
-        call("storage.filesystem.utilization", 24.0, unit="percent"),
+        call("storage.filesystem.utilization", 0.24, unit="percent"),
     ]
 
 


### PR DESCRIPTION
- emit storage utilization as 0..1 values instead of multiplying by 100