### PR TITLE
fix: render complete high-resolution PDF maps

### DIFF
--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -29,15 +29,32 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 
+_BASELINE_RENDER_CPUS = 4
+_BASE_PRINT_PAGE_TIMEOUT = 900
+_BASE_RENDER_TIMEOUT = 1500
+
+
 def render_capacity(cpu_count: int) -> int:
-    return max(1, cpu_count)
+    return max(1, cpu_count // 2)
 
 
-_max_concurrent = render_capacity(detect_cpu_count())
+def render_timeouts(cpu_count: int) -> tuple[int, int]:
+    available_cpus = max(1, cpu_count)
+
+    def scale(timeout: int) -> int:
+        return max(
+            timeout,
+            (timeout * _BASELINE_RENDER_CPUS + available_cpus - 1) // available_cpus,
+        )
+
+    return scale(_BASE_PRINT_PAGE_TIMEOUT), scale(_BASE_RENDER_TIMEOUT)
+
+
+_CPU_COUNT = detect_cpu_count()
+_max_concurrent = render_capacity(_CPU_COUNT)
 
 PDF_QUEUE_TIMEOUT = 60
-_RENDER_TIMEOUT = 1500
-_PRINT_PAGE_TIMEOUT = 900
+_PRINT_PAGE_TIMEOUT, _RENDER_TIMEOUT = render_timeouts(_CPU_COUNT)
 _PROGRESS_CHUNK_BYTES = 512 * 1024
 _RENDER_SLOT_POLL_INTERVAL = 0.25
 
@@ -471,6 +488,12 @@ async def render_pdf_file(  # noqa: PLR0913
                     "url": frontend_url,
                 },
             ]
+        )
+        await context.add_init_script(
+            script=(
+                f"window.__PRINT_TIMEOUT_MS__ = {_PRINT_PAGE_TIMEOUT * 1000};"
+                f"window.__PRINT_CPU_COUNT__ = {_CPU_COUNT};"
+            )
         )
         page = await context.new_page()
         page.on("console", lambda msg: logger.debug("browser.console", text=msg.text))

--- a/backend/app/logic/pdf.py
+++ b/backend/app/logic/pdf.py
@@ -36,7 +36,8 @@ def render_capacity(cpu_count: int) -> int:
 _max_concurrent = render_capacity(detect_cpu_count())
 
 PDF_QUEUE_TIMEOUT = 60
-_RENDER_TIMEOUT = 300
+_RENDER_TIMEOUT = 1500
+_PRINT_PAGE_TIMEOUT = 900
 _PROGRESS_CHUNK_BYTES = 512 * 1024
 _RENDER_SLOT_POLL_INTERVAL = 0.25
 
