### PR TITLE
fix: require complete maps in PDF exports

### DIFF
--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -11,10 +11,10 @@ from contextlib import (
 )
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, ClassVar, Literal
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 
 import structlog
-from playwright.async_api import Browser, Page, Playwright, async_playwright
+from playwright.async_api import Browser, Page, Playwright, Response, async_playwright
 from pydantic import BaseModel, Field
 
 from app.core.config import get_settings
@@ -73,6 +73,10 @@ class PdfArtifact(BaseModel):
 
 
 class PdfQueueTimeoutError(TimeoutError):
+    pass
+
+
+class PdfPageRenderError(RuntimeError):
     pass
 
 
@@ -358,7 +362,31 @@ async def _load_print_page(
         deadline = loop.time() + 60
         last_counts = (-1, -1)
         while True:
-            ready = await page.evaluate("window.__PRINT_READY__ === true")
+            state = await page.evaluate(
+                """() => ({
+                    ready: window.__PRINT_READY__ === true,
+                    error: window.__PRINT_ERROR__ ?? null,
+                })"""
+            )
+            ready = state["ready"]
+            if state["error"]:
+                error = state["error"]
+                code = (
+                    error.get("code", "unknown")
+                    if isinstance(error, dict)
+                    else "unknown"
+                )
+                logger.warning(
+                    "pdf.print_page_failed",
+                    album_id=aid,
+                    error_code=code,
+                )
+                detail = (
+                    "A map could not be rendered for PDF export. Please try again."
+                    if code == "map-render-failed"
+                    else "Album rendering did not finish in time. Please try again."
+                )
+                raise PdfPageRenderError(detail)
             counts = (finished, started)
             if counts != last_counts or ready:
                 last_counts = counts
@@ -420,6 +448,23 @@ async def render_pdf_file(  # noqa: PLR0913
                 error_type=type(err).__name__,
             ),
         )
+
+        def log_failed_mapbox_response(response: Response) -> None:
+            if response.status < 300:
+                return
+            parsed = urlparse(response.url)
+            host = parsed.hostname or ""
+            if host != "mapbox.com" and not host.endswith(".mapbox.com"):
+                return
+            logger.warning(
+                "pdf.mapbox_response_failed",
+                host=host,
+                path=parsed.path,
+                resource_type=response.request.resource_type,
+                status=response.status,
+            )
+
+        page.on("response", log_failed_mapbox_response)
         url = _print_url(frontend_url, aid, dark=dark, chapter=chapter)
         async for progress in _load_print_page(page, url, aid, dark=dark):
             yield progress
