### PR TITLE
fix: make route enrichment failures durable

### DIFF
--- a/backend/app/alembic/versions/c071165892df_track_segment_route_enrichment.py
+++ b/backend/app/alembic/versions/c071165892df_track_segment_route_enrichment.py
@@ -1,0 +1,85 @@
+"""Track segment route enrichment.
+
+Revision ID: c071165892df
+Revises: 34461f89a555
+Create Date: 2026-08-31 17:54:58.821394
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "c071165892df"
+down_revision = "34461f89a555"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sa.Enum(
+        "matched", "no_route", "failed", name="routeenrichmentstatus"
+    ).create(op.get_bind())
+    op.create_table(
+        "segment_route_enrichment",
+        sa.Column("uid", sa.Integer(), nullable=False),
+        sa.Column("aid", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("start_time", sa.Float(), nullable=False),
+        sa.Column("end_time", sa.Float(), nullable=False),
+        sa.Column(
+            "status",
+            postgresql.ENUM(
+                "matched",
+                "no_route",
+                "failed",
+                name="routeenrichmentstatus",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "error_code",
+            sqlmodel.sql.sqltypes.AutoString(length=100),
+            nullable=True,
+        ),
+        sa.Column("attempted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["uid", "aid", "start_time", "end_time"],
+            [
+                "segment.uid",
+                "segment.aid",
+                "segment.start_time",
+                "segment.end_time",
+            ],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("uid", "aid", "start_time", "end_time"),
+    )
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO segment_route_enrichment (
+                uid, aid, start_time, end_time, status, error_code, attempted_at
+            )
+            SELECT
+                uid,
+                aid,
+                start_time,
+                end_time,
+                'matched'::routeenrichmentstatus,
+                NULL,
+                CURRENT_TIMESTAMP
+            FROM segment
+            WHERE route IS NOT NULL AND route::text <> 'null'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("segment_route_enrichment")
+    sa.Enum(
+        "matched", "no_route", "failed", name="routeenrichmentstatus"
+    ).drop(op.get_bind())

--- a/backend/app/logic/segment_routes.py
+++ b/backend/app/logic/segment_routes.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import structlog
 from dbos import DBOS, SetWorkflowID
-from sqlalchemy import String, cast, or_, update
+from sqlalchemy import String, and_, cast, or_
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -17,8 +16,12 @@ from app.core.http_clients import HttpClients
 from app.core.locks import try_advisory_lock
 from app.core.observability import set_span_data, start_span
 from app.logic.route_matching import MATCHABLE_KINDS
-from app.models.segment import Segment
-from app.services.mapbox import match_segments_with_stats
+from app.models.segment import (
+    RouteEnrichmentStatus,
+    Segment,
+    SegmentRouteEnrichment,
+)
+from app.services.mapbox import RouteMatchResult, match_segments_with_stats
 
 if TYPE_CHECKING:
     from fastapi import BackgroundTasks
@@ -33,26 +36,43 @@ type SegmentSnapshot = tuple[SegmentKey, list[tuple[float, float]], str]
 _route_http_clients: list[HttpClients] = []
 
 
+class RouteEnrichmentIncompleteError(RuntimeError):
+    pass
+
+
 @dataclass
 class RouteEnrichmentStats:
     candidates: int = 0
     matched: int = 0
+    no_route: int = 0
+    failed: int = 0
+    recorded: int = 0
     updated: int = 0
     route_requests: int = 0
     matching_requests: int = 0
     directions_requests: int = 0
-
-    @property
-    def skipped(self) -> int:
-        return self.candidates - self.matched
+    already_running: bool = False
 
     @property
     def stale(self) -> int:
-        return self.matched - self.updated
+        return self.candidates - self.recorded
 
 
 def _route_missing() -> ColumnElement[bool]:
     return or_(col(Segment.route).is_(None), cast(col(Segment.route), String) == "null")
+
+
+def _without_enrichment_state() -> ColumnElement[bool]:
+    return col(SegmentRouteEnrichment.uid).is_(None)
+
+
+def _enrichment_join() -> ColumnElement[bool]:
+    return and_(
+        col(SegmentRouteEnrichment.uid) == col(Segment.uid),
+        col(SegmentRouteEnrichment.aid) == col(Segment.aid),
+        col(SegmentRouteEnrichment.start_time) == col(Segment.start_time),
+        col(SegmentRouteEnrichment.end_time) == col(Segment.end_time),
+    )
 
 
 def enqueue_album_route_enrichment(
@@ -89,12 +109,53 @@ def route_enrichment_payload(uid: int, aid: str) -> dict[str, Any]:
     return {"uid": uid, "aid": aid}
 
 
-@DBOS.workflow(name="route.enrich_album")
-async def album_route_enrichment_workflow(payload: dict[str, Any]) -> dict[str, Any]:
+@DBOS.step(
+    retries_allowed=True,
+    max_attempts=3,
+    interval_seconds=5,
+    backoff_rate=2,
+)
+async def enrich_album_routes_step(payload: dict[str, Any]) -> dict[str, Any]:
     uid = int(payload["uid"])
     aid = str(payload["aid"])
-    await match_album_segment_routes(get_route_enrichment_http_clients(), uid, aid)
-    return route_enrichment_payload(uid, aid)
+    stats = await match_album_segment_routes(
+        get_route_enrichment_http_clients(), uid, aid
+    )
+    return asdict(stats)
+
+
+@DBOS.step(retries_allowed=True, max_attempts=3)
+async def mark_album_route_failure_step(
+    payload: dict[str, Any], error_code: str
+) -> int:
+    uid = int(payload["uid"])
+    aid = str(payload["aid"])
+    async with AsyncSession(get_engine()) as session:
+        return await _mark_pending_failed(session, uid, aid, error_code)
+
+
+@DBOS.workflow(name="route.enrich_album")
+async def album_route_enrichment_workflow(payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        result = await enrich_album_routes_step(payload)
+    except Exception as exc:
+        error_code = f"retry_exhausted:{type(exc).__name__}"
+        try:
+            await mark_album_route_failure_step(payload, error_code)
+        except Exception as marker_exc:
+            logger.exception(
+                "route_enrichment.failure_record_failed",
+                user_id=int(payload["uid"]),
+                album_id=str(payload["aid"]),
+                error_type=type(marker_exc).__name__,
+            )
+        raise
+
+    stats = RouteEnrichmentStats(**result)
+    if stats.failed:
+        msg = f"route enrichment recorded {stats.failed} failed segment(s)"
+        raise RouteEnrichmentIncompleteError(msg)
+    return route_enrichment_payload(int(payload["uid"]), str(payload["aid"]))
 
 
 def start_album_route_enrichment(uid: int, aid: str) -> object:
@@ -114,36 +175,64 @@ def start_album_route_enrichment(uid: int, aid: str) -> object:
         return None
 
 
-async def match_album_segment_routes(http: HttpClients, uid: int, aid: str) -> None:
+async def pending_route_enrichment_targets(
+    session: AsyncSession,
+) -> list[tuple[int, str]]:
+    rows = await session.exec(
+        select(Segment.uid, Segment.aid)
+        .outerjoin(SegmentRouteEnrichment, _enrichment_join())
+        .where(
+            col(Segment.kind).in_(MATCHABLE_KINDS),
+            _route_missing(),
+            _without_enrichment_state(),
+        )
+        .distinct()
+        .order_by(col(Segment.uid), col(Segment.aid))
+    )
+    return list(rows.all())
+
+
+async def reconcile_missing_route_enrichments() -> None:
+    async with AsyncSession(get_engine()) as session:
+        targets = await pending_route_enrichment_targets(session)
+    for uid, aid in targets:
+        start_album_route_enrichment(uid, aid)
+
+
+async def match_album_segment_routes(
+    http: HttpClients, uid: int, aid: str
+) -> RouteEnrichmentStats:
     lock_key = f"segment-route-match:{uid}:{aid}"
     started = time.perf_counter()
-    try:
-        with start_span(
-            "route_enrichment.run",
-            "Run route enrichment",
-            **{"app.workflow": "route_enrichment", "user.id": uid, "album.id": aid},
-        ) as span:
-            async with try_advisory_lock(lock_key) as acquired:
-                if not acquired:
-                    set_span_data(span, result="already_running")
-                    logger.info(
-                        "route_enrichment.already_running",
-                        user_id=uid,
-                        album_id=aid,
-                    )
-                    return
+    with start_span(
+        "route_enrichment.run",
+        "Run route enrichment",
+        **{"app.workflow": "route_enrichment", "user.id": uid, "album.id": aid},
+    ) as span:
+        async with try_advisory_lock(lock_key) as acquired:
+            if not acquired:
+                stats = RouteEnrichmentStats(already_running=True)
+                set_span_data(span, result="already_running")
+                logger.info(
+                    "route_enrichment.already_running",
+                    user_id=uid,
+                    album_id=aid,
+                )
+                return stats
 
+            try:
                 async with AsyncSession(get_engine()) as session:
-                    await _match_routes_in_session(
+                    return await _match_routes_in_session(
                         http, session, uid, aid, span, started
                     )
-    except Exception:
-        logger.exception(
-            "route_enrichment.failed",
-            user_id=uid,
-            album_id=aid,
-            duration_ms=_duration_ms(started),
-        )
+            except Exception:
+                logger.exception(
+                    "route_enrichment.failed",
+                    user_id=uid,
+                    album_id=aid,
+                    duration_ms=_duration_ms(started),
+                )
+                raise
 
 
 async def _match_routes_in_session(  # noqa: PLR0913
@@ -153,13 +242,13 @@ async def _match_routes_in_session(  # noqa: PLR0913
     aid: str,
     span: Span,
     started: float,
-) -> None:
+) -> RouteEnrichmentStats:
     snapshots = await _unmatched_snapshots(session, uid, aid)
     if not snapshots:
         stats = RouteEnrichmentStats()
         _set_route_span_data(span, stats, result="empty")
         _log_complete(uid, aid, started, stats)
-        return
+        return stats
 
     pairs = [(coords, profile) for _, coords, profile in snapshots]
     with start_span(
@@ -172,7 +261,7 @@ async def _match_routes_in_session(  # noqa: PLR0913
             "route.candidates": len(snapshots),
         },
     ):
-        routes, route_stats = await match_segments_with_stats(
+        results, route_stats = await match_segments_with_stats(
             http.mapbox_matching,
             http.mapbox_directions,
             pairs,
@@ -182,13 +271,26 @@ async def _match_routes_in_session(  # noqa: PLR0913
     stats.route_requests = route_stats.requests
     stats.matching_requests = route_stats.matching_requests
     stats.directions_requests = route_stats.directions_requests
-    for (key, _, _), route in zip(snapshots, routes, strict=True):
-        if route:
+    for (key, _, _), result in zip(snapshots, results, strict=True):
+        outcome = result
+        if outcome.status == RouteEnrichmentStatus.matched and not outcome.route:
+            outcome = RouteMatchResult(
+                status=RouteEnrichmentStatus.failed,
+                error_code="invalid_geometry",
+            )
+        if outcome.status == RouteEnrichmentStatus.matched:
             stats.matched += 1
-            stats.updated += await _write_route(session, key, route)
+        elif outcome.status == RouteEnrichmentStatus.no_route:
+            stats.no_route += 1
+        else:
+            stats.failed += 1
+        recorded, updated = await _write_outcome(session, key, outcome)
+        stats.recorded += recorded
+        stats.updated += updated
     await session.commit()
     _set_route_span_data(span, stats, result="completed")
     _log_complete(uid, aid, started, stats)
+    return stats
 
 
 def _duration_ms(started: float) -> int:
@@ -207,8 +309,10 @@ def _set_route_span_data(
         **{
             "route.candidates": stats.candidates,
             "route.matched": stats.matched,
+            "route.no_route": stats.no_route,
+            "route.failed": stats.failed,
+            "route.recorded": stats.recorded,
             "route.updated": stats.updated,
-            "route.skipped": stats.skipped,
             "route.stale": stats.stale,
             "route.requests": stats.route_requests,
             "mapbox.matching_requests": stats.matching_requests,
@@ -229,8 +333,10 @@ def _log_complete(
         album_id=aid,
         candidates=stats.candidates,
         matched=stats.matched,
+        no_route=stats.no_route,
+        failed=stats.failed,
+        recorded=stats.recorded,
         updated=stats.updated,
-        skipped=stats.skipped,
         stale=stats.stale,
         route_requests=stats.route_requests,
         matching_requests=stats.matching_requests,
@@ -244,11 +350,13 @@ async def _unmatched_snapshots(
 ) -> list[SegmentSnapshot]:
     result = await session.exec(
         select(Segment)
+        .outerjoin(SegmentRouteEnrichment, _enrichment_join())
         .where(
             Segment.uid == uid,
             Segment.aid == aid,
             col(Segment.kind).in_(MATCHABLE_KINDS),
             _route_missing(),
+            _without_enrichment_state(),
         )
         .order_by(col(Segment.start_time))
     )
@@ -262,21 +370,49 @@ async def _unmatched_snapshots(
     ]
 
 
-async def _write_route(
+async def _write_outcome(
     session: AsyncSession,
     key: SegmentKey,
-    route: Sequence[tuple[float, float]],
-) -> int:
-    uid, aid, start_time, end_time = key
-    result = await session.exec(
-        update(Segment)
-        .where(
-            col(Segment.uid) == uid,
-            col(Segment.aid) == aid,
-            col(Segment.start_time) == start_time,
-            col(Segment.end_time) == end_time,
-            _route_missing(),
+    result: RouteMatchResult,
+) -> tuple[int, int]:
+    segment = await session.get(Segment, key)
+    state = await session.get(SegmentRouteEnrichment, key)
+    if segment is None or segment.route is not None or state is not None:
+        return 0, 0
+
+    updated = 0
+    if result.status == RouteEnrichmentStatus.matched and result.route:
+        segment.route = list(result.route)
+        session.add(segment)
+        updated = 1
+
+    session.add(
+        SegmentRouteEnrichment(
+            uid=segment.uid,
+            aid=segment.aid,
+            start_time=segment.start_time,
+            end_time=segment.end_time,
+            status=result.status,
+            error_code=result.error_code,
         )
-        .values(route=list(route))
     )
-    return result.rowcount or 0
+    return 1, updated
+
+
+async def _mark_pending_failed(
+    session: AsyncSession,
+    uid: int,
+    aid: str,
+    error_code: str,
+) -> int:
+    snapshots = await _unmatched_snapshots(session, uid, aid)
+    failed = RouteMatchResult(
+        status=RouteEnrichmentStatus.failed,
+        error_code=error_code[:100],
+    )
+    recorded = 0
+    for key, _, _ in snapshots:
+        wrote, _ = await _write_outcome(session, key, failed)
+        recorded += wrote
+    await session.commit()
+    return recorded

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,10 @@ from app.logic.export import lifespan as export_lifespan
 from app.logic.external_media.undo import lifespan as undo_lifespan
 from app.logic.media_upgrade.pipeline import cleanup_orphaned_tmp
 from app.logic.pdf import lifespan as pdf_lifespan
-from app.logic.segment_routes import set_route_enrichment_http_clients
+from app.logic.segment_routes import (
+    reconcile_missing_route_enrichments,
+    set_route_enrichment_http_clients,
+)
 from app.logic.session import cancel_all_sessions
 from app.logic.storage_metrics import storage_metrics_loop
 from app.logic.uploads.cleanup import upload_cleanup_loop
@@ -59,6 +62,16 @@ async def _reconcile_media_hashes() -> None:
         )
 
 
+async def _reconcile_segment_routes() -> None:
+    try:
+        await reconcile_missing_route_enrichments()
+    except Exception as exc:
+        logger.exception(
+            "route_enrichment.startup_reconciliation_failed",
+            error_type=type(exc).__name__,
+        )
+
+
 def _launch_background_tasks(
     upload_store: UploadStoreService,
 ) -> list[asyncio.Task[None]]:
@@ -84,6 +97,7 @@ async def _dbos_lifespan(
     upload_store: UploadStoreService,
 ) -> AsyncGenerator[None]:
     await launch_dbos(settings)
+    await _reconcile_segment_routes()
     await _reconcile_media_hashes()
     tasks = _launch_background_tasks(upload_store)
     try:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,9 @@ from app.models.processing import (
     ProcessingOperation as ProcessingOperation,
     UploadSession as UploadSession,
 )
-from app.models.segment import Segment as Segment
+from app.models.segment import (
+    Segment as Segment,
+    SegmentRouteEnrichment as SegmentRouteEnrichment,
+)
 from app.models.step import Step as Step
 from app.models.user import User as User

--- a/backend/app/models/segment.py
+++ b/backend/app/models/segment.py
@@ -1,10 +1,11 @@
 from bisect import bisect_right
+from datetime import UTC, datetime
 from enum import StrEnum
 from operator import attrgetter
 from typing import Literal, NamedTuple
 
 from pydantic import BaseModel
-from sqlalchemy import ForeignKeyConstraint
+from sqlalchemy import DateTime, ForeignKeyConstraint
 from sqlmodel import Column, Field, SQLModel
 
 from app.core.db import PydanticJSON
@@ -19,6 +20,12 @@ class SegmentKind(StrEnum):
     hike = "hike"
     walking = "walking"
     driving = "driving"
+
+
+class RouteEnrichmentStatus(StrEnum):
+    matched = "matched"
+    no_route = "no_route"
+    failed = "failed"
 
 
 class SegmentData(NamedTuple):
@@ -47,6 +54,28 @@ class Segment(SQLModel, table=True):
     route: list[tuple[float, float]] | None = Field(
         default=None,
         sa_column=Column(PydanticJSON(list[tuple[float, float]] | None), nullable=True),
+    )
+
+
+class SegmentRouteEnrichment(SQLModel, table=True):
+    __tablename__ = "segment_route_enrichment"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["uid", "aid", "start_time", "end_time"],
+            ["segment.uid", "segment.aid", "segment.start_time", "segment.end_time"],
+            ondelete="CASCADE",
+        ),
+    )
+
+    uid: int = Field(primary_key=True)
+    aid: str = Field(primary_key=True)
+    start_time: float = Field(primary_key=True)
+    end_time: float = Field(primary_key=True)
+    status: RouteEnrichmentStatus
+    error_code: str | None = Field(default=None, max_length=100)
+    attempted_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
     )
 
 

--- a/backend/app/services/mapbox.py
+++ b/backend/app/services/mapbox.py
@@ -1,7 +1,7 @@
 """Mapbox Map Matching & Directions API client.
 
 Density-based API selection: dense GPS → Map Matching, sparse → Directions.