@@ -330,6 +331,16 @@ def _print_url(
     return f"{frontend_url.rstrip('/')}/print/{quote(aid)}?{urlencode(query)}"
 
 
+async def _release_print_map_memory(
+    page: Page, phase: str | None, *, released: bool
+) -> bool:
+    if released or phase != "map-memory":
+        return released
+    await page.request_gc()
+    await page.evaluate("window.__PRINT_MAP_MEMORY_RELEASED__ = true")
+    return True
+
+
 async def _load_print_page(
     page: Page,
     url: str,
@@ -359,27 +370,49 @@ async def _load_print_page(
         await page.goto(url, wait_until="domcontentloaded")
         logger.info("pdf.dom_loaded", album_id=aid)
         loop = asyncio.get_running_loop()
-        deadline = loop.time() + 60
+        deadline = loop.time() + _PRINT_PAGE_TIMEOUT
         last_counts = (-1, -1)
+        map_memory_released = False
         while True:
             state = await page.evaluate(
                 """() => ({
                     ready: window.__PRINT_READY__ === true,
                     error: window.__PRINT_ERROR__ ?? null,
+                    phase: document.querySelector('.print-view')?.dataset.printPhase
+                        ?? null,
                 })"""
+            )
+            map_memory_released = await _release_print_map_memory(
+                page, state["phase"], released=map_memory_released
             )
             ready = state["ready"]
             if state["error"]:
                 error = state["error"]
+                map_counts = await page.evaluate(
+                    """() => ({
+                        ready: document.querySelectorAll(
+                            '[data-map][data-map-snapshot-ready]'
+                        ).length,
+                        total: document.querySelectorAll('[data-map]').length,
+                    })"""
+                )
                 code = (
                     error.get("code", "unknown")
                     if isinstance(error, dict)
                     else "unknown"
                 )
-                logger.warning(
+                map_error = (
+                    error.get("mapError", "unknown")
+                    if isinstance(error, dict)
+                    else "unknown"
+                )
+                logger.error(
                     "pdf.print_page_failed",
                     album_id=aid,
                     error_code=code,
+                    map_error=map_error,
+                    maps_ready=map_counts["ready"],
+                    maps_total=map_counts["total"],
                 )
                 detail = (
                     "A map could not be rendered for PDF export. Please try again."
@@ -425,7 +458,7 @@ async def render_pdf_file(  # noqa: PLR0913
     ):
         context = await browser.new_context(
             viewport={"width": 1920, "height": 1080},
-            device_scale_factor=2,
+            device_scale_factor=1,
             bypass_csp=True,
             extra_http_headers={"Referer": str(settings.PUBLIC_URL)},
         )
@@ -548,7 +581,7 @@ async def render_album_pdf_stream(  # noqa: C901, PLR0913
     except PdfPageRenderError as exc:
         yield PdfError(detail=str(exc))
     except TimeoutError:
-        logger.warning(
+        logger.exception(
             "pdf.render_timeout",
             album_id=aid,
             timeout_s=_RENDER_TIMEOUT,

--- a/backend/tests/logic/test_pdf_resources.py
+++ b/backend/tests/logic/test_pdf_resources.py
@@ -1,0 +1,13 @@
+from app.logic.pdf import render_capacity, render_timeouts
+
+
+def test_pdf_rendering_scales_down_for_constrained_cpus() -> None:
+    one_cpu = render_timeouts(1)
+    two_cpus = render_timeouts(2)
+    four_cpus = render_timeouts(4)
+
+    assert one_cpu[0] > two_cpus[0] > four_cpus[0]
+    assert one_cpu[1] > two_cpus[1] > four_cpus[1]
+    assert all(render > page for page, render in (one_cpu, two_cpus, four_cpus))
+    assert render_capacity(1) == render_capacity(2) == 1
+    assert render_capacity(4) > render_capacity(2)

--- a/compose.yml
+++ b/compose.yml
@@ -103,8 +103,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
-          cpus: "2.0"
+          memory: 6G
+          cpus: "4.0"
           pids: 512
     networks: [backend, frontend]
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -103,8 +103,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 6G
-          cpus: "4.0"
+          memory: 5G
+          cpus: "2.0"
           pids: 512
     networks: [backend, frontend]
     depends_on:

--- a/frontend/e2e/pdf-map-print.test.ts
+++ b/frontend/e2e/pdf-map-print.test.ts
@@ -316,8 +316,10 @@ test.describe("PDF map snapshots", () => {
         return width / image.getBoundingClientRect().width;
       }),
     );
-    for (const pixelRatio of pixelRatios)
-      expect(pixelRatio).toBeGreaterThan(2.9);
+    for (const pixelRatio of pixelRatios) {
+      expect(pixelRatio).toBeGreaterThan(1.9);
+      expect(pixelRatio).toBeLessThan(2.1);
+    }
 
     const counts = await snapshotColorCounts(page);
     expect(counts[0][0]).toBeGreaterThan(1_000);

--- a/frontend/e2e/pdf-map-print.test.ts
+++ b/frontend/e2e/pdf-map-print.test.ts
@@ -74,7 +74,11 @@ const TERRAIN_TILE = Buffer.from(
   "base64",
 );
 
-async function installPdfMapFixture(page: Page, tileDelayMs = 600) {
+async function installPdfMapFixture(
+  page: Page,
+  tileDelayMs: number | null = null,
+  printBundle = bundle,
+) {
   await page.route(`${API}/config`, (route) =>
     route.fulfill({ json: { MAPBOX_TOKEN: "test-token" } }),
   );
@@ -82,23 +86,35 @@ async function installPdfMapFixture(page: Page, tileDelayMs = 600) {
     route.fulfill({ json: mockUser }),
   );
   await page.route(`${API}/albums/*/print-bundle*`, (route) =>
-    route.fulfill({ json: bundle }),
+    route.fulfill({ json: printBundle }),
   );
   await page.route(`${API}/albums/*/segments/points*`, (route) =>
     route.fulfill({ json: [hike] }),
   );
-  await page.route(`${API}/albums/*/media/*`, (route) =>
-    route.fulfill({
+  let fullMediaRequests = 0;
+  await page.route(`${API}/albums/*/media/*`, (route) => {
+    if (!new URL(route.request().url()).searchParams.has("w"))
+      fullMediaRequests++;
+    return route.fulfill({
       contentType: "image/jpeg",
       body: Buffer.from(TINY_JPEG_BASE64, "base64"),
-    }),
-  );
+    });
+  });
 
   let tileRequested = false;
   let tileFulfilled = false;
+  let releaseTiles = () => {};
+  const tileGate =
+    tileDelayMs === null
+      ? new Promise<void>((resolve) => {
+          releaseTiles = resolve;
+        })
+      : null;
   await page.route("**/e2e-map/**/*.png", async (route) => {
     tileRequested = true;
-    await new Promise((resolve) => setTimeout(resolve, tileDelayMs));
+    if (tileGate) await tileGate;
+    else if (tileDelayMs > 0)
+      await new Promise((resolve) => setTimeout(resolve, tileDelayMs));
     await route.fulfill({
       contentType: "image/png",
       body: BASEMAP_TILE,
@@ -118,7 +134,7 @@ async function installPdfMapFixture(page: Page, tileDelayMs = 600) {
         sources: {
           basemap: {
             type: "raster",
-            tiles: ["http://localhost:5173/e2e-map/{z}/{x}/{y}.png"],
+            tiles: [`${new URL(page.url()).origin}/e2e-map/{z}/{x}/{y}.png`],
             tileSize: 256,
             maxzoom: 14,
           },
@@ -129,7 +145,12 @@ async function installPdfMapFixture(page: Page, tileDelayMs = 600) {
             type: "background",
             paint: { "background-color": "#202020" },
           },
-          { id: "basemap", type: "raster", source: "basemap" },
+          {
+            id: "basemap",
+            type: "raster",
+            source: "basemap",
+            paint: { "raster-fade-duration": 1_500 },
+          },
         ],
       },
     }),
@@ -138,82 +159,165 @@ async function installPdfMapFixture(page: Page, tileDelayMs = 600) {
     route.fulfill({
       json: {
         tilejson: "2.2.0",
-        tiles: ["http://localhost:5173/e2e-dem/{z}/{x}/{y}.png"],
+        tiles: [`${new URL(page.url()).origin}/e2e-dem/{z}/{x}/{y}.png`],
         minzoom: 0,
         maxzoom: 14,
       },
     }),
+  );
+  await page.route("**/map-sessions/v1*", (route) =>
+    route.fulfill({ status: 204 }),
   );
 
   await page.emulateMedia({ media: "print" });
   return {
     tileRequested: () => tileRequested,
     tileFulfilled: () => tileFulfilled,
+    fullMediaRequests: () => fullMediaRequests,
+    releaseTiles,
   };
+}
+
+async function releasePrintMapMemory(page: Page) {
+  await page.waitForFunction(() => {
+    const record = window as unknown as Record<string, unknown>;
+    return (
+      document
+        .querySelector(".print-view")
+        ?.getAttribute("data-print-phase") === "map-memory" ||
+      Boolean(record.__PRINT_ERROR__)
+    );
+  });
+  if (
+    await page.evaluate(() =>
+      Boolean((window as unknown as Record<string, unknown>).__PRINT_ERROR__),
+    )
+  )
+    return;
+
+  await page.requestGC();
+  await page.evaluate(() => {
+    (
+      window as unknown as Record<string, unknown>
+    ).__PRINT_MAP_MEMORY_RELEASED__ = true;
+  });
 }
 
 async function snapshotColorCounts(page: Page) {
   return page.locator(".mapbox-print-snapshot").evaluateAll(
-    async (images, targets) =>
-      Promise.all(
-        images.map(async (image) => {
-          const img = image as HTMLImageElement;
-          await img.decode();
-          const canvas = document.createElement("canvas");
-          canvas.width = img.naturalWidth;
-          canvas.height = img.naturalHeight;
-          const context = canvas.getContext("2d", { willReadFrequently: true });
-          if (!context) throw new Error("2D canvas is unavailable");
-          context.drawImage(img, 0, 0);
-          const pixels = context.getImageData(
-            0,
-            0,
-            canvas.width,
-            canvas.height,
-          ).data;
-          const counts = targets.map(() => 0);
-          for (let i = 0; i < pixels.length; i += 4) {
-            targets.forEach((target, index) => {
-              if (
-                Math.abs(pixels[i] - target[0]) <= 12 &&
-                Math.abs(pixels[i + 1] - target[1]) <= 12 &&
-                Math.abs(pixels[i + 2] - target[2]) <= 12
-              ) {
-                counts[index]++;
-              }
-            });
-          }
-          return counts;
-        }),
-      ),
+    async (images, targets) => {
+      const results: number[][] = [];
+      const canvas = document.createElement("canvas");
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      if (!context) throw new Error("2D canvas is unavailable");
+
+      for (const image of images) {
+        const snapshot = image as HTMLCanvasElement | HTMLImageElement;
+        if (snapshot instanceof HTMLImageElement) await snapshot.decode();
+        const sourceWidth =
+          snapshot instanceof HTMLCanvasElement
+            ? snapshot.width
+            : snapshot.naturalWidth;
+        const sourceHeight =
+          snapshot instanceof HTMLCanvasElement
+            ? snapshot.height
+            : snapshot.naturalHeight;
+        const scale = Math.min(1, 1_000 / sourceWidth);
+        canvas.width = Math.round(sourceWidth * scale);
+        canvas.height = Math.round(sourceHeight * scale);
+        context.drawImage(snapshot, 0, 0, canvas.width, canvas.height);
+        const pixels = context.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height,
+        ).data;
+        const counts = targets.map(() => 0);
+        for (let i = 0; i < pixels.length; i += 4) {
+          targets.forEach((target, index) => {
+            if (
+              Math.abs(pixels[i] - target[0]) <= 12 &&
+              Math.abs(pixels[i + 1] - target[1]) <= 12 &&
+              Math.abs(pixels[i + 2] - target[2]) <= 12
+            ) {
+              counts[index]++;
+            }
+          });
+        }
+        results.push(counts);
+      }
+      canvas.width = 0;
+      canvas.height = 0;
+      return results;
+    },
     [BASEMAP_COLOR, OVERVIEW_ROUTE_COLOR, HIKE_ROUTE_COLOR],
   );
 }
 
 test.describe("PDF map snapshots", () => {
+  test.describe.configure({ timeout: 120_000 });
+
   test("waits for delayed basemap tiles and runtime routes", async ({
     page,
   }) => {
     const tiles = await installPdfMapFixture(page);
 
     await page.goto("/print/aid-1");
-    await expect.poll(tiles.tileRequested).toBe(true);
+    await expect.poll(tiles.tileRequested, { timeout: 30_000 }).toBe(true);
     expect(tiles.tileFulfilled()).toBe(false);
     expect(
       await page.evaluate(
         () => (window as unknown as Record<string, unknown>).__PRINT_READY__,
       ),
     ).not.toBe(true);
+    expect(tiles.fullMediaRequests()).toBe(0);
+    tiles.releaseTiles();
+    const mapMemoryReleased = releasePrintMapMemory(page);
+
+    await expect.poll(tiles.tileFulfilled, { timeout: 30_000 }).toBe(true);
+    await page.waitForTimeout(400);
+    await expect(page.locator("[data-map-snapshot-ready]")).toHaveCount(0);
+
+    await page.waitForFunction(
+      () => document.querySelectorAll("[data-map-snapshot-ready]").length >= 1,
+    );
+    expect(tiles.fullMediaRequests()).toBe(0);
+    await mapMemoryReleased;
 
     await page.waitForFunction(
       () =>
         (window as unknown as Record<string, unknown>).__PRINT_READY__ === true,
+    );
+    expect(tiles.fullMediaRequests()).toBeGreaterThan(0);
+    await expect(page.locator(".print-view")).toHaveAttribute(
+      "data-print-phase",
+      "ready",
     );
     expect(tiles.tileFulfilled()).toBe(true);
     const snapshots = page.locator(
       "[data-map][data-map-snapshot-ready] > .mapbox-print-snapshot",
     );
     await expect(snapshots).toHaveCount(2);
+    const elevationProfile = page.locator(
+      ".hike-map-canvas ~ .elevation-chart svg[role='img']",
+    );
+    await expect(elevationProfile).toHaveCount(1);
+    await expect(elevationProfile.locator("path[stroke]")).toHaveAttribute(
+      "d",
+      /\S+/,
+    );
+    const pixelRatios = await snapshots.evaluateAll((images) =>
+      images.map((image) => {
+        const snapshot = image as HTMLCanvasElement | HTMLImageElement;
+        const width =
+          snapshot instanceof HTMLCanvasElement
+            ? snapshot.width
+            : snapshot.naturalWidth;
+        return width / image.getBoundingClientRect().width;
+      }),
+    );
+    for (const pixelRatio of pixelRatios)
+      expect(pixelRatio).toBeGreaterThan(2.9);
 
     const counts = await snapshotColorCounts(page);
     expect(counts[0][0]).toBeGreaterThan(1_000);
@@ -225,14 +329,14 @@ test.describe("PDF map snapshots", () => {
   test("reports snapshot failure without marking the PDF ready", async ({
     page,
   }) => {
-    await page.addInitScript(() => {
-      HTMLCanvasElement.prototype.toDataURL = () => {
-        throw new Error("snapshot unavailable");
-      };
-    });
-    await installPdfMapFixture(page, 0);
+    const tiles = await installPdfMapFixture(page);
 
     await page.goto("/print/aid-1");
+    await expect.poll(tiles.tileRequested, { timeout: 30_000 }).toBe(true);
+    await page.evaluate(() => {
+      HTMLCanvasElement.prototype.toBlob = (callback) => callback(null);
+    });
+    tiles.releaseTiles();
     await page.waitForFunction(() =>
       Boolean((window as unknown as Record<string, unknown>).__PRINT_ERROR__),
     );
@@ -247,5 +351,65 @@ test.describe("PDF map snapshots", () => {
         () => (window as unknown as Record<string, unknown>).__PRINT_READY__,
       ),
     ).not.toBe(true);
+    expect(tiles.fullMediaRequests()).toBe(0);
+  });
+
+  test("renders every map in one print document without exhausting WebGL contexts", async ({
+    page,
+  }) => {
+    test.setTimeout(420_000);
+    const manyMapBundle: PrintBundle = {
+      ...bundle,
+      album: {
+        ...bundle.album,
+        maps_ranges: Array.from({ length: 18 }, (_, index) => [
+          "2024-01-01",
+          `2024-01-${String(index + 1).padStart(2, "0")}`,
+        ]),
+      },
+    };
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await installPdfMapFixture(page, 0, manyMapBundle);
+
+    await page.goto("/print/aid-1");
+    await releasePrintMapMemory(page);
+    const state = await page
+      .waitForFunction(() => {
+        const record = window as unknown as Record<string, unknown>;
+        if (record.__PRINT_READY__ !== true && !record.__PRINT_ERROR__)
+          return null;
+        return {
+          ready: record.__PRINT_READY__ === true,
+          error: record.__PRINT_ERROR__ ?? null,
+          maps: document.querySelectorAll("[data-map]").length,
+          snapshots: document.querySelectorAll(
+            "[data-map][data-map-snapshot-ready]",
+          ).length,
+        };
+      })
+      .then((result) => result.jsonValue());
+
+    expect(state).toEqual({
+      ready: true,
+      error: null,
+      maps: 19,
+      snapshots: 19,
+    });
+
+    await expect(page.locator(".album-container")).toHaveAttribute(
+      "data-expected-pages",
+      "22",
+    );
+    await expect(
+      page.locator("[data-map][data-map-snapshot-ready]"),
+    ).toHaveCount(19);
+    await expect(page.locator(".mapboxgl-canvas")).toHaveCount(0);
+    expect(await page.locator(".map-step-marker").count()).toBeGreaterThan(0);
+    expect(
+      consoleMessages.some((message) =>
+        message.includes("Too many active WebGL contexts"),
+      ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/components/album/MediaItem.vue
+++ b/frontend/src/components/album/MediaItem.vue
@@ -3,7 +3,7 @@ import type { PhotoQuality } from "@/utils/photoQuality";
 import { useAlbum } from "@/composables/useAlbum";
 import { usePhotoFocus, STEP_ID_KEY } from "@/composables/usePhotoFocus";
 import { registerQualityBadge } from "@/composables/usePhotoQuality";
-import { usePrintMode } from "@/composables/usePrintReady";
+import { usePrintMediaReady, usePrintMode } from "@/composables/usePrintReady";
 import { PROGRAMMATIC_SCROLL_KEY } from "@/composables/useProgrammaticScroll";
 import { useVideoFrameMutation } from "@/queries/useVideoFrameMutation";
 import PanoramaActions from "./PanoramaActions.vue";
@@ -64,10 +64,13 @@ const emit = defineEmits<{
 const { albumId, mediaByName, placementMediaUrl } = useAlbum();
 const openPanoramaDialog = usePanoramaFrame();
 const printMode = usePrintMode();
+const printMediaReady = usePrintMediaReady();
 const supportsIntersectionObserver =
   typeof window !== "undefined" && "IntersectionObserver" in window;
 const shouldLoadImmediately = computed(
-  () => printMode || !props.lazy || !supportsIntersectionObserver,
+  () =>
+    (printMode && printMediaReady.value) ||
+    (!printMode && (!props.lazy || !supportsIntersectionObserver)),
 );
 
 const programmaticScroll = inject(PROGRAMMATIC_SCROLL_KEY, ref(false));
@@ -92,6 +95,10 @@ const visible = useElementVisibility(rootRef, {
 });
 const loadImg = ref(shouldLoadImmediately.value);
 watchEffect(() => {
+  if (printMode) {
+    if (printMediaReady.value) loadImg.value = true;
+    return;
+  }
   if (
     shouldLoadImmediately.value ||
     (visible.value && !programmaticScroll.value)

--- a/frontend/src/components/album/PanoramaSpreadPage.vue
+++ b/frontend/src/components/album/PanoramaSpreadPage.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useAlbum } from "@/composables/useAlbum";
-import { usePrintMode } from "@/composables/usePrintReady";
+import { usePrintMediaReady, usePrintMode } from "@/composables/usePrintReady";
 import { usePanoramaFrame } from "@/composables/usePanoramaFrame";
 import { PAGE_HEIGHT_MM, PAGE_WIDTH_MM } from "@/utils/pageSize";
 import { computed } from "vue";
@@ -18,8 +18,12 @@ const emit = defineEmits<{
 const { placementMediaUrl } = useAlbum();
 const openPanoramaDialog = usePanoramaFrame();
 const printMode = usePrintMode();
+const printMediaReady = usePrintMediaReady();
 const spreadAspectRatio = (PAGE_WIDTH_MM * 2) / PAGE_HEIGHT_MM;
 const src = computed(() => placementMediaUrl(props.media));
+const renderedSrc = computed(() =>
+  printMode && !printMediaReady.value ? undefined : src.value,
+);
 
 function openPanoramaFrame(): void {
   openPanoramaDialog?.({
@@ -36,7 +40,7 @@ function openPanoramaFrame(): void {
     :data-media="media"
   >
     <img
-      :src="src"
+      :src="renderedSrc"
       alt=""
       class="panorama-media"
       :loading="printMode ? 'eager' : 'lazy'"
@@ -70,5 +74,4 @@ function openPanoramaFrame(): void {
 .side-right .panorama-media {
   left: -100%;
 }
-
 </style>

--- a/frontend/src/components/album/map/HikeMapPage.vue
+++ b/frontend/src/components/album/map/HikeMapPage.vue
@@ -64,7 +64,12 @@ const toTime = computed(
   () => (adjAfter.value || null)?.end_time ?? props.hikeSegment.end_time,
 );
 
-const { data: fetchedSegments } = useSegmentPointsQuery(fromTime, toTime);
+const { data: fetchedSegments } = useSegmentPointsQuery(
+  fromTime,
+  toTime,
+  true,
+  !printMode,
+);
 
 const fullHikeSegment = computed(() =>
   fetchedSegments.value?.find(

--- a/frontend/src/components/album/map/MapPage.vue
+++ b/frontend/src/components/album/map/MapPage.vue
@@ -38,6 +38,7 @@ const { data: segments } = useSegmentPointsQuery(
   fromTime,
   toTime,
   loadSegments,
+  !printMode,
 );
 const container = useTemplateRef("map");
 const { map, fitBounds } = useMapbox({

--- a/frontend/src/components/album/map/map-segments.css
+++ b/frontend/src/components/album/map/map-segments.css
@@ -28,6 +28,12 @@
   display: none;
 }
 
+.mapbox-print-marker-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
 @media print {
   [data-map][data-map-snapshot-ready] .mapboxgl-canvas {
     opacity: 0;

--- a/frontend/src/composables/useMapbox.ts
+++ b/frontend/src/composables/useMapbox.ts
@@ -29,6 +29,65 @@ mapboxgl.setRTLTextPlugin(
 
 const MAP_INIT_ROOT_MARGIN_PX = 200;
 const MAP_VISIBILITY_SETTLE_MS = 100;
+const MAX_CONCURRENT_PRINT_MAPS = 2;
+const PRINT_PIXEL_RATIO = 3;
+const PRINT_TILE_SETTLE_MS = 2_000;
+
+let activePrintMaps = 0;
+const queuedPrintMaps: Array<() => void> = [];
+let printPixelRatioUsers = 0;
+
+function acquirePrintPixelRatio(): () => void {
+  printPixelRatioUsers++;
+  if (printPixelRatioUsers === 1) {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: PRINT_PIXEL_RATIO,
+    });
+  }
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    printPixelRatioUsers--;
+    if (printPixelRatioUsers === 0)
+      Reflect.deleteProperty(window, "devicePixelRatio");
+  };
+}
+
+function enqueuePrintMap(start: (release: () => void) => void): () => void {
+  let state: "queued" | "active" | "done" = "queued";
+
+  const drain = () => {
+    while (
+      activePrintMaps < MAX_CONCURRENT_PRINT_MAPS &&
+      queuedPrintMaps.length > 0
+    ) {
+      queuedPrintMaps.shift()?.();
+    }
+  };
+  const release = () => {
+    if (state === "done") return;
+    if (state === "queued") {
+      const index = queuedPrintMaps.indexOf(run);
+      if (index !== -1) queuedPrintMaps.splice(index, 1);
+    } else {
+      activePrintMaps--;
+    }
+    state = "done";
+    drain();
+  };
+  const run = () => {
+    if (state !== "queued") return;
+    state = "active";
+    activePrintMaps++;
+    start(release);
+  };
+
+  queuedPrintMaps.push(run);
+  drain();
+  return release;
+}
 
 interface UseMapboxOptions {
   container: Ref<HTMLElement | null>;
@@ -49,13 +108,15 @@ function langFromLocale(locale: string | undefined): string {
 export function useMapbox(options: UseMapboxOptions) {
   mapboxgl.accessToken = getSettings().MAPBOX_TOKEN ?? "";
   const map = shallowRef<mapboxgl.Map | null>(null);
-  let pendingIdle: (() => void) | null = null;
   let pendingRender: (() => void) | null = null;
+  let readinessTimer: ReturnType<typeof setTimeout> | null = null;
   let readinessGeneration = 0;
   let initIdleHandle: number | null = null;
   let initTimeout: ReturnType<typeof setTimeout> | null = null;
   let visibilityTimeout: ReturnType<typeof setTimeout> | null = null;
   let initIntersectionObserver: IntersectionObserver | null = null;
+  let releasePrintSlot: (() => void) | null = null;
+  let releasePrintPixelRatio: (() => void) | null = null;
 
   function init() {
     if (!options.container.value || map.value) return;
@@ -100,6 +161,7 @@ export function useMapbox(options: UseMapboxOptions) {
       console.warn("[mapbox] failed to initialise map:", e);
       if (options.preserveDrawingBuffer) {
         el.dataset.mapError = "initialization-failed";
+        releasePrintMapSlot();
       } else {
         el.dataset.mapReady = "";
       }
@@ -122,29 +184,37 @@ export function useMapbox(options: UseMapboxOptions) {
   function armIdleReady(el: HTMLElement, m: mapboxgl.Map) {
     disarmIdleReady(m);
     const generation = ++readinessGeneration;
+    let tilesLoadedAt: number | null = null;
     delete el.dataset.mapReady;
     delete el.dataset.mapSnapshotReady;
     delete el.dataset.mapError;
-    let attempts = 0;
     const markReady = () => {
       if (generation !== readinessGeneration) return;
       el.dataset.mapReady = "";
-      pendingIdle = null;
       pendingRender = null;
+      if (readinessTimer !== null) {
+        clearTimeout(readinessTimer);
+        readinessTimer = null;
+      }
       if (idleFallback !== null) {
         clearTimeout(idleFallback);
         idleFallback = null;
       }
+      if (options.preserveDrawingBuffer) disposePrintMap(el, m, true);
     };
     const markError = (code: string) => {
       if (generation !== readinessGeneration) return;
       el.dataset.mapError = code;
-      pendingIdle = null;
       pendingRender = null;
+      if (readinessTimer !== null) {
+        clearTimeout(readinessTimer);
+        readinessTimer = null;
+      }
       if (idleFallback !== null) {
         clearTimeout(idleFallback);
         idleFallback = null;
       }
+      if (options.preserveDrawingBuffer) disposePrintMap(el, m, false);
     };
     const capture = async () => {
       if (generation !== readinessGeneration) return;
@@ -152,30 +222,78 @@ export function useMapbox(options: UseMapboxOptions) {
       if (await snapshotCanvasForPrint(el, m, generation)) markReady();
       else markError("snapshot-failed");
     };
+    let captureStarted = false;
+    const startCapture = () => {
+      if (captureStarted || generation !== readinessGeneration) return;
+      captureStarted = true;
+      if (readinessTimer !== null) {
+        clearTimeout(readinessTimer);
+        readinessTimer = null;
+      }
+      if (pendingRender) {
+        m.off("render", pendingRender);
+        pendingRender = null;
+      }
+      void capture();
+    };
     const check = () => {
       if (generation !== readinessGeneration) return;
-      if (!m.areTilesLoaded() && ++attempts < 20) {
-        m.once("idle", check);
+      readinessTimer = null;
+      if (!m.isStyleLoaded() || !m.areTilesLoaded()) {
+        tilesLoadedAt = null;
+        readinessTimer = setTimeout(check, 250);
         return;
       }
-      pendingIdle = null;
       if (!options.preserveDrawingBuffer) {
         markReady();
         return;
       }
-      pendingRender = () => void capture();
+      tilesLoadedAt ??= Date.now();
+      if (!m.idle() && Date.now() - tilesLoadedAt < PRINT_TILE_SETTLE_MS) {
+        readinessTimer = setTimeout(check, 250);
+        return;
+      }
+      pendingRender = startCapture;
       m.once("render", pendingRender);
       m.triggerRepaint();
+      readinessTimer = setTimeout(startCapture, 500);
     };
-    pendingIdle = check;
-    m.once("idle", check);
+    readinessTimer = setTimeout(check, 0);
     // Preview maps remain fail-open so a lost WebGL context does not leave the
     // editor blank. Print maps must fail the export instead of hiding damage.
     idleFallback = setTimeout(() => {
       if (el.dataset.mapReady || el.dataset.mapError) return;
       if (options.preserveDrawingBuffer) markError("render-timeout");
       else markReady();
-    }, 30_000);
+    }, 300_000);
+  }
+
+  function disposePrintMap(
+    el: HTMLElement,
+    m: mapboxgl.Map,
+    preserveMarkers: boolean,
+  ) {
+    if (preserveMarkers) {
+      const markers = el.querySelectorAll<HTMLElement>(".mapboxgl-marker");
+      if (markers.length > 0) {
+        const overlay = document.createElement("div");
+        overlay.className = "mapbox-print-marker-overlay";
+        overlay.setAttribute("aria-hidden", "true");
+        for (const marker of markers) overlay.append(marker.cloneNode(true));
+        el.append(overlay);
+      }
+    }
+    disarmIdleReady(m);
+    m.remove();
+    if (map.value === m) map.value = null;
+    releasePrintMapSlot();
+  }
+
+  function releasePrintMapSlot() {
+    releasePrintSlot?.();
+    releasePrintSlot = null;
+    releasePrintPixelRatio?.();
+    releasePrintPixelRatio = null;
   }
 
   async function snapshotCanvasForPrint(
@@ -187,23 +305,32 @@ export function useMapbox(options: UseMapboxOptions) {
       const canvas = m.getCanvas();
       if (canvas.width === 0 || canvas.height === 0) return false;
 
-      const dataUrl = canvas.toDataURL("image/png");
-      if (!dataUrl.startsWith("data:image/png;base64,") || dataUrl.length < 32)
-        return false;
+      const cssWidth = canvas.clientWidth || el.clientWidth;
+      const cssHeight = canvas.clientHeight || el.clientHeight;
+      if (cssWidth === 0 || cssHeight === 0) return false;
 
-      let snapshot = el.querySelector<HTMLImageElement>(
-        ":scope > .mapbox-print-snapshot",
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, "image/jpeg", 0.95),
       );
-      if (!snapshot) {
-        snapshot = document.createElement("img");
-        snapshot.className = "mapbox-print-snapshot";
-        snapshot.alt = "";
-        snapshot.setAttribute("aria-hidden", "true");
-        el.prepend(snapshot);
-      }
-      snapshot.src = dataUrl;
-      await snapshot.decode();
+      if (!blob || generation !== readinessGeneration) return false;
+
+      const snapshot = document.createElement("img");
+      snapshot.className = "mapbox-print-snapshot";
+      snapshot.alt = "";
+      snapshot.setAttribute("aria-hidden", "true");
+      snapshot.decoding = "async";
+      const objectUrl = URL.createObjectURL(blob);
+      await new Promise<void>((resolve, reject) => {
+        snapshot.addEventListener("load", () => resolve(), { once: true });
+        snapshot.addEventListener(
+          "error",
+          () => reject(new Error("image load failed")),
+          { once: true },
+        );
+        snapshot.src = objectUrl;
+      });
       if (generation !== readinessGeneration) return false;
+      el.prepend(snapshot);
       el.dataset.mapSnapshotReady = "";
       return true;
     } catch (e) {
@@ -213,9 +340,9 @@ export function useMapbox(options: UseMapboxOptions) {
   }
 
   function disarmIdleReady(m: mapboxgl.Map) {
-    if (pendingIdle) {
-      m.off("idle", pendingIdle);
-      pendingIdle = null;
+    if (readinessTimer !== null) {
+      clearTimeout(readinessTimer);
+      readinessTimer = null;
     }
     if (pendingRender) {
       m.off("render", pendingRender);
@@ -232,6 +359,7 @@ export function useMapbox(options: UseMapboxOptions) {
     if (map.value) disarmIdleReady(map.value);
     map.value?.remove();
     map.value = null;
+    releasePrintMapSlot();
   }
 
   function fitBounds(
@@ -254,6 +382,16 @@ export function useMapbox(options: UseMapboxOptions) {
   }
 
   function scheduleInit() {
+    if (options.preserveDrawingBuffer) {
+      const el = options.container.value;
+      if (el) el.dataset.map = "";
+      releasePrintPixelRatio = acquirePrintPixelRatio();
+      releasePrintSlot = enqueuePrintMap((release) => {
+        releasePrintSlot = release;
+        init();
+      });
+      return;
+    }
     if (!options.deferInit) {
       init();
       return;

--- a/frontend/src/composables/useMapbox.ts
+++ b/frontend/src/composables/useMapbox.ts
@@ -33,7 +33,8 @@ mapboxgl.setRTLTextPlugin(
 
 const MAP_INIT_ROOT_MARGIN_PX = 200;
 const MAP_VISIBILITY_SETTLE_MS = 100;
-const MAX_CONCURRENT_PRINT_MAPS = 2;
+const MAX_CONCURRENT_PRINT_MAPS = 4;
+const PRINT_MAPS_PER_CPU = 2;
 const PRINT_PIXEL_RATIO = 2;
 const PRINT_TILE_SETTLE_MS = 2_000;
 
@@ -42,7 +43,10 @@ const queuedPrintMaps: Array<() => void> = [];
 let printPixelRatioUsers = 0;
 
 function maxConcurrentPrintMaps(): number {
-  return Math.min(MAX_CONCURRENT_PRINT_MAPS, getPrintCpuCount() ?? 2);
+  return Math.min(
+    MAX_CONCURRENT_PRINT_MAPS,
+    (getPrintCpuCount() ?? 2) * PRINT_MAPS_PER_CPU,
+  );
 }
 
 function acquirePrintPixelRatio(): () => void {

--- a/frontend/src/composables/useMapbox.ts
+++ b/frontend/src/composables/useMapbox.ts
@@ -2,6 +2,10 @@ import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 
 import { useResizeObserver } from "@vueuse/core";
+import {
+  getPrintCpuCount,
+  getPrintTimeoutMs,
+} from "@/composables/usePrintReady";
 import { getSettings } from "@/config";
 import {
   onBeforeUnmount,
@@ -30,12 +34,16 @@ mapboxgl.setRTLTextPlugin(
 const MAP_INIT_ROOT_MARGIN_PX = 200;
 const MAP_VISIBILITY_SETTLE_MS = 100;
 const MAX_CONCURRENT_PRINT_MAPS = 2;
-const PRINT_PIXEL_RATIO = 3;
+const PRINT_PIXEL_RATIO = 2;
 const PRINT_TILE_SETTLE_MS = 2_000;
 
 let activePrintMaps = 0;
 const queuedPrintMaps: Array<() => void> = [];
 let printPixelRatioUsers = 0;
+
+function maxConcurrentPrintMaps(): number {
+  return Math.min(MAX_CONCURRENT_PRINT_MAPS, getPrintCpuCount() ?? 2);
+}
 
 function acquirePrintPixelRatio(): () => void {
   printPixelRatioUsers++;
@@ -60,7 +68,7 @@ function enqueuePrintMap(start: (release: () => void) => void): () => void {
 
   const drain = () => {
     while (
-      activePrintMaps < MAX_CONCURRENT_PRINT_MAPS &&
+      activePrintMaps < maxConcurrentPrintMaps() &&
       queuedPrintMaps.length > 0
     ) {
       queuedPrintMaps.shift()?.();
@@ -261,11 +269,14 @@ export function useMapbox(options: UseMapboxOptions) {
     readinessTimer = setTimeout(check, 0);
     // Preview maps remain fail-open so a lost WebGL context does not leave the
     // editor blank. Print maps must fail the export instead of hiding damage.
-    idleFallback = setTimeout(() => {
-      if (el.dataset.mapReady || el.dataset.mapError) return;
-      if (options.preserveDrawingBuffer) markError("render-timeout");
-      else markReady();
-    }, 300_000);
+    idleFallback = setTimeout(
+      () => {
+        if (el.dataset.mapReady || el.dataset.mapError) return;
+        if (options.preserveDrawingBuffer) markError("render-timeout");
+        else markReady();
+      },
+      Math.max(300_000, getPrintTimeoutMs() - 60_000),
+    );
   }
 
   function disposePrintMap(

--- a/frontend/src/composables/usePrintReady.ts
+++ b/frontend/src/composables/usePrintReady.ts
@@ -11,6 +11,26 @@ const KEY: InjectionKey<true> = Symbol("print-mode");
 const MEDIA_READY_KEY: InjectionKey<Readonly<Ref<boolean>>> =
   Symbol("print-media-ready");
 const MEDIA_READY_DEFAULT = readonly(ref(true));
+const DEFAULT_PRINT_TIMEOUT_MS = 900_000;
+
+type PrintRuntimeWindow = Window & {
+  __PRINT_CPU_COUNT__?: unknown;
+  __PRINT_TIMEOUT_MS__?: unknown;
+};
+
+export function getPrintTimeoutMs(): number {
+  const value = (window as PrintRuntimeWindow).__PRINT_TIMEOUT_MS__;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_PRINT_TIMEOUT_MS;
+}
+
+export function getPrintCpuCount(): number | undefined {
+  const value = (window as PrintRuntimeWindow).__PRINT_CPU_COUNT__;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
 
 /** Call in AlbumViewer when printMode is true. */
 export function providePrintMode(): void {

--- a/frontend/src/composables/usePrintReady.ts
+++ b/frontend/src/composables/usePrintReady.ts
@@ -1,6 +1,16 @@
-import { inject, provide, type InjectionKey } from "vue";
+import {
+  inject,
+  provide,
+  readonly,
+  ref,
+  type InjectionKey,
+  type Ref,
+} from "vue";
 
 const KEY: InjectionKey<true> = Symbol("print-mode");
+const MEDIA_READY_KEY: InjectionKey<Readonly<Ref<boolean>>> =
+  Symbol("print-media-ready");
+const MEDIA_READY_DEFAULT = readonly(ref(true));
 
 /** Call in AlbumViewer when printMode is true. */
 export function providePrintMode(): void {
@@ -9,4 +19,12 @@ export function providePrintMode(): void {
 
 export function usePrintMode(): boolean {
   return inject(KEY, false) === true;
+}
+
+export function providePrintMediaReady(ready: Ref<boolean>): void {
+  provide(MEDIA_READY_KEY, readonly(ready));
+}
+
+export function usePrintMediaReady(): Readonly<Ref<boolean>> {
+  return inject(MEDIA_READY_KEY, MEDIA_READY_DEFAULT);
 }

--- a/frontend/src/pages/PrintView.vue
+++ b/frontend/src/pages/PrintView.vue
@@ -3,7 +3,10 @@ import AlbumViewer from "@/components/AlbumViewer.vue";
 import { usePrintBundleQuery } from "@/queries/queries";
 import { useUserQuery } from "@/queries/useUserQuery";
 import { useLocale } from "@/composables/useLocale";
-import { providePrintMediaReady } from "@/composables/usePrintReady";
+import {
+  getPrintTimeoutMs,
+  providePrintMediaReady,
+} from "@/composables/usePrintReady";
 import { ALLOWED_FONTS } from "@/utils/fonts";
 import { useI18n } from "vue-i18n";
 import { Dark } from "quasar";
@@ -99,7 +102,7 @@ function setPrintError(error: PrintError) {
 }
 
 function waitForPrintReady() {
-  const MAX_WAIT = 900_000;
+  const MAX_WAIT = getPrintTimeoutMs();
   const startTime = Date.now();
   let waiting = false;
 

--- a/frontend/src/pages/PrintView.vue
+++ b/frontend/src/pages/PrintView.vue
@@ -3,10 +3,11 @@ import AlbumViewer from "@/components/AlbumViewer.vue";
 import { usePrintBundleQuery } from "@/queries/queries";
 import { useUserQuery } from "@/queries/useUserQuery";
 import { useLocale } from "@/composables/useLocale";
+import { providePrintMediaReady } from "@/composables/usePrintReady";
 import { ALLOWED_FONTS } from "@/utils/fonts";
 import { useI18n } from "vue-i18n";
 import { Dark } from "quasar";
-import { computed, onMounted, onUnmounted } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRoute } from "vue-router";
 import type { SegmentOutline } from "@/client";
 
@@ -24,6 +25,13 @@ const { data: bundle, error } = usePrintBundleQuery(aid, chapterId);
 const { locale } = useUserQuery();
 const { t } = useI18n();
 useLocale(locale);
+
+const printMediaReady = ref(false);
+const printPhase = ref<"maps" | "map-memory" | "media" | "ready" | "error">(
+  "maps",
+);
+const printMapsCaptured = ref(false);
+providePrintMediaReady(printMediaReady);
 
 const album = computed(() => bundle.value?.album);
 const media = computed(() => bundle.value?.album.media ?? []);
@@ -81,15 +89,17 @@ let pollTimer = 0;
 type PrintError = {
   code: "map-render-failed" | "render-timeout";
   message: string;
+  mapError?: string;
 };
 
 function setPrintError(error: PrintError) {
   clearTimeout(pollTimer);
+  printPhase.value = "error";
   (window as unknown as Record<string, unknown>).__PRINT_ERROR__ = error;
 }
 
 function waitForPrintReady() {
-  const MAX_WAIT = 45_000;
+  const MAX_WAIT = 900_000;
   const startTime = Date.now();
   let waiting = false;
 
@@ -124,14 +134,6 @@ function waitForPrintReady() {
       return;
     }
 
-    const pending = Array.from(
-      document.querySelectorAll<HTMLImageElement>("[data-media] img"),
-    ).filter((img) => !img.complete);
-    if (pending.length > 0) {
-      schedulePoll(300);
-      return;
-    }
-
     const failedMap = document.querySelector<HTMLElement>(
       "[data-map][data-map-error]",
     );
@@ -139,15 +141,48 @@ function waitForPrintReady() {
       setPrintError({
         code: "map-render-failed",
         message: `A map could not be rendered (${failedMap.dataset.mapError}).`,
+        mapError: failedMap.dataset.mapError ?? "unknown",
       });
       return;
     }
 
-    // A print map is ready only after its decoded canvas snapshot is installed.
+    // A print map is ready only after its image snapshot is installed.
     const unreadyMaps = document.querySelectorAll(
       "[data-map]:not([data-map-snapshot-ready])",
     );
     if (unreadyMaps.length > 0) {
+      schedulePoll(300);
+      return;
+    }
+
+    if (!printMapsCaptured.value) {
+      printMapsCaptured.value = true;
+      printPhase.value = "map-memory";
+      schedulePoll(0);
+      return;
+    }
+
+    const hasPrintMaps = document.querySelector("[data-map]") !== null;
+    if (
+      hasPrintMaps &&
+      !(window as unknown as Record<string, unknown>)
+        .__PRINT_MAP_MEMORY_RELEASED__
+    ) {
+      schedulePoll(100);
+      return;
+    }
+
+    if (!printMediaReady.value) {
+      printMediaReady.value = true;
+      printPhase.value = "media";
+      schedulePoll(0);
+      return;
+    }
+
+    const pending = Array.from(
+      document.querySelectorAll<HTMLImageElement>("[data-media] img"),
+    ).filter((img) => !img.complete);
+    if (pending.length > 0) {
       schedulePoll(300);
       return;
     }
@@ -166,6 +201,7 @@ function waitForPrintReady() {
 
   function setReady() {
     clearTimeout(pollTimer);
+    printPhase.value = "ready";
     // Remove trailing page break to prevent an empty last page in PDF output.
     const pages = document.querySelectorAll(".page-container");
     if (pages.length) {
@@ -182,7 +218,7 @@ onUnmounted(() => clearTimeout(pollTimer));
 </script>
 
 <template>
-  <div class="print-view">
+  <div class="print-view" :data-print-phase="printPhase">
     <div v-if="error" class="status-message flex flex-center text-negative">
       {{ t("error.loadAlbum") }} {{ error.message }}
     </div>

--- a/frontend/src/queries/useSegmentPointsQuery.ts
+++ b/frontend/src/queries/useSegmentPointsQuery.ts
@@ -26,6 +26,7 @@ export function useSegmentPointsQuery(
   fromTime: Ref<number>,
   toTime: Ref<number>,
   enabled: MaybeRefOrGetter<boolean> = true,
+  refetchUnmatchedRoutes: MaybeRefOrGetter<boolean> = true,
 ) {
   const { albumId } = useAlbum();
 
@@ -65,6 +66,7 @@ export function useSegmentPointsQuery(
     if (
       disposed ||
       !toValue(enabled) ||
+      !toValue(refetchUnmatchedRoutes) ||
       !hasUnmatchedRoute(query.data.value) ||
       attempts >= ROUTE_REFETCH_LIMIT
     )
@@ -81,7 +83,7 @@ export function useSegmentPointsQuery(
   }
 
   watch(
-    [query.data, () => toValue(enabled)],
+    [query.data, () => toValue(enabled), () => toValue(refetchUnmatchedRoutes)],
     () => {
       if (!hasUnmatchedRoute(query.data.value)) attempts = 0;
       schedule();

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ dev = [
     { name = "pytest-httpx", specifier = "~=0.35" },
     { name = "pytest-randomly", specifier = "~=4.0" },
     { name = "ruff", specifier = "<1" },
-    { name = "syrupy", specifier = "~=5.0" },
+    { name = "syrupy", specifier = "~=6.0" },
     { name = "ty", specifier = "<1" },
     { name = "vulture", specifier = ">=2.16" },
 ]
@@ -1602,14 +1602,14 @@ wheels = [
 
 [[package]]
 name = "syrupy"
-version = "5.1.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/b0/24bca682d6a6337854be37f242d116cceeda9942571d5804c44bc1bdd427/syrupy-5.1.0.tar.gz", hash = "sha256:df543c7aa50d3cf1246e83d58fe490afe5f7dab7b41e74ecc0d8d23ae19bd4b8", size = 50495, upload-time = "2026-01-25T14:53:06.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/a7/3c797c76994dc817582abdda90ee31867a9883567b0add47dbc0ccb12ce4/syrupy-6.0.0.tar.gz", hash = "sha256:bf4f5f662a7b23a9e5711bd5597e301cd09c00f31be5fa4095f79da7b0585f3d", size = 99435, upload-time = "2026-08-22T20:48:39.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/70/cf880c3b95a6034ef673e74b369941b42315c01f1554a5637a4f8b911009/syrupy-5.1.0-py3-none-any.whl", hash = "sha256:95162d2b05e61ed3e13f117b88dfab7c58bd6f90e66ebbf918e8a77114ad51c5", size = 51658, upload-time = "2026-01-25T14:53:05.105Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ff/4d8ae6d6070ea73ee9d466701584a75db9586ce09de98f8f1b3276efad5f/syrupy-6.0.0-py3-none-any.whl", hash = "sha256:3efa16d767bd8614413cc20057552e4aec14428c6e5ea788c1f7e03047e8a5e4", size = 58047, upload-time = "2026-08-22T20:48:38.213Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Closes #196

- Render at most two print maps concurrently at 2x device pixel ratio, and capture only after the style, tiles, fade, route, and terrain layers have settled.
- Scale map concurrency and the shared browser/backend readiness deadlines to the CPUs available inside the container.
- Replace each live WebGL map with a decoded JPEG snapshot, preserve its markers, then dispose Mapbox immediately so large albums do not exhaust WebGL contexts.
- Wait for every map snapshot, ask Chromium to release map memory, and only then load album media. Snapshot failures and timeouts fail the export with structured error details instead of returning a partial PDF.