@@ -445,7 +490,7 @@ async def render_pdf_file(  # noqa: PLR0913
         await context.close()
 
 
-async def render_album_pdf_stream(  # noqa: PLR0913
+async def render_album_pdf_stream(  # noqa: C901, PLR0913
     browser: Browser,
     session: AsyncSession,
     aid: str,
@@ -500,6 +545,8 @@ async def render_album_pdf_stream(  # noqa: PLR0913
         owned = True
         yield PdfDone(token=token)
 
+    except PdfPageRenderError as exc:
+        yield PdfError(detail=str(exc))
     except TimeoutError:
         logger.warning(
             "pdf.render_timeout",

--- a/backend/app/logic/pdf_chapters.py
+++ b/backend/app/logic/pdf_chapters.py
@@ -15,6 +15,7 @@ from app.logic.pdf import (
     PdfDone,
     PdfError,
     PdfEvent,
+    PdfPageRenderError,
     PdfProgress,
     PdfQueued,
     PdfQueueTimeoutError,
@@ -156,6 +157,8 @@ async def render_album_chapters_zip_stream(  # noqa: C901, PLR0913
         if isinstance(done, PdfError):
             return
         owned = True
+    except PdfPageRenderError as exc:
+        yield PdfError(detail=str(exc))
     except Exception:
         logger.exception("pdf.chapter_zip_generation_failed", album_id=aid)
         yield PdfError(detail="Chapter ZIP generation failed. Please try again.")

--- a/frontend/e2e/pdf-map-print.test.ts
+++ b/frontend/e2e/pdf-map-print.test.ts
@@ -1,0 +1,251 @@
+import type { Page } from "@playwright/test";
+
+import type { PrintBundle, Segment, StepRead } from "../src/client";
+import {
+  mockAlbum,
+  mockMedia,
+  mockStep,
+  mockUser,
+  TINY_JPEG_BASE64,
+} from "../tests/fixtures/mocks";
+import { expect, test } from "./fixtures";
+
+const API = "**/api/v1";
+const BASEMAP_COLOR = [20, 107, 58] as const;
+const OVERVIEW_ROUTE_COLOR = [74, 144, 217] as const;
+const HIKE_ROUTE_COLOR = [231, 124, 49] as const;
+
+const secondStep: StepRead = {
+  ...mockStep,
+  id: 2,
+  name: "Utrecht",
+  timestamp: 1704070800,
+  datetime: "2024-01-01T13:00:00+01:00",
+  location: {
+    ...mockStep.location,
+    name: "Utrecht",
+    detail: "Utrecht",
+    lat: 52.09,
+    lon: 5.12,
+  },
+  cover: null,
+  pages: [],
+};
+
+const hike: Segment = {
+  uid: 1,
+  aid: "aid-1",
+  start_time: mockStep.timestamp,
+  end_time: secondStep.timestamp,
+  kind: "hike",
+  timezone_id: "Europe/Amsterdam",
+  points: [
+    { lat: 52.37, lon: 4.89, time: mockStep.timestamp },
+    { lat: 52.24, lon: 5.0, time: 1704069000 },
+    { lat: 52.09, lon: 5.12, time: secondStep.timestamp },
+  ],
+  route: null,
+};
+
+const bundle: PrintBundle = {
+  album: {
+    ...mockAlbum,
+    hidden_headers: ["cover-front", "cover-back", "overview"],
+    maps_ranges: [["2024-01-01", "2024-01-01"]],
+    chapters: [
+      {
+        ...mockAlbum.chapters[0],
+        step_ids: [mockStep.id, secondStep.id],
+      },
+    ],
+    media: mockMedia,
+  },
+  steps: [mockStep, secondStep],
+  segments: [hike],
+  total_distance_km: 0,
+};
+
+const BASEMAP_TILE = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGUExURRRrOv///0zqgckAAAABYktHRAH/Ai3eAAAAB3RJTUUH6ggeDQgXuG9ltQAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyNi0wOC0zMFQxMzowODoyMyswMDowMGSJqt8AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjYtMDgtMzBUMTM6MDg6MjMrMDA6MDAV1BJjAAAAKHRFWHRkYXRlOnRpbWVzdGFtcAAyMDI2LTA4LTMwVDEzOjA4OjIzKzAwOjAwQsEzvAAAAB9JREFUaN7twQENAAAAwqD3T20ON6AAAAAAAAAAAL4NIQAAAX8ZnKcAAAAASUVORK5CYII=",
+  "base64",
+);
+const TERRAIN_TILE = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGUExURQGGoP///x1IEE8AAAABYktHRAH/Ai3eAAAAB3RJTUUH6ggeDQgXuG9ltQAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyNi0wOC0zMFQxMzowODoyMyswMDowMGSJqt8AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjYtMDgtMzBUMTM6MDg6MjMrMDA6MDAV1BJjAAAAKHRFWHRkYXRlOnRpbWVzdGFtcAAyMDI2LTA4LTMwVDEzOjA4OjIzKzAwOjAwQsEzvAAAAB9JREFUaN7twQENAAAAwqD3T20ON6AAAAAAAAAAAL4NIQAAAX8ZnKcAAAAASUVORK5CYII=",
+  "base64",
+);
+
+async function installPdfMapFixture(page: Page, tileDelayMs = 600) {
+  await page.route(`${API}/config`, (route) =>
+    route.fulfill({ json: { MAPBOX_TOKEN: "test-token" } }),
+  );
+  await page.route(`${API}/users`, (route) =>
+    route.fulfill({ json: mockUser }),
+  );
+  await page.route(`${API}/albums/*/print-bundle*`, (route) =>
+    route.fulfill({ json: bundle }),
+  );
+  await page.route(`${API}/albums/*/segments/points*`, (route) =>
+    route.fulfill({ json: [hike] }),
+  );
+  await page.route(`${API}/albums/*/media/*`, (route) =>
+    route.fulfill({
+      contentType: "image/jpeg",
+      body: Buffer.from(TINY_JPEG_BASE64, "base64"),
+    }),
+  );
+
+  let tileRequested = false;
+  let tileFulfilled = false;
+  await page.route("**/e2e-map/**/*.png", async (route) => {
+    tileRequested = true;
+    await new Promise((resolve) => setTimeout(resolve, tileDelayMs));
+    await route.fulfill({
+      contentType: "image/png",
+      body: BASEMAP_TILE,
+    });
+    tileFulfilled = true;
+  });
+  await page.route("**/e2e-dem/**/*.png", (route) =>
+    route.fulfill({
+      contentType: "image/png",
+      body: TERRAIN_TILE,
+    }),
+  );
+  await page.route("**/styles/v1/mapbox/standard-satellite*", (route) =>
+    route.fulfill({
+      json: {
+        version: 8,
+        sources: {
+          basemap: {
+            type: "raster",
+            tiles: ["http://localhost:5173/e2e-map/{z}/{x}/{y}.png"],
+            tileSize: 256,
+            maxzoom: 14,
+          },
+        },
+        layers: [
+          {
+            id: "background",
+            type: "background",
+            paint: { "background-color": "#202020" },
+          },
+          { id: "basemap", type: "raster", source: "basemap" },
+        ],
+      },
+    }),
+  );
+  await page.route("**/v4/mapbox.mapbox-terrain-dem-v1.json*", (route) =>
+    route.fulfill({
+      json: {
+        tilejson: "2.2.0",
+        tiles: ["http://localhost:5173/e2e-dem/{z}/{x}/{y}.png"],
+        minzoom: 0,
+        maxzoom: 14,
+      },
+    }),
+  );
+
+  await page.emulateMedia({ media: "print" });
+  return {
+    tileRequested: () => tileRequested,
+    tileFulfilled: () => tileFulfilled,
+  };
+}
+
+async function snapshotColorCounts(page: Page) {
+  return page.locator(".mapbox-print-snapshot").evaluateAll(
+    async (images, targets) =>
+      Promise.all(
+        images.map(async (image) => {
+          const img = image as HTMLImageElement;
+          await img.decode();
+          const canvas = document.createElement("canvas");
+          canvas.width = img.naturalWidth;
+          canvas.height = img.naturalHeight;
+          const context = canvas.getContext("2d", { willReadFrequently: true });
+          if (!context) throw new Error("2D canvas is unavailable");
+          context.drawImage(img, 0, 0);
+          const pixels = context.getImageData(
+            0,
+            0,
+            canvas.width,
+            canvas.height,
+          ).data;
+          const counts = targets.map(() => 0);
+          for (let i = 0; i < pixels.length; i += 4) {
+            targets.forEach((target, index) => {
+              if (
+                Math.abs(pixels[i] - target[0]) <= 12 &&
+                Math.abs(pixels[i + 1] - target[1]) <= 12 &&
+                Math.abs(pixels[i + 2] - target[2]) <= 12
+              ) {
+                counts[index]++;
+              }
+            });
+          }
+          return counts;
+        }),
+      ),
+    [BASEMAP_COLOR, OVERVIEW_ROUTE_COLOR, HIKE_ROUTE_COLOR],
+  );
+}
+
+test.describe("PDF map snapshots", () => {
+  test("waits for delayed basemap tiles and runtime routes", async ({
+    page,
+  }) => {
+    const tiles = await installPdfMapFixture(page);
+
+    await page.goto("/print/aid-1");
+    await expect.poll(tiles.tileRequested).toBe(true);
+    expect(tiles.tileFulfilled()).toBe(false);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as Record<string, unknown>).__PRINT_READY__,
+      ),
+    ).not.toBe(true);
+
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).__PRINT_READY__ === true,
+    );
+    expect(tiles.tileFulfilled()).toBe(true);
+    const snapshots = page.locator(
+      "[data-map][data-map-snapshot-ready] > .mapbox-print-snapshot",
+    );
+    await expect(snapshots).toHaveCount(2);
+
+    const counts = await snapshotColorCounts(page);
+    expect(counts[0][0]).toBeGreaterThan(1_000);
+    expect(counts[0][1]).toBeGreaterThan(10);
+    expect(counts[1][0]).toBeGreaterThan(1_000);
+    expect(counts[1][2]).toBeGreaterThan(10);
+  });
+
+  test("reports snapshot failure without marking the PDF ready", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      HTMLCanvasElement.prototype.toDataURL = () => {
+        throw new Error("snapshot unavailable");
+      };
+    });
+    await installPdfMapFixture(page, 0);
+
+    await page.goto("/print/aid-1");
+    await page.waitForFunction(() =>
+      Boolean((window as unknown as Record<string, unknown>).__PRINT_ERROR__),
+    );
+
+    expect(
+      await page.evaluate(
+        () => (window as unknown as Record<string, unknown>).__PRINT_ERROR__,
+      ),
+    ).toMatchObject({ code: "map-render-failed" });
+    expect(
+      await page.evaluate(
+        () => (window as unknown as Record<string, unknown>).__PRINT_READY__,
+      ),
+    ).not.toBe(true);
+  });
+});