-Rate-limited to stay under Mapbox free-tier limits (60 req/min).
+Rate limiting is provided by the shared Mapbox HTTP clients.
 """
 
 import asyncio
@@ -22,6 +22,7 @@ from app.logic.route_matching import (
     simplify_route,
     total_length_km,
 )
+from app.models.segment import RouteEnrichmentStatus
 
 logger = structlog.get_logger(__name__)
 
@@ -50,6 +51,16 @@ class MapboxRouteClients:
     directions: MapboxClient
 
 
+class MapboxTransientError(RuntimeError):
+    pass
+
+
+class RouteMatchResult(BaseModel):
+    status: RouteEnrichmentStatus
+    route: Coords | None = None
+    error_code: str | None = None
+
+
 class _GeoJSONLineString(BaseModel):
     type: Literal["LineString"]
     coordinates: list[list[float]]
@@ -60,6 +71,7 @@ class _Matching(BaseModel):
 
 
 class _MatchingResponse(BaseModel):
+    code: str = "Ok"
     matchings: list[_Matching] = []
 
 
@@ -68,7 +80,54 @@ class _Route(BaseModel):
 
 
 class _DirectionsResponse(BaseModel):
+    code: str = "Ok"
     routes: list[_Route] = []
+
+
+_NO_ROUTE_CODES = frozenset({"NoMatch", "NoRoute", "NoSegment"})
+
+
+def _failed(error_code: str) -> RouteMatchResult:
+    return RouteMatchResult(
+        status=RouteEnrichmentStatus.failed,
+        error_code=error_code[:100],
+    )
+
+
+def _no_route(error_code: str) -> RouteMatchResult:
+    return RouteMatchResult(
+        status=RouteEnrichmentStatus.no_route,
+        error_code=error_code[:100],
+    )
+
+
+def _matched(route: Coords) -> RouteMatchResult:
+    return RouteMatchResult(status=RouteEnrichmentStatus.matched, route=route)
+
+
+def _response_error_code(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict) and isinstance(payload.get("code"), str):
+        return payload["code"]
+    return f"http_{response.status_code}"
+
+
+def _http_failure(response: httpx.Response, *, operation: str) -> RouteMatchResult:
+    error_code = _response_error_code(response)
+    logger.warning(
+        "mapbox.api_error",
+        operation=operation,
+        status_code=response.status_code,
+        error_code=error_code,
+    )
+    if response.status_code == 429 or response.status_code >= 500:
+        raise MapboxTransientError(f"{operation}:{error_code}")
+    if error_code in _NO_ROUTE_CODES:
+        return _no_route(error_code)
+    return _failed(error_code)
 
 
 def _encode_coords(coords: Coords) -> str:
@@ -88,7 +147,7 @@ async def _fetch_matching(
     profile: Profile,
     token: str,
     stats: RouteMatchStats | None = None,
-) -> Coords | None:
+) -> RouteMatchResult:
     if stats is not None:
         stats.matching_requests += 1
     reduced = reduce_coords(coords, MATCH_MAX_COORDS)
@@ -103,7 +162,7 @@ async def _fetch_matching(
         },
     ) as span:
         try:
-            resp = await client.get(
+            response = await client.get(
                 f"{_MATCHING_URL}/{profile}/{_encode_coords(reduced)}",
                 params={
                     "geometries": "geojson",
@@ -112,25 +171,27 @@ async def _fetch_matching(
                     "access_token": token,
                 },
             )
-            set_span_data(span, **{"http.status_code": resp.status_code})
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as e:
+            set_span_data(span, **{"http.status_code": response.status_code})
+        except httpx.RequestError as exc:
             logger.warning(
-                "mapbox.matching_api_error",
-                status_code=e.response.status_code,
+                "mapbox.matching_request_failed",
+                error_type=type(exc).__name__,
             )
-            return None
-        except httpx.TimeoutException:
-            logger.warning("mapbox.matching_timeout")
-            return None
-    data = _MatchingResponse.model_validate_json(resp.content)
+            raise MapboxTransientError("matching:request_failed") from exc
+    if not response.is_success:
+        return _http_failure(response, operation="matching")
+    data = _MatchingResponse.model_validate_json(response.content)
+    if data.code in _NO_ROUTE_CODES:
+        return _no_route(data.code)
+    if data.code != "Ok":
+        return _failed(data.code)
     if not data.matchings:
-        return None
+        return _no_route("NoMatch")
     all_coords: Coords = []
     for matching in data.matchings:
         pts: Coords = [(c[0], c[1]) for c in matching.geometry.coordinates]
         all_coords.extend(pts[1:] if all_coords else pts)
-    return all_coords if len(all_coords) >= 2 else None
+    return _matched(all_coords) if len(all_coords) >= 2 else _failed("invalid_geometry")
 
 
 async def _fetch_directions(
@@ -139,7 +200,7 @@ async def _fetch_directions(
     profile: Profile,
     token: str,
     stats: RouteMatchStats | None = None,
-) -> Coords | None:
+) -> RouteMatchResult:
     if stats is not None:
         stats.directions_requests += 1
     with start_span(
@@ -152,7 +213,7 @@ async def _fetch_directions(
         },
     ) as span:
         try:
-            resp = await client.get(
+            response = await client.get(
                 f"{_DIRECTIONS_URL}/{profile}/{_encode_coords(coords)}",
                 params={
                     "geometries": "geojson",
@@ -160,30 +221,32 @@ async def _fetch_directions(
                     "access_token": token,
                 },
             )
-            set_span_data(span, **{"http.status_code": resp.status_code})
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as e:
+            set_span_data(span, **{"http.status_code": response.status_code})
+        except httpx.RequestError as exc:
             logger.warning(
-                "mapbox.directions_api_error",
-                status_code=e.response.status_code,
+                "mapbox.directions_request_failed",
+                error_type=type(exc).__name__,
             )
-            return None
-        except httpx.TimeoutException:
-            logger.warning("mapbox.directions_timeout")
-            return None
-    data = _DirectionsResponse.model_validate_json(resp.content)
+            raise MapboxTransientError("directions:request_failed") from exc
+    if not response.is_success:
+        return _http_failure(response, operation="directions")
+    data = _DirectionsResponse.model_validate_json(response.content)
+    if data.code in _NO_ROUTE_CODES:
+        return _no_route(data.code)
+    if data.code != "Ok":
+        return _failed(data.code)
     if not data.routes:
-        return None
+        return _no_route("NoRoute")
     result: Coords = [(c[0], c[1]) for c in data.routes[0].geometry.coordinates]
-    return result if len(result) >= 2 else None
+    return _matched(result) if len(result) >= 2 else _failed("invalid_geometry")
 
 
 async def _chunked_route(
     coords: Coords,
     chunk_size: int,
     overlap: int,
-    route_fn: Callable[[Coords], Coroutine[None, None, Coords | None]],
-) -> Coords | None:
+    route_fn: Callable[[Coords], Coroutine[None, None, RouteMatchResult]],
+) -> RouteMatchResult:
     chunks: list[Coords] = []
     start = 0
     while start < len(coords):
@@ -195,12 +258,27 @@ async def _chunked_route(
 
     results = await asyncio.gather(*[route_fn(c) for c in chunks])
 
+    if failed := next(
+        (result for result in results if result.status == RouteEnrichmentStatus.failed),
+        None,
+    ):
+        return failed
+    if no_route := next(
+        (
+            result
+            for result in results
+            if result.status == RouteEnrichmentStatus.no_route
+        ),
+        None,
+    ):
+        return no_route
+
     all_coords: Coords = []
-    for piece in results:
-        if piece is None:
-            continue
-        all_coords.extend(piece[1:] if all_coords else piece)
-    return all_coords if len(all_coords) >= 2 else None
+    for result in results:
+        if not result.route:
+            return _failed("invalid_geometry")
+        all_coords.extend(result.route[1:] if all_coords else result.route)
+    return _matched(all_coords) if len(all_coords) >= 2 else _failed("invalid_geometry")
 
 
 async def _match_one(
@@ -209,18 +287,18 @@ async def _match_one(
     profile: Profile,
     token: str,
     stats: RouteMatchStats | None = None,
-) -> Coords | None:
+) -> RouteMatchResult:
     """Match a single segment's GPS points to roads via Mapbox APIs."""
     if len(points_lonlat) < 2:
