### PR TITLE
fix: bound route enrichment by GPS traces

### DIFF
--- a/backend/app/core/http.py
+++ b/backend/app/core/http.py
@@ -13,7 +13,11 @@ built here enforce an explicit ``asyncio.timeout`` to compensate.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from time import perf_counter
 
 import httpx
 from hishel import (
@@ -39,6 +43,28 @@ from app.core.config import get_settings
 _CACHE_TTL = 60 * 60 * 24 * 30  # 30 days
 _RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
 _DEFAULT_LIMITS = httpx.Limits(max_connections=20)
+
+
+@dataclass
+class HttpTransportMetrics:
+    outbound_attempts: int = 0
+    limiter_wait_ms: int = 0
+    provider_latency_ms: int = 0
+
+
+_http_metrics: ContextVar[HttpTransportMetrics | None] = ContextVar(
+    "http_transport_metrics", default=None
+)
+
+
+@contextmanager
+def collect_http_transport_metrics() -> Iterator[HttpTransportMetrics]:
+    metrics = HttpTransportMetrics()
+    token = _http_metrics.set(metrics)
+    try:
+        yield metrics
+    finally:
+        _http_metrics.reset(token)
 
 
 class _CacheOnlySuccess(BaseFilter[HishelResponse]):
@@ -97,10 +123,22 @@ class RateLimitedTransport(AsyncBaseTransport):
         self._weight_fn = weight_fn
 
     async def handle_async_request(self, request: Request) -> Response:
+        metrics = _http_metrics.get()
+        wait_started = perf_counter()
         await self._limiter.try_acquire_async(
             "http-request", weight=self._weight_fn(request)
         )
-        return await self._inner.handle_async_request(request)
+        if metrics is not None:
+            metrics.outbound_attempts += 1
+            metrics.limiter_wait_ms += round((perf_counter() - wait_started) * 1000)
+        provider_started = perf_counter()
+        try:
+            return await self._inner.handle_async_request(request)
+        finally:
+            if metrics is not None:
+                metrics.provider_latency_ms += round(
+                    (perf_counter() - provider_started) * 1000
+                )
 
     async def aclose(self) -> None:
         try:

--- a/backend/app/logic/route_matching.py
+++ b/backend/app/logic/route_matching.py
@@ -1,12 +1,10 @@
 import numpy as np
 from simplification.cutil import simplify_coords_idx
 
-from app.logic.spatial.geo import Coords, total_length_km
+from app.logic.spatial.geo import Coords
 from app.models.segment import SegmentKind
 
 MATCHABLE_KINDS = frozenset({SegmentKind.driving, SegmentKind.walking})
-
-SPARSE_THRESHOLD_KM = 2
 
 # RDP tolerances (degrees, approximate)
 _RDP_TOLERANCES = [
@@ -16,23 +14,22 @@ _RDP_TOLERANCES = [
 ]
 
 
-def is_sparse(coords: Coords) -> bool:
-    if len(coords) < 2:
-        return False
-    total = total_length_km(coords)
-    return total / (len(coords) - 1) > SPARSE_THRESHOLD_KM
-
-
-def reduce_coords(coords: Coords, max_count: int) -> Coords:
-    """Simplify coords to at most max_count points using RDP."""
+def reduce_coord_indices(coords: Coords, max_count: int) -> list[int]:
+    """Return RDP-selected indices so parallel metadata stays aligned."""
     if len(coords) <= max_count:
-        return coords
+        return list(range(len(coords)))
     tolerance = 0.0001
+    indices = list(range(len(coords)))
     result = coords
     while len(result) > max_count and tolerance < 1.0:
-        result = _simplify(result, tolerance)
+        selected = simplify_coords_idx(np.array(result), tolerance).tolist()
+        indices = [indices[i] for i in selected]
+        result = [result[i] for i in selected]
         tolerance *= 2
-    return result
+    if len(indices) > max_count:
+        positions = np.linspace(0, len(indices) - 1, max_count, dtype=int)
+        indices = [indices[i] for i in positions]
+    return indices
 
 
 def simplify_route(coords: Coords, span_km: float) -> Coords:

--- a/backend/app/logic/segment_routes.py
+++ b/backend/app/logic/segment_routes.py
@@ -21,7 +21,12 @@ from app.models.segment import (
     Segment,
     SegmentRouteEnrichment,
 )
-from app.services.mapbox import RouteMatchResult, match_segments_with_stats
+from app.services.mapbox import (
+    REQUEST_BUDGET_EXCEEDED,
+    RouteMatchResult,
+    match_segments_with_stats,
+    route_request_batch_indices,
+)
 
 if TYPE_CHECKING:
     from fastapi import BackgroundTasks
@@ -31,7 +36,8 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 type SegmentKey = tuple[int, str, float, float]
-type SegmentSnapshot = tuple[SegmentKey, list[tuple[float, float]], str]
+type SegmentKeyPayload = dict[str, int | str | float]
+type SegmentSnapshot = tuple[SegmentKey, list[tuple[float, float, float]], str]
 
 _route_http_clients: list[HttpClients] = []
 
@@ -51,11 +57,46 @@ class RouteEnrichmentStats:
     route_requests: int = 0
     matching_requests: int = 0
     directions_requests: int = 0
+    cache_hits: int = 0
+    outbound_attempts: int = 0
+    retries: int = 0
+    limiter_wait_ms: int = 0
+    provider_latency_ms: int = 0
+    budget_fallbacks: int = 0
     already_running: bool = False
 
     @property
     def stale(self) -> int:
         return self.candidates - self.recorded
+
+
+def _segment_key_payload(key: SegmentKey) -> SegmentKeyPayload:
+    uid, aid, start_time, end_time = key
+    return {
+        "uid": uid,
+        "aid": aid,
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+
+def _segment_key_from_payload(payload: SegmentKeyPayload) -> SegmentKey:
+    return (
+        int(payload["uid"]),
+        str(payload["aid"]),
+        float(payload["start_time"]),
+        float(payload["end_time"]),
+    )
+
+
+def _snapshots_for_keys(
+    snapshots: list[SegmentSnapshot],
+    keys: list[SegmentKey] | None,
+) -> list[SegmentSnapshot]:
+    if keys is None:
+        return snapshots
+    by_key = {snapshot[0]: snapshot for snapshot in snapshots}
+    return [by_key[key] for key in keys if key in by_key]
 
 
 def _route_missing() -> ColumnElement[bool]:
@@ -109,51 +150,89 @@ def route_enrichment_payload(uid: int, aid: str) -> dict[str, Any]:
     return {"uid": uid, "aid": aid}
 
 
+@DBOS.step(retries_allowed=True, max_attempts=3)
+async def plan_album_route_batch_step(
+    payload: dict[str, Any],
+) -> list[SegmentKeyPayload]:
+    uid = int(payload["uid"])
+    aid = str(payload["aid"])
+    async with AsyncSession(get_engine()) as session:
+        snapshots = await _unmatched_snapshots(session, uid, aid)
+    pairs = [(coords, profile) for _, coords, profile in snapshots]
+    indexes = route_request_batch_indices(pairs)
+    if snapshots and not indexes:
+        msg = "no route enrichment candidate fits the request budget"
+        raise RouteEnrichmentIncompleteError(msg)
+    return [_segment_key_payload(snapshots[index][0]) for index in indexes]
+
+
 @DBOS.step(
     retries_allowed=True,
     max_attempts=3,
     interval_seconds=5,
     backoff_rate=2,
 )
-async def enrich_album_routes_step(payload: dict[str, Any]) -> dict[str, Any]:
+async def enrich_album_routes_step(
+    payload: dict[str, Any], batch: list[SegmentKeyPayload]
+) -> dict[str, Any]:
     uid = int(payload["uid"])
     aid = str(payload["aid"])
     stats = await match_album_segment_routes(
-        get_route_enrichment_http_clients(), uid, aid
+        get_route_enrichment_http_clients(),
+        uid,
+        aid,
+        [_segment_key_from_payload(key) for key in batch],
     )
     return asdict(stats)
 
 
 @DBOS.step(retries_allowed=True, max_attempts=3)
 async def mark_album_route_failure_step(
-    payload: dict[str, Any], error_code: str
+    payload: dict[str, Any],
+    error_code: str,
+    batch: list[SegmentKeyPayload],
 ) -> int:
     uid = int(payload["uid"])
     aid = str(payload["aid"])
     async with AsyncSession(get_engine()) as session:
-        return await _mark_pending_failed(session, uid, aid, error_code)
+        return await _mark_pending_failed(
+            session,
+            uid,
+            aid,
+            error_code,
+            [_segment_key_from_payload(key) for key in batch],
+        )
 
 
 @DBOS.workflow(name="route.enrich_album")
 async def album_route_enrichment_workflow(payload: dict[str, Any]) -> dict[str, Any]:
-    try:
-        result = await enrich_album_routes_step(payload)
-    except Exception as exc:
-        error_code = f"retry_exhausted:{type(exc).__name__}"
+    failed = 0
+    while batch := await plan_album_route_batch_step(payload):
         try:
-            await mark_album_route_failure_step(payload, error_code)
-        except Exception as marker_exc:
-            logger.exception(
-                "route_enrichment.failure_record_failed",
-                user_id=int(payload["uid"]),
-                album_id=str(payload["aid"]),
-                error_type=type(marker_exc).__name__,
-            )
-        raise
+            result = await enrich_album_routes_step(payload, batch)
+        except Exception as exc:
+            error_code = f"retry_exhausted:{type(exc).__name__}"
+            try:
+                await mark_album_route_failure_step(payload, error_code, batch)
+            except Exception as marker_exc:
+                logger.exception(
+                    "route_enrichment.failure_record_failed",
+                    user_id=int(payload["uid"]),
+                    album_id=str(payload["aid"]),
+                    error_type=type(marker_exc).__name__,
+                )
+            raise
 
-    stats = RouteEnrichmentStats(**result)
-    if stats.failed:
-        msg = f"route enrichment recorded {stats.failed} failed segment(s)"
+        stats = RouteEnrichmentStats(**result)
+        if stats.already_running:
+            break
+        if stats.budget_fallbacks:
+            msg = "route enrichment batch exceeded its planned request budget"
+            raise RouteEnrichmentIncompleteError(msg)
+        failed += stats.failed
+
+    if failed:
+        msg = f"route enrichment recorded {failed} failed segment(s)"
         raise RouteEnrichmentIncompleteError(msg)
     return route_enrichment_payload(int(payload["uid"]), str(payload["aid"]))
 
@@ -200,7 +279,10 @@ async def reconcile_missing_route_enrichments() -> None:
 
 
 async def match_album_segment_routes(
-    http: HttpClients, uid: int, aid: str
+    http: HttpClients,
+    uid: int,
+    aid: str,
+    keys: list[SegmentKey] | None = None,
 ) -> RouteEnrichmentStats:
     lock_key = f"segment-route-match:{uid}:{aid}"
     started = time.perf_counter()
@@ -223,7 +305,7 @@ async def match_album_segment_routes(
             try:
                 async with AsyncSession(get_engine()) as session:
                     return await _match_routes_in_session(
-                        http, session, uid, aid, span, started
+                        http, session, uid, aid, span, started, keys
                     )
             except Exception:
                 logger.exception(
@@ -242,8 +324,12 @@ async def _match_routes_in_session(  # noqa: PLR0913
     aid: str,
     span: Span,
     started: float,
+    keys: list[SegmentKey] | None,
 ) -> RouteEnrichmentStats:
-    snapshots = await _unmatched_snapshots(session, uid, aid)
+    snapshots = _snapshots_for_keys(
+        await _unmatched_snapshots(session, uid, aid),
+        keys,
+    )
     if not snapshots:
         stats = RouteEnrichmentStats()
         _set_route_span_data(span, stats, result="empty")
@@ -271,8 +357,16 @@ async def _match_routes_in_session(  # noqa: PLR0913
     stats.route_requests = route_stats.requests
     stats.matching_requests = route_stats.matching_requests
     stats.directions_requests = route_stats.directions_requests
+    stats.cache_hits = route_stats.cache_hits
+    stats.outbound_attempts = route_stats.outbound_attempts
+    stats.retries = route_stats.retries
+    stats.limiter_wait_ms = route_stats.limiter_wait_ms
+    stats.provider_latency_ms = route_stats.provider_latency_ms
+    stats.budget_fallbacks = route_stats.budget_fallbacks
     for (key, _, _), result in zip(snapshots, results, strict=True):
         outcome = result
+        if outcome.error_code == REQUEST_BUDGET_EXCEEDED:
+            continue
         if outcome.status == RouteEnrichmentStatus.matched and not outcome.route:
             outcome = RouteMatchResult(
                 status=RouteEnrichmentStatus.failed,
@@ -317,6 +411,12 @@ def _set_route_span_data(
             "route.requests": stats.route_requests,
             "mapbox.matching_requests": stats.matching_requests,
             "mapbox.directions_requests": stats.directions_requests,
+            "mapbox.cache_hits": stats.cache_hits,
+            "mapbox.outbound_attempts": stats.outbound_attempts,
+            "mapbox.retries": stats.retries,
+            "mapbox.limiter_wait_ms": stats.limiter_wait_ms,
+            "mapbox.provider_latency_ms": stats.provider_latency_ms,
+            "mapbox.budget_fallbacks": stats.budget_fallbacks,
         },
     )
 
@@ -341,6 +441,12 @@ def _log_complete(
         route_requests=stats.route_requests,
         matching_requests=stats.matching_requests,
         directions_requests=stats.directions_requests,
+        cache_hits=stats.cache_hits,
+        outbound_attempts=stats.outbound_attempts,
+        retries=stats.retries,
+        limiter_wait_ms=stats.limiter_wait_ms,
+        provider_latency_ms=stats.provider_latency_ms,
+        budget_fallbacks=stats.budget_fallbacks,
         duration_ms=_duration_ms(started),
     )
 
@@ -363,7 +469,7 @@ async def _unmatched_snapshots(
     return [
         (
             (seg.uid, seg.aid, seg.start_time, seg.end_time),
-            [(p.lon, p.lat) for p in seg.points],
+            [(p.lon, p.lat, p.time) for p in seg.points],
             str(seg.kind),
         )
         for seg in result.all()
@@ -404,8 +510,12 @@ async def _mark_pending_failed(
     uid: int,
     aid: str,
     error_code: str,
+    keys: list[SegmentKey],
 ) -> int:
-    snapshots = await _unmatched_snapshots(session, uid, aid)
+    snapshots = _snapshots_for_keys(
+        await _unmatched_snapshots(session, uid, aid),
+        keys,
+    )
     failed = RouteMatchResult(
         status=RouteEnrichmentStatus.failed,
         error_code=error_code[:100],

--- a/backend/app/logic/spatial/segments.py
+++ b/backend/app/logic/spatial/segments.py
@@ -27,6 +27,7 @@ import math
 from collections import Counter
 from collections.abc import Iterable, Sequence
 from datetime import datetime
+from itertools import pairwise
 from typing import Protocol, cast
 
 import numpy as np
@@ -521,24 +522,39 @@ def _gdf_to_point(gdf: pl.DataFrame, idx: int) -> Point:
     return Point(lat=gdf["lat"][idx], lon=gdf["lon"][idx], time=gdf["time"][idx])
 
 
-def _simplify_points(gdf: pl.DataFrame) -> list[Point]:
+def _simplify_points(
+    gdf: pl.DataFrame, *, max_time_gap_s: float | None = None
+) -> list[Point]:
     """RDP-simplify a group, keeping step waypoints."""
     la, lo, ti = gdf["lat"].to_numpy(), gdf["lon"].to_numpy(), gdf["time"].to_numpy()
     keep = np.zeros(len(la), dtype=bool)
     keep[simplify_coords_idx(np.column_stack((lo, la)), RDP_EPSILON_DEG)] = True
     if "is_step" in gdf.columns:
         keep |= gdf["is_step"].to_numpy()
+    if max_time_gap_s is not None:
+        selected = np.flatnonzero(keep)
+        for left, right in pairwise(selected):
+            current = int(left)
+            while ti[right] - ti[current] >= max_time_gap_s:
+                next_idx = int(
+                    np.searchsorted(ti, ti[current] + max_time_gap_s, side="left") - 1
+                )
+                current = max(current + 1, next_idx)
+                keep[current] = True
     return [Point(lat=la[i], lon=lo[i], time=ti[i]) for i in range(len(la)) if keep[i]]
 
 
 def _resolve_kind(kind: str, gdf: pl.DataFrame) -> SegmentKind:
-    """Resolve "other" -> walking/driving by average speed."""
     if kind != "other":
         return SegmentKind(kind)
-    total_h = float(gdf["gap_h"].sum())
-    total_km = float(gdf["dist_km"].sum())
-    avg = total_km / total_h if total_h > 0 else 0.0
-    return SegmentKind.driving if avg > HIKE_MAX_SPEED_KMH else SegmentKind.walking
+    moving = gdf.filter(pl.col("gap_h") < MAX_HIKE_GAP_H)
+    fast_km = float(
+        moving.filter(pl.col("speed_kmh") > HIKE_MAX_SPEED_KMH)["dist_km"].sum()
+    )
+    slow_km = float(
+        moving.filter(pl.col("speed_kmh") <= HIKE_MAX_SPEED_KMH)["dist_km"].sum()
+    )
+    return SegmentKind.driving if fast_km > slow_km else SegmentKind.walking
 
 
 def _emit_segments(
@@ -548,22 +564,37 @@ def _emit_segments(
     prev_last_pt: Point | None = None
 
     for _, gdf in df.group_by("output_id", maintain_order=True):
-        kind = cast("str", gdf["final_mode"][0])
+        raw_kind = cast("str", gdf["final_mode"][0])
+        groups = [gdf]
+        if raw_kind == "other":
+            groups = gdf.with_columns(
+                (pl.col("gap_h") >= MAX_HIKE_GAP_H).cum_sum().alias("trace_id")
+            ).partition_by("trace_id", maintain_order=True)
 
-        if kind == "flight":
-            pts = [_gdf_to_point(gdf, 0), _gdf_to_point(gdf, -1)]
-        else:
-            pts = _simplify_points(gdf)
+        for trace in groups:
+            kind = _resolve_kind(raw_kind, trace)
+            if kind == SegmentKind.flight:
+                pts = [_gdf_to_point(trace, 0), _gdf_to_point(trace, -1)]
+            else:
+                pts = _simplify_points(
+                    trace,
+                    max_time_gap_s=(
+                        MAX_HIKE_GAP_H * 3600 if raw_kind == "other" else None
+                    ),
+                )
 
-        # Stitch: prepend previous endpoint if there's a time gap
-        if prev_last_pt is not None and (not pts or pts[0].time > prev_last_pt.time):
-            pts = [prev_last_pt, *pts]
+            if (
+                prev_last_pt is not None
+                and pts
+                and 0 < pts[0].time - prev_last_pt.time < MAX_HIKE_GAP_H * 3600
+            ):
+                pts = [prev_last_pt, *pts]
 
-        if len(pts) < 2:
-            continue
+            if len(pts) < 2:
+                continue
 
-        prev_last_pt = pts[-1]
-        yield SegmentData(kind=_resolve_kind(kind, gdf), points=pts)
+            prev_last_pt = pts[-1]
+            yield SegmentData(kind=kind, points=pts)
 
 
 def build_segments(

--- a/backend/app/services/mapbox.py
+++ b/backend/app/services/mapbox.py
@@ -1,12 +1,8 @@
-"""Mapbox Map Matching & Directions API client.
-
-Density-based API selection: dense GPS → Map Matching, sparse → Directions.
-Rate limiting is provided by the shared Mapbox HTTP clients.
-"""
+"""Mapbox routing for timestamped, contiguous GPS traces."""
 
 import asyncio
-from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from itertools import pairwise
 from typing import Literal
 
 import httpx
@@ -14,22 +10,30 @@ import structlog
 from pydantic import BaseModel
 
 from app.core.config import get_settings
+from app.core.http import collect_http_transport_metrics
 from app.core.observability import set_span_data, start_span
 from app.logic.route_matching import (
     Coords,
-    is_sparse,
-    reduce_coords,
+    reduce_coord_indices,
     simplify_route,
-    total_length_km,
 )
+from app.logic.spatial.geo import total_length_km
 from app.models.segment import RouteEnrichmentStatus
 
 logger = structlog.get_logger(__name__)
 
 type Profile = str  # "driving" or "walking"
 type MapboxClient = httpx.AsyncClient
+type TimedCoord = tuple[float, float, float]
+type TimedCoords = list[TimedCoord]
 
 MATCH_MAX_COORDS = 100
+MATCH_CHUNK_COORDS = 90
+MAX_ROUTE_REQUESTS_PER_RUN = 100
+MAX_TRACE_GAP_S = 4 * 60 * 60
+REQUEST_BUDGET_EXCEEDED = "request_budget_exceeded"
+
+_DIRECTIONS_MAX_DISTANCE_KM = {"walking": 1_000.0, "driving": 10_000.0}
 
 _MATCHING_URL = "https://api.mapbox.com/matching/v5/mapbox"
 _DIRECTIONS_URL = "https://api.mapbox.com/directions/v5/mapbox"
@@ -39,6 +43,12 @@ _DIRECTIONS_URL = "https://api.mapbox.com/directions/v5/mapbox"
 class RouteMatchStats:
     matching_requests: int = 0
     directions_requests: int = 0
+    cache_hits: int = 0
+    outbound_attempts: int = 0
+    retries: int = 0
+    limiter_wait_ms: int = 0
+    provider_latency_ms: int = 0
+    budget_fallbacks: int = 0
 
     @property
     def requests(self) -> int:
@@ -49,6 +59,23 @@ class RouteMatchStats:
 class MapboxRouteClients:
     matching: MapboxClient
     directions: MapboxClient
+
+
+@dataclass(frozen=True)
+class _RoutePart:
+    operation: Literal["matching", "directions"]
+    points: TimedCoords
+
+
+@dataclass
+class _RequestBudget:
+    remaining: int
+
+    def reserve(self, requests: int) -> bool:
+        if requests > self.remaining:
+            return False
+        self.remaining -= requests
+        return True
 
 
 class MapboxTransientError(RuntimeError):
@@ -134,6 +161,44 @@ def _encode_coords(coords: Coords) -> str:
     return ";".join(f"{lon},{lat}" for lon, lat in coords)
 
 
+def _coords(points: TimedCoords) -> Coords:
+    return [(lon, lat) for lon, lat, _ in points]
+
+
+def _matching_request_points(points: TimedCoords) -> list[tuple[int, int]]:
+    selected = reduce_coord_indices(_coords(points), MATCH_MAX_COORDS)
+    request_points: list[tuple[int, int]] = []
+    for index in selected:
+        timestamp = int(points[index][2])
+        if not request_points or timestamp > request_points[-1][1]:
+            request_points.append((index, timestamp))
+    return request_points
+
+
+def _parse_matching_response(response: httpx.Response) -> RouteMatchResult:
+    data = _MatchingResponse.model_validate_json(response.content)
+    if data.code in _NO_ROUTE_CODES:
+        return _no_route(data.code)
+    if data.code != "Ok":
+        return _failed(data.code)
+    if not data.matchings:
+        return _no_route("NoMatch")
+    all_coords: Coords = []
+    for matching in data.matchings:
+        points: Coords = [
+            (coord[0], coord[1]) for coord in matching.geometry.coordinates
+        ]
+        all_coords.extend(points[1:] if all_coords else points)
+    return _matched(all_coords) if len(all_coords) >= 2 else _failed("invalid_geometry")
+
+
+def _record_cache_result(
+    response: httpx.Response, stats: RouteMatchStats | None
+) -> None:
+    if stats is not None and response.extensions.get("hishel_from_cache") is True:
+        stats.cache_hits += 1
+
+
 def _token() -> str | None:
     token = get_settings().MAPBOX_TOKEN
     if not token:
@@ -143,14 +208,19 @@ def _token() -> str | None:
 
 async def _fetch_matching(
     client: httpx.AsyncClient,
-    coords: Coords,
+    points: TimedCoords,
     profile: Profile,
     token: str,
     stats: RouteMatchStats | None = None,
 ) -> RouteMatchResult:
+    coords = _coords(points)
+    request_points = _matching_request_points(points)
+    if len(request_points) < 2:
+        return _no_route("insufficient_timestamp_span")
     if stats is not None:
         stats.matching_requests += 1
-    reduced = reduce_coords(coords, MATCH_MAX_COORDS)
+    reduced = [coords[index] for index, _ in request_points]
+    timestamps = [timestamp for _, timestamp in request_points]
     with start_span(
         "mapbox.matching",
         "Mapbox Map Matching API",
@@ -168,9 +238,11 @@ async def _fetch_matching(
                     "geometries": "geojson",
                     "overview": "full",
                     "tidy": "true",
+                    "timestamps": ";".join(map(str, timestamps)),
                     "access_token": token,
                 },
             )
+            _record_cache_result(response, stats)
             set_span_data(span, **{"http.status_code": response.status_code})
         except httpx.RequestError as exc:
             logger.warning(
@@ -180,29 +252,19 @@ async def _fetch_matching(
             raise MapboxTransientError("matching:request_failed") from exc
     if not response.is_success:
         return _http_failure(response, operation="matching")
-    data = _MatchingResponse.model_validate_json(response.content)
-    if data.code in _NO_ROUTE_CODES:
-        return _no_route(data.code)
-    if data.code != "Ok":
-        return _failed(data.code)
-    if not data.matchings:
-        return _no_route("NoMatch")
-    all_coords: Coords = []
-    for matching in data.matchings:
-        pts: Coords = [(c[0], c[1]) for c in matching.geometry.coordinates]
-        all_coords.extend(pts[1:] if all_coords else pts)
-    return _matched(all_coords) if len(all_coords) >= 2 else _failed("invalid_geometry")
+    return _parse_matching_response(response)
 
 
 async def _fetch_directions(
     client: httpx.AsyncClient,
-    coords: Coords,
+    points: TimedCoords,
     profile: Profile,
     token: str,
     stats: RouteMatchStats | None = None,
 ) -> RouteMatchResult:
     if stats is not None:
         stats.directions_requests += 1
+    coords = _coords(points)
     with start_span(
         "mapbox.directions",
         "Mapbox Directions API",
@@ -221,6 +283,7 @@ async def _fetch_directions(
                     "access_token": token,
                 },
             )
+            _record_cache_result(response, stats)
             set_span_data(span, **{"http.status_code": response.status_code})
         except httpx.RequestError as exc:
             logger.warning(
@@ -241,23 +304,67 @@ async def _fetch_directions(
     return _matched(result) if len(result) >= 2 else _failed("invalid_geometry")
 
 
-async def _chunked_route(
-    coords: Coords,
-    chunk_size: int,
-    overlap: int,
-    route_fn: Callable[[Coords], Coroutine[None, None, RouteMatchResult]],
-) -> RouteMatchResult:
-    chunks: list[Coords] = []
+def _matching_parts(points: TimedCoords) -> list[_RoutePart]:
+    parts: list[_RoutePart] = []
     start = 0
-    while start < len(coords):
-        end = min(start + chunk_size, len(coords))
-        chunks.append(coords[start:end])
-        if end == len(coords):
+    while start < len(points) - 1:
+        end = min(start + MATCH_CHUNK_COORDS, len(points))
+        parts.append(_RoutePart("matching", points[start:end]))
+        if end == len(points):
             break
-        start += chunk_size - overlap
+        start = end - 1
+    return parts
 
-    results = await asyncio.gather(*[route_fn(c) for c in chunks])
 
+def _plan_route(
+    points: TimedCoords, profile: Profile
+) -> tuple[list[_RoutePart], str | None]:
+    if profile not in _DIRECTIONS_MAX_DISTANCE_KM:
+        return [], "unsupported_profile"
+    if any(b[2] <= a[2] for a, b in pairwise(points)):
+        return [], "invalid_timestamps"
+    if any(b[2] - a[2] >= MAX_TRACE_GAP_S for a, b in pairwise(points)):
+        return [], "discontinuous_trace"
+
+    if len(points) == 2:
+        if total_length_km(_coords(points)) > _DIRECTIONS_MAX_DISTANCE_KM[profile]:
+            return [], "directions_distance_limit"
+        return [_RoutePart("directions", points)], None
+    return _matching_parts(points), None
+
+
+def route_request_batch_indices(
+    pairs: list[tuple[TimedCoords, Profile]],
+    max_requests: int = MAX_ROUTE_REQUESTS_PER_RUN,
+) -> list[int]:
+    """Return pair indices whose planned requests fit within one batch."""
+    budget = _RequestBudget(max_requests)
+    selected: list[int] = []
+    for index, (points, profile) in enumerate(pairs):
+        plan, planning_error = _plan_route(points, profile)
+        requests = len(plan) if planning_error is None else 0
+        if budget.reserve(requests):
+            selected.append(index)
+    return selected
+
+
+async def _execute_route_plan(
+    clients: MapboxRouteClients,
+    plan: list[_RoutePart],
+    profile: Profile,
+    token: str,
+    stats: RouteMatchStats | None,
+) -> RouteMatchResult:
+    results = await asyncio.gather(
+        *(
+            _fetch_matching(clients.matching, part.points, profile, token, stats)
+            if part.operation == "matching"
+            else _fetch_directions(
+                clients.directions, part.points, profile, token, stats
+            )
+            for part in plan
+        )
+    )
     if failed := next(
         (result for result in results if result.status == RouteEnrichmentStatus.failed),
         None,
@@ -281,59 +388,50 @@ async def _chunked_route(
     return _matched(all_coords) if len(all_coords) >= 2 else _failed("invalid_geometry")
 
 
-async def _match_one(
+async def _match_one(  # noqa: PLR0913
     clients: MapboxRouteClients,
-    points_lonlat: Coords,
+    points: TimedCoords,
     profile: Profile,
     token: str,
     stats: RouteMatchStats | None = None,
+    budget: _RequestBudget | None = None,
 ) -> RouteMatchResult:
     """Match a single segment's GPS points to roads via Mapbox APIs."""
-    if len(points_lonlat) < 2:
+    if len(points) < 2:
         return _failed("insufficient_points")
 
-    if is_sparse(points_lonlat):
-        if len(points_lonlat) <= 25:
-            result = await _fetch_directions(
-                clients.directions, points_lonlat, profile, token, stats
-            )
-        else:
-            result = await _chunked_route(
-                points_lonlat,
-                20,
-                1,
-                lambda c: _fetch_directions(
-                    clients.directions, c, profile, token, stats
-                ),
-            )
-    elif len(points_lonlat) <= MATCH_MAX_COORDS:
-        result = await _fetch_matching(
-            clients.matching, points_lonlat, profile, token, stats
+    plan, planning_error = _plan_route(points, profile)
+    if planning_error is not None:
+        status = (
+            _failed
+            if planning_error in {"invalid_timestamps", "unsupported_profile"}
+            else _no_route
         )
-    else:
-        result = await _chunked_route(
-            points_lonlat,
-            90,
-            10,
-            lambda c: _fetch_matching(clients.matching, c, profile, token, stats),
-        )
+        return status(planning_error)
+    if budget is not None and not budget.reserve(len(plan)):
+        if stats is not None:
+            stats.budget_fallbacks += 1
+        return _no_route(REQUEST_BUDGET_EXCEEDED)
+
+    result = await _execute_route_plan(clients, plan, profile, token, stats)
 
     if result.status != RouteEnrichmentStatus.matched or not result.route:
         logger.debug(
             "mapbox.segment_match_failed",
             profile=profile,
-            point_count=len(points_lonlat),
+            point_count=len(points),
             status=result.status,
             error_code=result.error_code,
         )
         return result
 
-    span = total_length_km(points_lonlat)
+    coords = _coords(points)
+    span = total_length_km(coords)
     simplified = simplify_route(result.route, span)
     logger.debug(
         "mapbox.segment_matched",
         profile=profile,
-        point_count=len(points_lonlat),
+        point_count=len(points),
         matched_point_count=len(result.route),
         simplified_point_count=len(simplified),
         length_km=span,
@@ -341,43 +439,10 @@ async def _match_one(
     return _matched(simplified)
 
 
-async def match_segment(
-    client: MapboxClient,
-    points_lonlat: Coords,
-    profile: Profile,
-) -> Coords | None:
-    """Match a single segment's GPS points to roads via Mapbox APIs.
-
-    Automatically selects Map Matching (dense) or Directions (sparse).
-    Returns road-snapped coordinates in [lon, lat] order, or None when Mapbox
-    reports no route or a permanent failure. Transient failures are raised.
-    """
-    token = _token()
-    if not token:
-        return None
-
-    result = await _match_one(
-        MapboxRouteClients(matching=client, directions=client),
-        points_lonlat,
-        profile,
-        token,
-    )
-    return result.route
-
-
-async def match_segments(
-    client: MapboxClient,
-    pairs: list[tuple[Coords, Profile]],
-) -> list[Coords | None]:
-    """Match multiple segments concurrently, sharing one HTTP connection pool."""
-    results, _stats = await match_segments_with_stats(client, client, pairs)
-    return [result.route for result in results]
-
-
 async def match_segments_with_stats(
     matching_client: MapboxClient,
     directions_client: MapboxClient,
-    pairs: list[tuple[Coords, Profile]],
+    pairs: list[tuple[TimedCoords, Profile]],
 ) -> tuple[list[RouteMatchResult], RouteMatchStats]:
     """Match multiple segments, returning route results and HTTP request counts."""
     stats = RouteMatchStats()
@@ -389,16 +454,26 @@ async def match_segments_with_stats(
         return [_failed("token_missing") for _ in pairs], stats
 
     clients = MapboxRouteClients(matching=matching_client, directions=directions_client)
-    results = await asyncio.gather(
-        *(
-            _match_one(
-                clients,
-                coords,
-                profile,
-                token,
-                stats,
+    budget = _RequestBudget(MAX_ROUTE_REQUESTS_PER_RUN)
+    with collect_http_transport_metrics() as transport_metrics:
+        results = await asyncio.gather(
+            *(
+                _match_one(
+                    clients,
+                    points,
+                    profile,
+                    token,
+                    stats,
+                    budget,
+                )
+                for points, profile in pairs
             )
-            for coords, profile in pairs
         )
+    stats.outbound_attempts = transport_metrics.outbound_attempts
+    stats.retries = max(
+        0,
+        stats.outbound_attempts - (stats.requests - stats.cache_hits),
     )
+    stats.limiter_wait_ms = transport_metrics.limiter_wait_ms
+    stats.provider_latency_ms = transport_metrics.provider_latency_ms
     return results, stats

--- a/backend/app/services/mapbox.py
+++ b/backend/app/services/mapbox.py
@@ -29,7 +29,7 @@ type TimedCoords = list[TimedCoord]
 
 MATCH_MAX_COORDS = 100
 MATCH_CHUNK_COORDS = 90
-MAX_ROUTE_REQUESTS_PER_RUN = 100
+ROUTE_REQUEST_BATCH_TARGET = 100
 MAX_TRACE_GAP_S = 4 * 60 * 60
 REQUEST_BUDGET_EXCEEDED = "request_budget_exceeded"
 
@@ -70,11 +70,18 @@ class _RoutePart:
 @dataclass
 class _RequestBudget:
     remaining: int
+    used: int = 0
 
     def reserve(self, requests: int) -> bool:
         if requests > self.remaining:
-            return False
+            # An indivisible route may exceed the target only in an empty batch.
+            if self.used or self.remaining == 0:
+                return False
+            self.used = requests
+            self.remaining = 0
+            return True
         self.remaining -= requests
+        self.used += requests
         return True
 
 
@@ -165,11 +172,11 @@ def _coords(points: TimedCoords) -> Coords:
     return [(lon, lat) for lon, lat, _ in points]
 
 
-def _matching_request_points(points: TimedCoords) -> list[tuple[int, int]]:
+def _matching_request_points(points: TimedCoords) -> list[tuple[int, float]]:
     selected = reduce_coord_indices(_coords(points), MATCH_MAX_COORDS)
-    request_points: list[tuple[int, int]] = []
+    request_points: list[tuple[int, float]] = []
     for index in selected:
-        timestamp = int(points[index][2])
+        timestamp = points[index][2]
         if not request_points or timestamp > request_points[-1][1]:
             request_points.append((index, timestamp))
     return request_points
@@ -335,7 +342,7 @@ def _plan_route(
 
 def route_request_batch_indices(
     pairs: list[tuple[TimedCoords, Profile]],
-    max_requests: int = MAX_ROUTE_REQUESTS_PER_RUN,
+    max_requests: int = ROUTE_REQUEST_BATCH_TARGET,
 ) -> list[int]:
     """Return pair indices whose planned requests fit within one batch."""
     budget = _RequestBudget(max_requests)
@@ -348,6 +355,42 @@ def route_request_batch_indices(
     return selected
 
 
+async def _fetch_route_part(
+    clients: MapboxRouteClients,
+    part: _RoutePart,
+    profile: Profile,
+    token: str,
+    stats: RouteMatchStats | None,
+) -> RouteMatchResult:
+    if part.operation == "matching":
+        return await _fetch_matching(
+            clients.matching, part.points, profile, token, stats
+        )
+    return await _fetch_directions(
+        clients.directions, part.points, profile, token, stats
+    )
+
+
+async def _execute_route_window(
+    clients: MapboxRouteClients,
+    parts: list[_RoutePart],
+    profile: Profile,
+    token: str,
+    stats: RouteMatchStats | None,
+) -> list[RouteMatchResult]:
+    tasks = [
+        asyncio.create_task(_fetch_route_part(clients, part, profile, token, stats))
+        for part in parts
+    ]
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
 async def _execute_route_plan(
     clients: MapboxRouteClients,
     plan: list[_RoutePart],
@@ -355,30 +398,34 @@ async def _execute_route_plan(
     token: str,
     stats: RouteMatchStats | None,
 ) -> RouteMatchResult:
-    results = await asyncio.gather(
-        *(
-            _fetch_matching(clients.matching, part.points, profile, token, stats)
-            if part.operation == "matching"
-            else _fetch_directions(
-                clients.directions, part.points, profile, token, stats
-            )
-            for part in plan
+    results: list[RouteMatchResult] = []
+    for start in range(0, len(plan), ROUTE_REQUEST_BATCH_TARGET):
+        window = await _execute_route_window(
+            clients,
+            plan[start : start + ROUTE_REQUEST_BATCH_TARGET],
+            profile,
+            token,
+            stats,
         )
-    )
-    if failed := next(
-        (result for result in results if result.status == RouteEnrichmentStatus.failed),
-        None,
-    ):
-        return failed
-    if no_route := next(
-        (
-            result
-            for result in results
-            if result.status == RouteEnrichmentStatus.no_route
-        ),
-        None,
-    ):
-        return no_route
+        if failed := next(
+            (
+                result
+                for result in window
+                if result.status == RouteEnrichmentStatus.failed
+            ),
+            None,
+        ):
+            return failed
+        if no_route := next(
+            (
+                result
+                for result in window
+                if result.status == RouteEnrichmentStatus.no_route
+            ),
+            None,
+        ):
+            return no_route
+        results.extend(window)
 
     all_coords: Coords = []
     for result in results:
@@ -454,7 +501,7 @@ async def match_segments_with_stats(
         return [_failed("token_missing") for _ in pairs], stats
 
     clients = MapboxRouteClients(matching=matching_client, directions=directions_client)
-    budget = _RequestBudget(MAX_ROUTE_REQUESTS_PER_RUN)
+    budget = _RequestBudget(ROUTE_REQUEST_BATCH_TARGET)
     with collect_http_transport_metrics() as transport_metrics:
         results = await asyncio.gather(
             *(

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -1,4 +1,5 @@
-from collections.abc import Callable
+import asyncio
+from collections.abc import Awaitable, Callable
 from itertools import pairwise
 
 import httpx
@@ -6,7 +7,9 @@ import pytest
 
 from app.models.segment import RouteEnrichmentStatus
 from app.services.mapbox import (
+    MATCH_CHUNK_COORDS,
     REQUEST_BUDGET_EXCEEDED,
+    ROUTE_REQUEST_BATCH_TARGET,
     MapboxRouteClients,
     MapboxTransientError,
     _fetch_directions,
@@ -16,7 +19,7 @@ from app.services.mapbox import (
     route_request_batch_indices,
 )
 
-type Handler = Callable[[httpx.Request], httpx.Response]
+type Handler = Callable[[httpx.Request], httpx.Response | Awaitable[httpx.Response]]
 
 
 def _client(handler: Handler) -> httpx.AsyncClient:
@@ -31,7 +34,7 @@ def _timed(coords: list[tuple[float, float]]) -> list[tuple[float, float, float]
 
 async def test_map_matching_no_match_is_terminal() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.params["timestamps"] == "1700000000;1700000060"
+        assert request.url.params["timestamps"] == "1700000000.267;1700000060.267"
         return httpx.Response(200, json={"code": "NoMatch"}, request=request)
 
     async with _client(handler) as client:
@@ -44,6 +47,26 @@ async def test_map_matching_no_match_is_terminal() -> None:
 
     assert result.status == RouteEnrichmentStatus.no_route
     assert result.error_code == "NoMatch"
+
+
+async def test_map_matching_preserves_subsecond_endpoint() -> None:
+    points = [
+        (4.0, 52.0, 1_700_000_000.1),
+        (4.1, 52.1, 1_700_000_001.1),
+        (4.2, 52.2, 1_700_000_001.9),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/4.0,52.0;4.1,52.1;4.2,52.2")
+        assert request.url.params["timestamps"] == (
+            "1700000000.1;1700000001.1;1700000001.9"
+        )
+        return httpx.Response(200, json={"code": "NoMatch"}, request=request)
+
+    async with _client(handler) as client:
+        result = await _fetch_matching(client, points, "walking", "token")
+
+    assert result.status == RouteEnrichmentStatus.no_route
 
 
 async def test_mapbox_server_failure_is_retryable() -> None:
@@ -135,6 +158,44 @@ async def test_chunked_matching_rejects_partial_success() -> None:
     assert result.error_code == "NoSegment"
 
 
+async def test_chunked_matching_cancels_sibling_after_transport_failure() -> None:
+    started = 0
+    cancelled = 0
+    both_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal cancelled, started
+        started += 1
+        if started == 2:
+            both_started.set()
+        async with asyncio.timeout(1):
+            await both_started.wait()
+
+        encoded = request.url.path.rsplit("/", 1)[-1]
+        if encoded.startswith("4.0,52.0;"):
+            raise httpx.ConnectError("injected", request=request)
+        try:
+            await never_finishes.wait()
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+        raise AssertionError("unreachable")
+
+    points = _timed([(4.0 + i * 0.001, 52.0) for i in range(101)])
+    async with _client(handler) as client:
+        with pytest.raises(MapboxTransientError):
+            await _match_one(
+                MapboxRouteClients(matching=client, directions=client),
+                points,
+                "driving",
+                "token",
+            )
+
+    assert started == 2
+    assert cancelled == 1
+
+
 async def test_chunked_matching_stitches_at_the_shared_point() -> None:
     calls = 0
 
@@ -214,3 +275,52 @@ def test_route_request_batch_uses_remaining_capacity() -> None:
     )
 
     assert indexes == [0, 2]
+
+
+async def test_single_route_exceeds_target_with_bounded_execution() -> None:
+    point_count = 2 + ROUTE_REQUEST_BATCH_TARGET * (MATCH_CHUNK_COORDS - 1)
+    oversized_route = _timed([(4.0 + i * 0.00001, 52.0) for i in range(point_count)])
+    calls = 0
+    active = 0
+    peak_active = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal active, calls, peak_active
+        calls += 1
+        active += 1
+        peak_active = max(peak_active, active)
+        try:
+            await asyncio.sleep(0)
+        finally:
+            active -= 1
+        encoded = request.url.path.rsplit("/", 1)[-1]
+        pairs = encoded.split(";")
+        coords = [
+            [float(value) for value in pair.split(",")]
+            for pair in (pairs[0], pairs[-1])
+        ]
+        return httpx.Response(
+            200,
+            json={
+                "code": "Ok",
+                "matchings": [
+                    {"geometry": {"type": "LineString", "coordinates": coords}}
+                ],
+            },
+            request=request,
+        )
+
+    indexes = route_request_batch_indices([(oversized_route, "driving")])
+    async with _client(handler) as client:
+        result = await _match_one(
+            MapboxRouteClients(matching=client, directions=client),
+            oversized_route,
+            "driving",
+            "token",
+            budget=_RequestBudget(ROUTE_REQUEST_BATCH_TARGET),
+        )
+
+    assert indexes == [0]
+    assert calls > ROUTE_REQUEST_BATCH_TARGET
+    assert peak_active <= ROUTE_REQUEST_BATCH_TARGET
+    assert result.status == RouteEnrichmentStatus.matched

--- a/backend/tests/test_mapbox.py
+++ b/backend/tests/test_mapbox.py
@@ -1,15 +1,19 @@
 from collections.abc import Callable
+from itertools import pairwise
 
 import httpx
 import pytest
 
 from app.models.segment import RouteEnrichmentStatus
 from app.services.mapbox import (
+    REQUEST_BUDGET_EXCEEDED,
+    MapboxRouteClients,
     MapboxTransientError,
-    RouteMatchResult,
-    _chunked_route,
     _fetch_directions,
     _fetch_matching,
+    _match_one,
+    _RequestBudget,
+    route_request_batch_indices,
 )
 
 type Handler = Callable[[httpx.Request], httpx.Response]
@@ -19,14 +23,21 @@ def _client(handler: Handler) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
+def _timed(coords: list[tuple[float, float]]) -> list[tuple[float, float, float]]:
+    return [
+        (lon, lat, 1_700_000_000.267 + i * 60) for i, (lon, lat) in enumerate(coords)
+    ]
+
+
 async def test_map_matching_no_match_is_terminal() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["timestamps"] == "1700000000;1700000060"
         return httpx.Response(200, json={"code": "NoMatch"}, request=request)
 
     async with _client(handler) as client:
         result = await _fetch_matching(
             client,
-            [(4.0, 52.0), (4.1, 52.1)],
+            _timed([(4.0, 52.0), (4.1, 52.1)]),
             "walking",
             "token",
         )
@@ -43,7 +54,7 @@ async def test_mapbox_server_failure_is_retryable() -> None:
         with pytest.raises(MapboxTransientError, match="ServerError"):
             await _fetch_directions(
                 client,
-                [(4.0, 52.0), (4.1, 52.1)],
+                _timed([(4.0, 52.0), (4.1, 52.1)]),
                 "driving",
                 "token",
             )
@@ -56,7 +67,7 @@ async def test_mapbox_invalid_input_is_recorded_as_failure() -> None:
     async with _client(handler) as client:
         result = await _fetch_directions(
             client,
-            [(4.0, 52.0), (4.1, 52.1)],
+            _timed([(4.0, 52.0), (4.1, 52.1)]),
             "driving",
             "token",
         )
@@ -72,7 +83,7 @@ async def test_mapbox_no_segment_response_is_terminal() -> None:
     async with _client(handler) as client:
         result = await _fetch_directions(
             client,
-            [(4.0, 52.0), (4.1, 52.1)],
+            _timed([(4.0, 52.0), (4.1, 52.1)]),
             "driving",
             "token",
         )
@@ -81,32 +92,125 @@ async def test_mapbox_no_segment_response_is_terminal() -> None:
     assert result.error_code == "NoSegment"
 
 
-async def test_chunked_route_rejects_partial_success() -> None:
+async def test_chunked_matching_rejects_partial_success() -> None:
     calls = 0
 
-    async def route_chunk(
-        chunk: list[tuple[float, float]],
-    ) -> RouteMatchResult:
+    def handler(request: httpx.Request) -> httpx.Response:
         nonlocal calls
         calls += 1
         if calls == 2:
-            return RouteMatchResult(
-                status=RouteEnrichmentStatus.no_route,
-                error_code="NoSegment",
+            return httpx.Response(
+                422,
+                json={"code": "NoSegment"},
+                request=request,
             )
-        return RouteMatchResult(
-            status=RouteEnrichmentStatus.matched,
-            route=chunk,
+        return httpx.Response(
+            200,
+            json={
+                "code": "Ok",
+                "matchings": [
+                    {
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [[0.0, 0.0], [0.001, 0.0]],
+                        }
+                    }
+                ],
+            },
+            request=request,
         )
 
-    result = await _chunked_route(
-        [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 3.0)],
-        chunk_size=3,
-        overlap=1,
-        route_fn=route_chunk,
-    )
+    points = _timed([(i * 0.001, 0.0) for i in range(101)])
+    async with _client(handler) as client:
+        result = await _match_one(
+            MapboxRouteClients(matching=client, directions=client),
+            points,
+            "driving",
+            "token",
+        )
 
     assert calls == 2
     assert result.status == RouteEnrichmentStatus.no_route
     assert result.route is None
     assert result.error_code == "NoSegment"
+
+
+async def test_chunked_matching_stitches_at_the_shared_point() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        encoded = request.url.path.rsplit("/", 1)[-1]
+        coords = [
+            [float(value) for value in pair.split(",")] for pair in encoded.split(";")
+        ]
+        return httpx.Response(
+            200,
+            json={
+                "code": "Ok",
+                "matchings": [
+                    {
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": coords,
+                        }
+                    }
+                ],
+            },
+            request=request,
+        )
+
+    points = _timed([(i * 0.001, 0.01 * (i % 2)) for i in range(101)])
+    async with _client(handler) as client:
+        result = await _match_one(
+            MapboxRouteClients(matching=client, directions=client),
+            points,
+            "driving",
+            "token",
+        )
+
+    assert calls == 2
+    assert result.status == RouteEnrichmentStatus.matched
+    assert result.route is not None
+    assert all(
+        current[0] < following[0] for current, following in pairwise(result.route)
+    )
+
+
+async def test_request_budget_falls_back_without_calling_mapbox() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500, request=request)
+
+    async with _client(handler) as client:
+        result = await _match_one(
+            MapboxRouteClients(matching=client, directions=client),
+            _timed([(4.0, 52.0), (4.001, 52.001)]),
+            "walking",
+            "token",
+            budget=_RequestBudget(0),
+        )
+
+    assert calls == 0
+    assert result.status == RouteEnrichmentStatus.no_route
+    assert result.error_code == REQUEST_BUDGET_EXCEEDED
+
+
+def test_route_request_batch_uses_remaining_capacity() -> None:
+    short_route = _timed([(4.0, 52.0), (4.001, 52.001)])
+    chunked_route = _timed([(i * 0.001, 0.0) for i in range(101)])
+
+    indexes = route_request_batch_indices(
+        [
+            (short_route, "walking"),
+            (chunked_route, "driving"),
+            (short_route, "walking"),
+        ],
+        max_requests=2,
+    )
+
+    assert indexes == [0, 2]

--- a/backend/tests/test_segment_routes.py
+++ b/backend/tests/test_segment_routes.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -23,7 +23,11 @@ from app.models.segment import (
     SegmentKind,
     SegmentRouteEnrichment,
 )
-from app.services.mapbox import MapboxTransientError, RouteMatchResult
+from app.services.mapbox import (
+    REQUEST_BUDGET_EXCEEDED,
+    MapboxTransientError,
+    RouteMatchResult,
+)
 
 from .factories import AID, insert_album, insert_segment
 
@@ -44,13 +48,39 @@ def _http() -> SimpleNamespace:
 
 
 def _stats(
-    *, requests: int = 1, matching_requests: int = 1, directions_requests: int = 0
+    *,
+    requests: int = 1,
+    matching_requests: int = 1,
+    directions_requests: int = 0,
+    budget_fallbacks: int = 0,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         requests=requests,
         matching_requests=matching_requests,
         directions_requests=directions_requests,
+        cache_hits=0,
+        outbound_attempts=requests,
+        retries=0,
+        limiter_wait_ms=0,
+        provider_latency_ms=0,
+        budget_fallbacks=budget_fallbacks,
     )
+
+
+def _batch(
+    *,
+    uid: int = 1,
+    start_time: float = 100.0,
+    end_time: float = 200.0,
+) -> list[dict[str, int | str | float]]:
+    return [
+        {
+            "uid": uid,
+            "aid": AID,
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+    ]
 
 
 def _matched(route: Route) -> RouteMatchResult:
@@ -247,6 +277,45 @@ async def test_no_route_is_recorded_and_not_retried(engine: AsyncEngine) -> None
     second.match_segments.assert_not_awaited()
 
 
+async def test_request_budget_fallback_is_not_recorded_and_is_retried(
+    engine: AsyncEngine,
+) -> None:
+    uid = 3011
+    route = [(4.0, 52.0), (4.1, 52.1)]
+    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+
+    first = await _run_route_enrichment(
+        engine,
+        uid,
+        route_result=(
+            [_no_route(REQUEST_BUDGET_EXCEEDED)],
+            _stats(
+                requests=0,
+                matching_requests=0,
+                budget_fallbacks=1,
+            ),
+        ),
+    )
+
+    assert await _state_for(engine, uid) is None
+    assert first.stats.no_route == 0
+    assert first.stats.recorded == 0
+    assert first.stats.stale == 1
+    assert first.stats.budget_fallbacks == 1
+
+    second = await _run_route_enrichment(
+        engine,
+        uid,
+        route_result=([_matched(route)], _stats()),
+    )
+
+    second.match_segments.assert_awaited_once()
+    assert await _route_for(engine, uid) == route
+    state = await _state_for(engine, uid)
+    assert state is not None
+    assert state.status == RouteEnrichmentStatus.matched
+
+
 async def test_permanent_failure_is_recorded(engine: AsyncEngine) -> None:
     uid = 3005
     await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
@@ -275,28 +344,42 @@ async def test_route_matching_exception_propagates(engine: AsyncEngine) -> None:
         )
 
 
-async def test_exhausted_failure_marker_records_pending_segments(
+async def test_exhausted_failure_marker_records_only_attempted_batch(
     engine: AsyncEngine,
 ) -> None:
     uid = 3010
-    await _seed_segments(engine, uid, (100.0, 200.0, SegmentKind.driving))
+    await _seed_segments(
+        engine,
+        uid,
+        (100.0, 200.0, SegmentKind.driving),
+        (300.0, 400.0, SegmentKind.driving),
+    )
     marker = inspect.unwrap(mark_album_route_failure_step)
 
     with patch("app.logic.segment_routes.get_engine", return_value=engine):
         recorded = await marker(
             {"uid": uid, "aid": AID},
             "retry_exhausted:MapboxTransientError",
+            _batch(uid=uid),
         )
 
     state = await _state_for(engine, uid)
+    unattempted_state = await _state_for(
+        engine,
+        uid,
+        start_time=300.0,
+        end_time=400.0,
+    )
     assert recorded == 1
     assert state is not None
     assert state.status == RouteEnrichmentStatus.failed
     assert state.error_code == "retry_exhausted:MapboxTransientError"
+    assert unattempted_state is None
 
 
 async def test_failed_outcome_fails_workflow() -> None:
     workflow = inspect.unwrap(album_route_enrichment_workflow)
+    batch = _batch()
     stats = {
         "candidates": 1,
         "matched": 0,
@@ -311,6 +394,10 @@ async def test_failed_outcome_fails_workflow() -> None:
     }
     with (
         patch(
+            "app.logic.segment_routes.plan_album_route_batch_step",
+            new=AsyncMock(side_effect=[batch, []]),
+        ),
+        patch(
             "app.logic.segment_routes.enrich_album_routes_step",
             new=AsyncMock(return_value=stats),
         ),
@@ -323,7 +410,12 @@ async def test_exhausted_transient_failure_is_recorded_and_propagated() -> None:
     workflow = inspect.unwrap(album_route_enrichment_workflow)
     marker = AsyncMock()
     payload = {"uid": 1, "aid": AID}
+    batch = _batch()
     with (
+        patch(
+            "app.logic.segment_routes.plan_album_route_batch_step",
+            new=AsyncMock(return_value=batch),
+        ),
         patch(
             "app.logic.segment_routes.enrich_album_routes_step",
             new=AsyncMock(side_effect=MapboxTransientError("unavailable")),
@@ -339,7 +431,43 @@ async def test_exhausted_transient_failure_is_recorded_and_propagated() -> None:
     marker.assert_awaited_once_with(
         payload,
         "retry_exhausted:MapboxTransientError",
+        batch,
     )
+
+
+async def test_workflow_drains_all_planned_batches() -> None:
+    workflow = inspect.unwrap(album_route_enrichment_workflow)
+    payload = {"uid": 1, "aid": AID}
+    first_batch = _batch()
+    second_batch = _batch(start_time=300.0, end_time=400.0)
+    plan = AsyncMock(side_effect=[first_batch, second_batch, []])
+    stats = {
+        "candidates": 1,
+        "matched": 1,
+        "recorded": 1,
+        "updated": 1,
+        "route_requests": 1,
+        "matching_requests": 1,
+    }
+    enrich = AsyncMock(side_effect=[stats, stats])
+
+    with (
+        patch(
+            "app.logic.segment_routes.plan_album_route_batch_step",
+            new=plan,
+        ),
+        patch(
+            "app.logic.segment_routes.enrich_album_routes_step",
+            new=enrich,
+        ),
+    ):
+        result = await workflow(payload)
+
+    assert result == payload
+    assert enrich.await_args_list == [
+        call(payload, first_batch),
+        call(payload, second_batch),
+    ]
 
 
 async def test_reconciliation_targets_only_unresolved_albums(

--- a/backend/tests/test_segments.py
+++ b/backend/tests/test_segments.py
@@ -1,16 +1,19 @@
 import datetime as _dt_mod
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 
 import polars as pl
 import pytest
 
+from app.logic.spatial.geo import total_length_km
 from app.logic.spatial.segments import (
     _remove_gps_noise,
     build_segments,
 )
-from app.models.polarsteps import Point
+from app.models.polarsteps import Point, PSLocations, PSTrip
 from app.models.segment import SegmentData, SegmentKind
+from app.services.mapbox import _plan_route
 
 _BASE_TS = datetime(2024, 1, 1, tzinfo=UTC).timestamp()
 
@@ -282,3 +285,34 @@ class TestRobustness:
         steps = [_step(0.0, 0.0, 9.0), _step(0.0, 0.1, 14.0)]
         segments = list(build_segments(steps, []))
         assert all(len(s.points) >= 2 for s in segments)
+
+
+def test_demo_routes_respect_mapbox_input_contracts() -> None:
+    trip_dir = (
+        Path(__file__).resolve().parents[2]
+        / "fixtures/demo/trip/south-america-2024-2025_14232450"
+    )
+    trip = PSTrip.from_trip_dir(trip_dir)
+    locations = PSLocations.from_trip_dir(trip_dir)
+    profile_distance_limit = {
+        SegmentKind.walking: 1_000,
+        SegmentKind.driving: 10_000,
+    }
+    coordinate_limit = {"matching": 100, "directions": 25}
+
+    segments = (
+        segment
+        for segment in build_segments(trip.all_steps, locations.locations)
+        if segment.kind in profile_distance_limit
+    )
+    for segment in segments:
+        points = [(point.lon, point.lat, point.time) for point in segment.points]
+        assert (
+            total_length_km([(lon, lat) for lon, lat, _ in points])
+            <= (profile_distance_limit[segment.kind])
+        )
+        plan, error = _plan_route(points, str(segment.kind))
+        assert error is None
+        assert plan
+        for part in plan:
+            assert 2 <= len(part.points) <= coordinate_limit[part.operation]


### PR DESCRIPTION
- plan timestamped Mapbox requests from contiguous GPS traces and process them in durable request-budgeted batches
- keep oversized individual routes lossless while bounding concurrent execution and cancelling sibling requests after failures
- record transport, cache, retry, limiter, and provider timing metrics for route enrichment