--- a/frontend/src/composables/useMapbox.ts
+++ b/frontend/src/composables/useMapbox.ts
@@ -50,6 +50,8 @@ export function useMapbox(options: UseMapboxOptions) {
   mapboxgl.accessToken = getSettings().MAPBOX_TOKEN ?? "";
   const map = shallowRef<mapboxgl.Map | null>(null);
   let pendingIdle: (() => void) | null = null;
+  let pendingRender: (() => void) | null = null;
+  let readinessGeneration = 0;
   let initIdleHandle: number | null = null;
   let initTimeout: ReturnType<typeof setTimeout> | null = null;
   let visibilityTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -96,8 +98,11 @@ export function useMapbox(options: UseMapboxOptions) {
       armIdleReady(el, m);
     } catch (e) {
       console.warn("[mapbox] failed to initialise map:", e);
-      // Mark ready on error so PrintView doesn't wait forever.
-      el.dataset.mapReady = "";
+      if (options.preserveDrawingBuffer) {
+        el.dataset.mapError = "initialization-failed";
+      } else {
+        el.dataset.mapReady = "";
+      }
     }
   }
 
@@ -116,38 +121,75 @@ export function useMapbox(options: UseMapboxOptions) {
 
   function armIdleReady(el: HTMLElement, m: mapboxgl.Map) {
     disarmIdleReady(m);
+    const generation = ++readinessGeneration;
     delete el.dataset.mapReady;
     delete el.dataset.mapSnapshotReady;
+    delete el.dataset.mapError;
     let attempts = 0;
     const markReady = () => {
-      if (options.preserveDrawingBuffer) snapshotCanvasForPrint(el, m);
+      if (generation !== readinessGeneration) return;
       el.dataset.mapReady = "";
       pendingIdle = null;
+      pendingRender = null;
       if (idleFallback !== null) {
         clearTimeout(idleFallback);
         idleFallback = null;
       }
     };
+    const markError = (code: string) => {
+      if (generation !== readinessGeneration) return;
+      el.dataset.mapError = code;
+      pendingIdle = null;
+      pendingRender = null;
+      if (idleFallback !== null) {
+        clearTimeout(idleFallback);
+        idleFallback = null;
+      }
+    };
+    const capture = async () => {
+      if (generation !== readinessGeneration) return;
+      pendingRender = null;
+      if (await snapshotCanvasForPrint(el, m, generation)) markReady();
+      else markError("snapshot-failed");
+    };
     const check = () => {
+      if (generation !== readinessGeneration) return;
       if (!m.areTilesLoaded() && ++attempts < 20) {
         m.once("idle", check);
         return;
       }
-      markReady();
+      pendingIdle = null;
+      if (!options.preserveDrawingBuffer) {
+        markReady();
+        return;
+      }
+      pendingRender = () => void capture();
+      m.once("render", pendingRender);
+      m.triggerRepaint();
     };
     pendingIdle = check;
     m.once("idle", check);
-    // Absolute fallback: mark ready after 30s even if idle never fires
-    // (e.g. WebGL context loss). Prevents map staying invisible forever.
+    // Preview maps remain fail-open so a lost WebGL context does not leave the
+    // editor blank. Print maps must fail the export instead of hiding damage.
     idleFallback = setTimeout(() => {
-      if (!el.dataset.mapReady) markReady();
+      if (el.dataset.mapReady || el.dataset.mapError) return;
+      if (options.preserveDrawingBuffer) markError("render-timeout");
+      else markReady();
     }, 30_000);
   }
 
-  function snapshotCanvasForPrint(el: HTMLElement, m: mapboxgl.Map) {
+  async function snapshotCanvasForPrint(
+    el: HTMLElement,
+    m: mapboxgl.Map,
+    generation: number,
+  ): Promise<boolean> {
     try {
       const canvas = m.getCanvas();
-      if (canvas.width === 0 || canvas.height === 0) return;
+      if (canvas.width === 0 || canvas.height === 0) return false;
+
+      const dataUrl = canvas.toDataURL("image/png");
+      if (!dataUrl.startsWith("data:image/png;base64,") || dataUrl.length < 32)
+        return false;
 
       let snapshot = el.querySelector<HTMLImageElement>(
         ":scope > .mapbox-print-snapshot",
@@ -159,10 +201,14 @@ export function useMapbox(options: UseMapboxOptions) {
         snapshot.setAttribute("aria-hidden", "true");
         el.prepend(snapshot);
       }
-      snapshot.src = canvas.toDataURL("image/png");
+      snapshot.src = dataUrl;
+      await snapshot.decode();
+      if (generation !== readinessGeneration) return false;
       el.dataset.mapSnapshotReady = "";
+      return true;
     } catch (e) {
       console.warn("[mapbox] failed to snapshot print canvas:", e);
+      return false;
     }
   }
 
@@ -171,6 +217,10 @@ export function useMapbox(options: UseMapboxOptions) {
       m.off("idle", pendingIdle);
       pendingIdle = null;
     }
+    if (pendingRender) {
+      m.off("render", pendingRender);
+      pendingRender = null;
+    }
     if (idleFallback !== null) {
       clearTimeout(idleFallback);
       idleFallback = null;
@@ -178,6 +228,7 @@ export function useMapbox(options: UseMapboxOptions) {
   }
 
   function destroy() {
+    readinessGeneration++;
     if (map.value) disarmIdleReady(map.value);
     map.value?.remove();
     map.value = null;

--- a/frontend/src/pages/PrintView.vue
+++ b/frontend/src/pages/PrintView.vue
@@ -78,6 +78,16 @@ async function loadFonts(): Promise<void> {
  */
 let pollTimer = 0;
 
+type PrintError = {
+  code: "map-render-failed" | "render-timeout";
+  message: string;
+};
+
+function setPrintError(error: PrintError) {
+  clearTimeout(pollTimer);
+  (window as unknown as Record<string, unknown>).__PRINT_ERROR__ = error;
+}
+
 function waitForPrintReady() {
   const MAX_WAIT = 45_000;
   const startTime = Date.now();
@@ -94,8 +104,10 @@ function waitForPrintReady() {
   function poll() {
     if (waiting) return;
     if (Date.now() - startTime > MAX_WAIT) {
-      console.warn("[print] timed out, forcing ready");
-      setReady();
+      setPrintError({
+        code: "render-timeout",
+        message: "Album rendering timed out before every map was ready.",
+      });
       return;
     }
 
@@ -120,9 +132,20 @@ function waitForPrintReady() {
       return;
     }
 
-    // Wait for all Mapbox maps to finish rendering tiles.
+    const failedMap = document.querySelector<HTMLElement>(
+      "[data-map][data-map-error]",
+    );
+    if (failedMap) {
+      setPrintError({
+        code: "map-render-failed",
+        message: `A map could not be rendered (${failedMap.dataset.mapError}).`,
+      });
+      return;
+    }
+
+    // A print map is ready only after its decoded canvas snapshot is installed.
     const unreadyMaps = document.querySelectorAll(
-      "[data-map]:not([data-map-ready])",
+      "[data-map]:not([data-map-snapshot-ready])",
     );
     if (unreadyMaps.length > 0) {
       schedulePoll(300);


### PR DESCRIPTION
- capture print maps only after Mapbox reaches idle and paints a final render frame
- require a decoded snapshot from every map before PDF readiness
- fail PDF and chapter exports with a useful error instead of returning partial output
- log sanitized non-2xx Mapbox response metadata while preserving the public referrer
- cover delayed raster tiles, overview and hike routes, and snapshot failure in real Chromium