-        return None
+        return _failed("insufficient_points")
 
     if is_sparse(points_lonlat):
         if len(points_lonlat) <= 25:
-            raw = await _fetch_directions(
+            result = await _fetch_directions(
                 clients.directions, points_lonlat, profile, token, stats
             )
         else:
-            raw = await _chunked_route(
+            result = await _chunked_route(
                 points_lonlat,
                 20,
                 1,
@@ -229,36 +307,38 @@ async def _match_one(
                 ),
             )
     elif len(points_lonlat) <= MATCH_MAX_COORDS:
-        raw = await _fetch_matching(
+        result = await _fetch_matching(
             clients.matching, points_lonlat, profile, token, stats
         )
     else:
-        raw = await _chunked_route(
+        result = await _chunked_route(
             points_lonlat,
             90,
             10,
             lambda c: _fetch_matching(clients.matching, c, profile, token, stats),
         )
 
-    if raw is None:
+    if result.status != RouteEnrichmentStatus.matched or not result.route:
         logger.debug(
             "mapbox.segment_match_failed",
             profile=profile,
             point_count=len(points_lonlat),
+            status=result.status,
+            error_code=result.error_code,
         )
-        return None
+        return result
 
     span = total_length_km(points_lonlat)
-    simplified = simplify_route(raw, span)
+    simplified = simplify_route(result.route, span)
     logger.debug(
         "mapbox.segment_matched",
         profile=profile,
         point_count=len(points_lonlat),
-        matched_point_count=len(raw),
+        matched_point_count=len(result.route),
         simplified_point_count=len(simplified),
         length_km=span,
     )
-    return simplified
+    return _matched(simplified)
 
 
 async def match_segment(
@@ -269,18 +349,20 @@ async def match_segment(
     """Match a single segment's GPS points to roads via Mapbox APIs.
 
     Automatically selects Map Matching (dense) or Directions (sparse).
-    Returns road-snapped coordinates in [lon, lat] order, or None on failure.
+    Returns road-snapped coordinates in [lon, lat] order, or None when Mapbox
+    reports no route or a permanent failure. Transient failures are raised.
     """
     token = _token()
     if not token:
         return None
 
-    return await _match_one(
+    result = await _match_one(
         MapboxRouteClients(matching=client, directions=client),
         points_lonlat,
         profile,
         token,
     )
+    return result.route
 
 
 async def match_segments(
@@ -288,15 +370,15 @@ async def match_segments(
     pairs: list[tuple[Coords, Profile]],
 ) -> list[Coords | None]:
     """Match multiple segments concurrently, sharing one HTTP connection pool."""
-    routes, _stats = await match_segments_with_stats(client, client, pairs)
-    return routes
+    results, _stats = await match_segments_with_stats(client, client, pairs)
+    return [result.route for result in results]
 
 
 async def match_segments_with_stats(
     matching_client: MapboxClient,
     directions_client: MapboxClient,
     pairs: list[tuple[Coords, Profile]],
-) -> tuple[list[Coords | None], RouteMatchStats]:
+) -> tuple[list[RouteMatchResult], RouteMatchStats]:
     """Match multiple segments, returning route results and HTTP request counts."""
     stats = RouteMatchStats()
     if not pairs:
@@ -304,10 +386,10 @@ async def match_segments_with_stats(
 
     token = _token()
     if not token:
-        return [None] * len(pairs), stats
+        return [_failed("token_missing") for _ in pairs], stats
 
     clients = MapboxRouteClients(matching=matching_client, directions=directions_client)
-    routes = await asyncio.gather(
+    results = await asyncio.gather(
         *(
             _match_one(
                 clients,
@@ -319,4 +401,4 @@ async def match_segments_with_stats(
             for coords, profile in pairs
         )
     )
-    return routes, stats
+    return results, stats

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -1,0 +1,112 @@
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from app.models.segment import RouteEnrichmentStatus
+from app.services.mapbox import (
+    MapboxTransientError,
+    RouteMatchResult,
+    _chunked_route,
+    _fetch_directions,
+    _fetch_matching,
+)
+
+type Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _client(handler: Handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_map_matching_no_match_is_terminal() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"code": "NoMatch"}, request=request)
+
+    async with _client(handler) as client:
+        result = await _fetch_matching(
+            client,
+            [(4.0, 52.0), (4.1, 52.1)],
+            "walking",
+            "token",
+        )
+
+    assert result.status == RouteEnrichmentStatus.no_route
+    assert result.error_code == "NoMatch"
+
+
+async def test_mapbox_server_failure_is_retryable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"code": "ServerError"}, request=request)
+
+    async with _client(handler) as client:
+        with pytest.raises(MapboxTransientError, match="ServerError"):
+            await _fetch_directions(
+                client,
+                [(4.0, 52.0), (4.1, 52.1)],
+                "driving",
+                "token",
+            )
+
+
+async def test_mapbox_invalid_input_is_recorded_as_failure() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json={"code": "InvalidInput"}, request=request)
+
+    async with _client(handler) as client:
+        result = await _fetch_directions(
+            client,
+            [(4.0, 52.0), (4.1, 52.1)],
+            "driving",
+            "token",
+        )
+
+    assert result.status == RouteEnrichmentStatus.failed
+    assert result.error_code == "InvalidInput"
+
+
+async def test_mapbox_no_segment_response_is_terminal() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json={"code": "NoSegment"}, request=request)
+
+    async with _client(handler) as client:
+        result = await _fetch_directions(
+            client,
+            [(4.0, 52.0), (4.1, 52.1)],
+            "driving",
+            "token",
+        )
+
+    assert result.status == RouteEnrichmentStatus.no_route
+    assert result.error_code == "NoSegment"
+
+
+async def test_chunked_route_rejects_partial_success() -> None:
+    calls = 0
+
+    async def route_chunk(
+        chunk: list[tuple[float, float]],
+    ) -> RouteMatchResult:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            return RouteMatchResult(
+                status=RouteEnrichmentStatus.no_route,
+                error_code="NoSegment",
+            )
+        return RouteMatchResult(
+            status=RouteEnrichmentStatus.matched,
+            route=chunk,
+        )
+
+    result = await _chunked_route(
+        [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 3.0)],
+        chunk_size=3,
+        overlap=1,
+        route_fn=route_chunk,
+    )
+
+    assert calls == 2
+    assert result.status == RouteEnrichmentStatus.no_route
+    assert result.route is None
+    assert result.error_code == "NoSegment"

--- a/backend/tests/test_segment_routes.py
+++ b/backend/tests/test_segment_routes.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.logic.segment_routes import (
+    RouteEnrichmentIncompleteError,
+    album_route_enrichment_workflow,
+    mark_album_route_failure_step,
     match_album_segment_routes,
+    pending_route_enrichment_targets,
 )
-from app.models.segment import Segment, SegmentKind
+from app.models.segment import (
+    RouteEnrichmentStatus,
+    Segment,
+    SegmentKind,
+    SegmentRouteEnrichment,
+)
+from app.services.mapbox import MapboxTransientError, RouteMatchResult
 
 from .factories import AID, insert_album, insert_segment
 
@@ -41,6 +53,24 @@ def _stats(
     )
 
 
+def _matched(route: Route) -> RouteMatchResult:
+    return RouteMatchResult(status=RouteEnrichmentStatus.matched, route=route)
+
+
+def _no_route(code: str = "NoRoute") -> RouteMatchResult:
+    return RouteMatchResult(
+        status=RouteEnrichmentStatus.no_route,
+        error_code=code,
+    )
+
+
+def _failed(code: str = "InvalidInput") -> RouteMatchResult:
+    return RouteMatchResult(
+        status=RouteEnrichmentStatus.failed,
+        error_code=code,
+    )
+
+
 async def _seed_segments(engine: AsyncEngine, uid: int, *segments: SegmentSeed) -> None:
     async with AsyncSession(engine) as session:
         await insert_album(session, uid)
@@ -61,7 +91,7 @@ async def _run_route_enrichment(
     *,
     http: SimpleNamespace | None = None,
     lock_acquired: bool = True,
-    route_result: tuple[list[Route | None], SimpleNamespace] | None = None,
+    route_result: tuple[list[RouteMatchResult], SimpleNamespace] | None = None,
     side_effect: object | None = None,
 ) -> SimpleNamespace:
     http = http or _http()
@@ -81,12 +111,13 @@ async def _run_route_enrichment(
             new=match_segments,
         ),
     ):
-        await match_album_segment_routes(http, uid, AID)
+        stats = await match_album_segment_routes(http, uid, AID)
 
     return SimpleNamespace(
         get_engine=get_engine,
         match_segments=match_segments,
         http=http,
+        stats=stats,
     )
 
 
@@ -101,6 +132,20 @@ async def _route_for(
         seg = await session.get(Segment, (uid, aid, start_time, end_time))
         assert seg is not None
         return seg.route
+
+
+async def _state_for(
+    engine: AsyncEngine,
+    uid: int,
+    aid: str = AID,
+    start_time: float = 100.0,
+    end_time: float = 200.0,
+) -> SegmentRouteEnrichment | None:
+    async with AsyncSession(engine) as session:
+        return await session.get(
+            SegmentRouteEnrichment,
+            (uid, aid, start_time, end_time),
+        )
 
 
 async def test_unmatched_driving_and_walking_segments_get_routes(
@@ -120,7 +165,7 @@ async def test_unmatched_driving_and_walking_segments_get_routes(
         engine,
         uid,
         route_result=(
-            [driving_route, walking_route],
+            [_matched(driving_route), _matched(walking_route)],
             _stats(requests=2, matching_requests=1, directions_requests=1),
         ),
     )
@@ -131,13 +176,16 @@ async def test_unmatched_driving_and_walking_segments_get_routes(
     assert (
         await _route_for(engine, uid, start_time=300.0, end_time=400.0) == walking_route
     )
-    match_segments = result.match_segments
-    match_segments.assert_awaited_once()
-    assert match_segments.await_args.args[:2] == (
+    first_state = await _state_for(engine, uid)
+    assert first_state is not None
+    assert first_state.status == RouteEnrichmentStatus.matched
+    assert result.stats.updated == 2
+    result.match_segments.assert_awaited_once()
+    assert result.match_segments.await_args.args[:2] == (
         result.http.mapbox_matching,
         result.http.mapbox_directions,
     )
-    assert [profile for _, profile in match_segments.await_args.args[2]] == [
+    assert [profile for _, profile in result.match_segments.await_args.args[2]] == [
         "driving",
         "walking",
     ]
@@ -165,41 +213,170 @@ async def test_rows_deleted_before_write_are_skipped(engine: AsyncEngine) -> Non
 
     async def delete_then_match(
         *_args: object,
-    ) -> tuple[list[list[tuple[float, float]]], SimpleNamespace]:
+    ) -> tuple[list[RouteMatchResult], SimpleNamespace]:
         async with AsyncSession(engine) as session:
             seg = await session.get(Segment, (uid, AID, 100.0, 200.0))
             assert seg is not None
             await session.delete(seg)
             await session.commit()
-        return [route], SimpleNamespace(
-            requests=1,
-            matching_requests=1,
-            directions_requests=0,
-        )
+        return [_matched(route)], _stats()
 
-    await _run_route_enrichment(engine, uid, side_effect=delete_then_match)
+    result = await _run_route_enrichment(engine, uid, side_effect=delete_then_match)
 
     async with AsyncSession(engine) as session:
         assert await session.get(Segment, (uid, AID, 100.0, 200.0)) is None
+    assert result.stats.stale == 1
 
 
-async def test_none_route_leaves_row_unchanged(engine: AsyncEngine) -> None:
+async def test_no_route_is_recorded_and_not_retried(engine: AsyncEngine) -> None:
     uid = 3004
     await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
-    await _run_route_enrichment(
+    first = await _run_route_enrichment(
         engine,
         uid,
-        route_result=([None], _stats()),
+        route_result=([_no_route("NoSegment")], _stats()),
     )
+    second = await _run_route_enrichment(engine, uid)
 
     assert await _route_for(engine, uid) is None
+    state = await _state_for(engine, uid)
+    assert state is not None
+    assert state.status == RouteEnrichmentStatus.no_route
+    assert state.error_code == "NoSegment"
+    assert first.stats.no_route == 1
+    second.match_segments.assert_not_awaited()
+
+
+async def test_permanent_failure_is_recorded(engine: AsyncEngine) -> None:
+    uid = 3005
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+    result = await _run_route_enrichment(
+        engine,
+        uid,
+        route_result=([_failed()], _stats()),
+    )
+
+    state = await _state_for(engine, uid)
+    assert state is not None
+    assert state.status == RouteEnrichmentStatus.failed
+    assert state.error_code == "InvalidInput"
+    assert result.stats.failed == 1
+
+
+async def test_route_matching_exception_propagates(engine: AsyncEngine) -> None:
+    uid = 3006
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+
+    with pytest.raises(RuntimeError, match="mapbox unavailable"):
+        await _run_route_enrichment(
+            engine,
+            uid,
+            side_effect=RuntimeError("mapbox unavailable"),
+        )
+
+
+async def test_exhausted_failure_marker_records_pending_segments(
+    engine: AsyncEngine,
+) -> None:
+    uid = 3010
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+    marker = inspect.unwrap(mark_album_route_failure_step)
+
+    with patch("app.logic.segment_routes.get_engine", return_value=engine):
+        recorded = await marker(
+            {"uid": uid, "aid": AID},
+            "retry_exhausted:MapboxTransientError",
+        )
+
+    state = await _state_for(engine, uid)
+    assert recorded == 1
+    assert state is not None
+    assert state.status == RouteEnrichmentStatus.failed
+    assert state.error_code == "retry_exhausted:MapboxTransientError"
+
+
+async def test_failed_outcome_fails_workflow() -> None:
+    workflow = inspect.unwrap(album_route_enrichment_workflow)
+    stats = {
+        "candidates": 1,
+        "matched": 0,
+        "no_route": 0,
+        "failed": 1,
+        "recorded": 1,
+        "updated": 0,
+        "route_requests": 1,
+        "matching_requests": 1,
+        "directions_requests": 0,
+        "already_running": False,
+    }
+    with (
+        patch(
+            "app.logic.segment_routes.enrich_album_routes_step",
+            new=AsyncMock(return_value=stats),
+        ),
+        pytest.raises(RouteEnrichmentIncompleteError),
+    ):
+        await workflow({"uid": 1, "aid": AID})
+
+
+async def test_exhausted_transient_failure_is_recorded_and_propagated() -> None:
+    workflow = inspect.unwrap(album_route_enrichment_workflow)
+    marker = AsyncMock()
+    payload = {"uid": 1, "aid": AID}
+    with (
+        patch(
+            "app.logic.segment_routes.enrich_album_routes_step",
+            new=AsyncMock(side_effect=MapboxTransientError("unavailable")),
+        ),
+        patch(
+            "app.logic.segment_routes.mark_album_route_failure_step",
+            new=marker,
+        ),
+        pytest.raises(MapboxTransientError, match="unavailable"),
+    ):
+        await workflow(payload)
+
+    marker.assert_awaited_once_with(
+        payload,
+        "retry_exhausted:MapboxTransientError",
+    )
+
+
+async def test_reconciliation_targets_only_unresolved_albums(
+    engine: AsyncEngine,
+) -> None:
+    pending_uid = 3007
+    resolved_uid = 3008
+    await _seed_segments(
+        engine,
+        pending_uid,
+        (100.0, 200.0, SegmentKind.driving),
+        (300.0, 400.0, SegmentKind.walking),
+    )
+    await _seed_segments(
+        engine,
+        resolved_uid,
+        (100.0, 200.0, SegmentKind.driving),
+    )
+    await _run_route_enrichment(
+        engine,
+        resolved_uid,
+        route_result=([_no_route()], _stats()),
+    )
+
+    async with AsyncSession(engine) as session:
+        targets = await pending_route_enrichment_targets(session)
+
+    assert targets.count((pending_uid, AID)) == 1
+    assert (resolved_uid, AID) not in targets
 
 
 async def test_advisory_lock_already_held_skips_run(engine: AsyncEngine) -> None:
-    uid = 3005
+    uid = 3009
     await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
     result = await _run_route_enrichment(engine, uid, lock_acquired=False)
 
     result.get_engine.assert_not_called()
     result.match_segments.assert_not_awaited()
+    assert result.stats.already_running
     assert await _route_for(engine, uid) is None


### PR DESCRIPTION

- persist matched, no-route, and failed outcomes separately from the public segment model
- execute album enrichment inside a retrying DBOS step and propagate exhausted or permanent failures to workflow status
- reject chunked routes unless every chunk succeeds
- reconcile existing route-less walking and driving segments once at startup


