### PR TITLE
feat: add self-host link to landing page

### DIFF
--- a/frontend/src/components/landing/AuthActions.vue
+++ b/frontend/src/components/landing/AuthActions.vue
@@ -28,6 +28,18 @@ const emit = defineEmits<{
     :to="{ name: 'editor' }"
   />
   <div v-else class="auth-actions column no-wrap items-center">
+    <i18n-t keypath="landing.selfHostPrompt" tag="p" class="self-host-prompt">
+      <template #link>
+        <a
+          href="https://github.com/itay-raveh/wanderbound#self-hosting"
+          target="_blank"
+          rel="noopener"
+          class="self-host-link"
+        >
+          {{ t("landing.selfHostLink") }}
+        </a>
+      </template>
+    </i18n-t>
     <q-btn
       v-if="localLoginEnabled"
       data-test="local-login"
@@ -58,6 +70,30 @@ const emit = defineEmits<{
 <style scoped>
 .auth-actions {
   gap: var(--gap-md-lg);
+}
+
+.self-host-prompt {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--type-sm);
+  text-align: center;
+}
+
+.self-host-link {
+  color: inherit;
+  font-weight: 600;
+  text-underline-offset: 0.15em;
+  transition: color var(--duration-fast);
+
+  &:hover {
+    color: var(--q-primary);
+  }
+
+  &:focus-visible {
+    border-radius: var(--radius-xs);
+    outline: 0.125rem solid var(--q-primary);
+    outline-offset: 0.125rem;
+  }
 }
 
 .demo-btn {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -43,6 +43,8 @@
     "overviewBody": "Highest point, coldest night, hottest day, furthest from home. Your trip on a single page with the countries you visited.",
     "localizationTitle": "Your language, your direction",
     "localizationBody": "Unlike the {polarsteps}' album, we handle Hebrew, Arabic, Japanese and right-to-left layouts. Your album matches your language.",
+    "selfHostPrompt": "Don’t want to sign in? {link}",
+    "selfHostLink": "Self-host Wanderbound.",
     "openEditor": "Open editor"
   },
   "login": {

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -43,6 +43,8 @@
     "overviewBody": "הפסגה הכי גבוהה, הלילה הכי קר, היום הכי חם, המקום כי רחוק מהבית.",
     "localizationTitle": "עובד בכל שפה",
     "localizationBody": "האלבום הרשמי של {polarsteps} לא תומך בעברית כמו שצריך. אנחנו תומכים במגוון שפות, כולל תמיכה נכונה ביישור ימין-לשמאל.",
+    "selfHostPrompt": "לא רוצים להתחבר? {link}",
+    "selfHostLink": "אפשר לארח את Wanderbound בעצמכם.",
     "openEditor": "לעורך"
   },
   "login": {


### PR DESCRIPTION
- add an always-visible self-hosting prompt above the landing page login controls